### PR TITLE
Event-based Puzzles

### DIFF
--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -19,6 +19,7 @@
                 <th>
                     @Html.DisplayNameFor(model => model.Event[0].UrlString)
                 </th>
+            <!--
                 <th>
                     @Html.DisplayNameFor(model => model.Event[0].MaxNumberOfTeams)
                 </th>
@@ -28,9 +29,11 @@
                 <th>
                     @Html.DisplayNameFor(model => model.Event[0].MaxExternalsPerTeam)
                 </th>
+            -->
                 <th>
                     @Html.DisplayNameFor(model => model.Event[0].IsInternEvent)
                 </th>
+            <!--
                 <th>
                     @Html.DisplayNameFor(model => model.Event[0].TeamRegistrationBegin)
                 </th>
@@ -70,6 +73,7 @@
                 <th>
                     @Html.DisplayNameFor(model => model.Event[0].AllowFeedback)
                 </th>
+            -->
             <th></th>
         </tr>
     </thead>
@@ -82,6 +86,7 @@
             <td>
                 @Html.DisplayFor(modelItem => item.UrlString)
             </td>
+        <!--
             <td>
                 @Html.DisplayFor(modelItem => item.MaxNumberOfTeams)
             </td>
@@ -91,9 +96,11 @@
             <td>
                 @Html.DisplayFor(modelItem => item.MaxExternalsPerTeam)
             </td>
+        -->
             <td>
                 @Html.DisplayFor(modelItem => item.IsInternEvent)
             </td>
+        <!--
             <td>
                 @Html.DisplayFor(modelItem => item.TeamRegistrationBegin)
             </td>
@@ -133,10 +140,12 @@
             <td>
                 @Html.DisplayFor(modelItem => item.AllowFeedback)
             </td>
+        -->
             <td>
                 <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |
                 <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |
-                <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a>
+                <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a> |
+                <a asp-page="/Puzzles/Index" asp-route-eventid="@item.ID">Puzzles</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -13,67 +13,15 @@
 <table class="table">
     <thead>
         <tr>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].Name)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].UrlString)
-                </th>
-            <!--
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].MaxNumberOfTeams)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].MaxTeamSize)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].MaxExternalsPerTeam)
-                </th>
-            -->
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].IsInternEvent)
-                </th>
-            <!--
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].TeamRegistrationBegin)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].TeamRegistrationEnd)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].TeamNameChangeEnd)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].TeamMembershipChangeEnd)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].TeamMiscDataChangeEnd)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].TeamDeleteEnd)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].EventBegin)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].AnswerSubmissionEnd)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].AnswersAvailableBegin)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].StandingsAvailableBegin)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].StandingsOverride)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].ShowFastestSolves)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Event[0].AllowFeedback)
-                </th>
-            -->
+            <th>
+                @Html.DisplayNameFor(model => model.Event[0].Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Event[0].UrlString)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Event[0].IsInternEvent)
+            </th>
             <th></th>
         </tr>
     </thead>
@@ -86,61 +34,9 @@
             <td>
                 @Html.DisplayFor(modelItem => item.UrlString)
             </td>
-        <!--
-            <td>
-                @Html.DisplayFor(modelItem => item.MaxNumberOfTeams)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.MaxTeamSize)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.MaxExternalsPerTeam)
-            </td>
-        -->
             <td>
                 @Html.DisplayFor(modelItem => item.IsInternEvent)
             </td>
-        <!--
-            <td>
-                @Html.DisplayFor(modelItem => item.TeamRegistrationBegin)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.TeamRegistrationEnd)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.TeamNameChangeEnd)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.TeamMembershipChangeEnd)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.TeamMiscDataChangeEnd)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.TeamDeleteEnd)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.EventBegin)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.AnswerSubmissionEnd)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.AnswersAvailableBegin)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.StandingsAvailableBegin)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.StandingsOverride)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.ShowFastestSolves)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.AllowFeedback)
-            </td>
-        -->
             <td>
                 <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |
                 <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |

--- a/ServerCore/Pages/Index.cshtml
+++ b/ServerCore/Pages/Index.cshtml
@@ -71,7 +71,7 @@
     <div class="col-md-3">
         <h2>Guide to Microsoft Puzzle Events</h2>
         <ul>
-            <li><a href="/puzzles">CLICK HERE TO CHECK YOUR DATABASE SETUP</a></li>
+            <li><a href="/events">CLICK HERE TO CHECK YOUR DATABASE SETUP</a></li>
             <li><a href="https://aka.ms/puzzleday">Intern? Click Here</a></li>
             <li><a href="https://aka.ms/nipd">Non-Intern Beginner? Click Here</a></li>
             <li><a href="https://aka.ms/puzzlehunt">Advanced Solver? Click Here</a></li>

--- a/ServerCore/Pages/Puzzles/Create.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Create.cshtml.cs
@@ -28,17 +28,15 @@ namespace ServerCore.Pages.Puzzles
         [BindProperty]
         public Puzzle Puzzle { get; set; }
 
-        public async Task<IActionResult> OnPostAsync(int? eventid)
+        public async Task<IActionResult> OnPostAsync(int eventid)
         {
             if (!ModelState.IsValid)
             {
                 return Page();
             }
 
-            if (eventid != null)
-            {
-                Puzzle.Event = await _context.Event.SingleOrDefaultAsync(m => m.ID == eventid);
-            }
+            Puzzle.Event = await _context.Event.SingleOrDefaultAsync(m => m.ID == eventid);
+
             _context.Puzzle.Add(Puzzle);
             await _context.SaveChangesAsync();
 

--- a/ServerCore/Pages/Puzzles/Create.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Create.cshtml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
 using ServerCore.Models;
 
@@ -27,17 +28,21 @@ namespace ServerCore.Pages.Puzzles
         [BindProperty]
         public Puzzle Puzzle { get; set; }
 
-        public async Task<IActionResult> OnPostAsync()
+        public async Task<IActionResult> OnPostAsync(int? eventid)
         {
             if (!ModelState.IsValid)
             {
                 return Page();
             }
 
+            if (eventid != null)
+            {
+                Puzzle.Event = await _context.Event.SingleOrDefaultAsync(m => m.ID == eventid);
+            }
             _context.Puzzle.Add(Puzzle);
             await _context.SaveChangesAsync();
 
-            return RedirectToPage("./Index");
+            return RedirectToPage("./Index", new { eventid = eventid });
         }
     }
 }

--- a/ServerCore/Pages/Puzzles/Delete.cshtml
+++ b/ServerCore/Pages/Puzzles/Delete.cshtml
@@ -95,6 +95,6 @@
     <form method="post">
         <input type="hidden" asp-for="Puzzle.ID" />
         <input type="submit" value="Delete" class="btn btn-default" /> |
-        <a asp-page="./Index">Back to List</a>
+        <a asp-page="./Index" asp-route-eventid="@Model.Puzzle.Event?.ID">Back to List</a>
     </form>
 </div>

--- a/ServerCore/Pages/Puzzles/Delete.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Delete.cshtml.cs
@@ -29,7 +29,7 @@ namespace ServerCore.Pages.Puzzles
                 return NotFound();
             }
 
-            Puzzle = await _context.Puzzle.SingleOrDefaultAsync(m => m.ID == id);
+            Puzzle = await _context.Puzzle.Where(m => m.ID == id).Include(p => p.Event).FirstOrDefaultAsync();
 
             if (Puzzle == null)
             {
@@ -45,7 +45,7 @@ namespace ServerCore.Pages.Puzzles
                 return NotFound();
             }
 
-            Puzzle = await _context.Puzzle.FindAsync(id);
+            Puzzle = await _context.Puzzle.Where(m => m.ID == id).Include(p => p.Event).FirstOrDefaultAsync();
 
             if (Puzzle != null)
             {
@@ -53,7 +53,7 @@ namespace ServerCore.Pages.Puzzles
                 await _context.SaveChangesAsync();
             }
 
-            return RedirectToPage("./Index");
+            return RedirectToPage("./Index", new { eventid = Puzzle.Event?.ID });
         }
     }
 }

--- a/ServerCore/Pages/Puzzles/Details.cshtml
+++ b/ServerCore/Pages/Puzzles/Details.cshtml
@@ -93,5 +93,5 @@
 </div>
 <div>
     <a asp-page="./Edit" asp-route-id="@Model.Puzzle.ID">Edit</a> |
-    <a asp-page="./Index">Back to List</a>
+    <a asp-page="./Index" asp-route-eventid="@Model.Puzzle.Event?.ID">Back to List</a>
 </div>

--- a/ServerCore/Pages/Puzzles/Details.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Details.cshtml.cs
@@ -28,7 +28,7 @@ namespace ServerCore.Pages.Puzzles
                 return NotFound();
             }
 
-            Puzzle = await _context.Puzzle.SingleOrDefaultAsync(m => m.ID == id);
+            Puzzle = await _context.Puzzle.Where(m => m.ID == id).Include(p => p.Event).FirstOrDefaultAsync();
 
             if (Puzzle == null)
             {

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -95,7 +95,7 @@
 </div>
 
 <div>
-    <a asp-page="./Index">Back to List</a>
+    <a asp-page="./Index" asp-route-eventid="@Model.Puzzle.Event?.ID">Back to List</a>
 </div>
 
 @section Scripts {

--- a/ServerCore/Pages/Puzzles/Edit.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml.cs
@@ -30,7 +30,7 @@ namespace ServerCore.Pages.Puzzles
                 return NotFound();
             }
 
-            Puzzle = await _context.Puzzle.SingleOrDefaultAsync(m => m.ID == id);
+            Puzzle = await _context.Puzzle.Where(m => m.ID == id).Include(p => p.Event).FirstOrDefaultAsync();
 
             if (Puzzle == null)
             {
@@ -64,7 +64,7 @@ namespace ServerCore.Pages.Puzzles
                 }
             }
 
-            return RedirectToPage("./Index");
+            return RedirectToPage("./Index", new { eventid = Puzzle.Event?.ID });
         }
 
         private bool PuzzleExists(int id)

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -8,7 +8,7 @@
 <h2>Index</h2>
 
 <p>
-    <a asp-page="Create">Create New</a>
+    <a asp-page="Create" asp-route-eventid="@Model.EventId">Create New</a>
 </p>
 <table class="table">
     <thead>

--- a/ServerCore/Pages/Puzzles/Index.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Index.cshtml.cs
@@ -19,11 +19,21 @@ namespace ServerCore.Pages.Puzzles
             _context = context;
         }
 
-        public IList<Puzzle> Puzzle { get;set; }
+        public IList<Puzzle> Puzzle { get; set; }
 
-        public async Task OnGetAsync()
+        public int? EventId { get; set; }
+
+        public async Task OnGetAsync(int? eventid)
         {
-            Puzzle = await _context.Puzzle.ToListAsync();
+            if (eventid != null)
+            {
+                Puzzle = await _context.Puzzle.Where((p) => p.Event != null && p.Event.ID == eventid).ToListAsync();
+                EventId = eventid;
+            }
+            else
+            {
+                Puzzle = await _context.Puzzle.ToListAsync();
+            }
         }
     }
 }


### PR DESCRIPTION
Making puzzles be owned by events, as a way to play with object
relationships.

The "CLICK HERE TO CHECK YOUR DATABASE SETUP" link now points to Events
instead of Puzzles, and the Events index has a new link to access that
event's puzzle list.

I've needed to pass the event ID around, and the event ID should
probably be part of some global context, but this is a helpful microcosm
of issues we'll have when doing other features so I still think it's a
good start.