### PR TITLE
Routing and event awareness cleanup

### DIFF
--- a/Data/DataModel/Event.cs
+++ b/Data/DataModel/Event.cs
@@ -19,8 +19,8 @@ namespace ServerCore.DataModel
         [NotMapped]
         public Uri URL
         {
-            get { return new Uri(UrlString); }
-            set { UrlString = value.ToString(); }
+            get { Uri.TryCreate(UrlString, UriKind.RelativeOrAbsolute, out Uri result); return result; }
+            set { UrlString = value?.ToString(); }
         }
 
         public int MaxNumberOfTeams { get; set; }

--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ServerCore.DataModel;
+using ServerCore.Models;
+
+namespace ServerCore.ModelBases
+{
+    public abstract class EventSpecificPageModel : PageModel
+    {
+        [FromRoute]
+        [ModelBinder(typeof(EventBinder))]
+        public Event Event { get; set; }
+
+        public class EventBinder : IModelBinder
+        {
+            public async Task BindModelAsync(ModelBindingContext bindingContext)
+            {
+                string eventIdAsString = bindingContext.ActionContext.RouteData.Values["eventId"] as string;
+
+                if (int.TryParse(eventIdAsString, out int eventId))
+                {
+                    var puzzleServerContext = bindingContext.HttpContext.RequestServices.GetService<PuzzleServerContext>();
+                    Event eventObj = await puzzleServerContext.Events.Where(e => e.ID == eventId).FirstOrDefaultAsync();
+
+                    if (eventObj != null)
+                    {
+                        bindingContext.Result = ModelBindingResult.Success(eventObj);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -41,7 +41,7 @@
                 <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |
                 <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |
                 <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a> |
-                <a asp-page="/Puzzles/Index" asp-route-eventid="@item.ID">Puzzles</a>
+                <a asp-page="/Puzzles/Index" asp-route-eventId="@item.ID">Puzzles</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Puzzles/Create.cshtml
+++ b/ServerCore/Pages/Puzzles/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/{eventId}/Puzzles/Create"
 @model ServerCore.Pages.Puzzles.CreateModel
 
 @{
@@ -94,7 +94,7 @@
 </div>
 
 <div>
-    <a asp-page="Index" asp-route-eventid="@Model.Event?.ID">Back to List</a>
+    <a asp-page="Index">Back to List</a>
 </div>
 
 @section Scripts {

--- a/ServerCore/Pages/Puzzles/Create.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Create.cshtml.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.Models;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Puzzles
 {
-    public class CreateModel : PageModel
+    public class CreateModel : EventSpecificPageModel
     {
         private readonly ServerCore.Models.PuzzleServerContext _context;
 
@@ -20,33 +14,27 @@ namespace ServerCore.Pages.Puzzles
             _context = context;
         }
 
-        public async Task<IActionResult> OnGetAsync(int eventid)
+        public IActionResult OnGet()
         {
-            Event = await _context.Events.SingleOrDefaultAsync(m => m.ID == eventid);
-            ViewData["Event"] = Event;
             return Page();
         }
 
         [BindProperty]
         public Puzzle Puzzle { get; set; }
 
-        public Event Event { get; set; }
-
-        public async Task<IActionResult> OnPostAsync(int eventid)
+        public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)
             {
                 return Page();
             }
 
-            Event = await _context.Events.SingleOrDefaultAsync(m => m.ID == eventid);
             Puzzle.Event = Event;
-            ViewData["Event"] = Event;
 
             _context.Puzzles.Add(Puzzle);
             await _context.SaveChangesAsync();
 
-            return RedirectToPage("./Index", new { eventid = eventid });
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/ServerCore/Pages/Puzzles/Delete.cshtml
+++ b/ServerCore/Pages/Puzzles/Delete.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page  "/{eventId}/Puzzles/Delete/{id}"
 @model ServerCore.Pages.Puzzles.DeleteModel
 
 @{
@@ -91,10 +91,10 @@
             @Html.DisplayFor(model => model.Puzzle.MaterialsUrlString)
         </dd>
     </dl>
-    
+
     <form method="post">
         <input type="hidden" asp-for="Puzzle.ID" />
         <input type="submit" value="Delete" class="btn btn-default" /> |
-        <a asp-page="./Index" asp-route-eventid="@Model.Puzzle.Event?.ID">Back to List</a>
+        <a asp-page="./Index">Back to List</a>
     </form>
 </div>

--- a/ServerCore/Pages/Puzzles/Delete.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Delete.cshtml.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.Models;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Puzzles
 {
-    public class DeleteModel : PageModel
+    public class DeleteModel : EventSpecificPageModel
     {
         private readonly ServerCore.Models.PuzzleServerContext _context;
 
@@ -22,13 +19,8 @@ namespace ServerCore.Pages.Puzzles
         [BindProperty]
         public Puzzle Puzzle { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(int? id)
+        public async Task<IActionResult> OnGetAsync(int id)
         {
-            if (id == null)
-            {
-                return NotFound();
-            }
-
             Puzzle = await _context.Puzzles.Where(m => m.ID == id).FirstOrDefaultAsync();
 
             if (Puzzle == null)
@@ -39,15 +31,9 @@ namespace ServerCore.Pages.Puzzles
             return Page();
         }
 
-        public async Task<IActionResult> OnPostAsync(int? id)
+        public async Task<IActionResult> OnPostAsync(int id)
         {
-            if (id == null)
-            {
-                return NotFound();
-            }
-
             Puzzle = await _context.Puzzles.Where(m => m.ID == id).FirstOrDefaultAsync();
-            ViewData["Event"] = Puzzle?.Event;
 
             if (Puzzle != null)
             {
@@ -55,7 +41,7 @@ namespace ServerCore.Pages.Puzzles
                 await _context.SaveChangesAsync();
             }
 
-            return RedirectToPage("./Index", new { eventid = Puzzle.Event?.ID });
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/ServerCore/Pages/Puzzles/Details.cshtml
+++ b/ServerCore/Pages/Puzzles/Details.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page  "/{eventId}/Puzzles/Details/{id}"
 @model ServerCore.Pages.Puzzles.DetailsModel
 
 @{
@@ -93,5 +93,5 @@
 </div>
 <div>
     <a asp-page="./Edit" asp-route-id="@Model.Puzzle.ID">Edit</a> |
-    <a asp-page="./Index" asp-route-eventid="@Model.Puzzle.Event?.ID">Back to List</a>
+    <a asp-page="./Index">Back to List</a>
 </div>

--- a/ServerCore/Pages/Puzzles/Details.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Details.cshtml.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.Models;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Puzzles
 {
-    public class DetailsModel : PageModel
+    public class DetailsModel : EventSpecificPageModel
     {
         private readonly ServerCore.Models.PuzzleServerContext _context;
 
@@ -21,15 +18,9 @@ namespace ServerCore.Pages.Puzzles
 
         public Puzzle Puzzle { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(int? id)
+        public async Task<IActionResult> OnGetAsync(int id)
         {
-            if (id == null)
-            {
-                return NotFound();
-            }
-
             Puzzle = await _context.Puzzles.Where(m => m.ID == id).FirstOrDefaultAsync();
-            ViewData["Event"] = Puzzle?.Event;
 
             if (Puzzle == null)
             {

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page  "/{eventId}/Puzzles/Edit/{id}"
 @model ServerCore.Pages.Puzzles.EditModel
 
 @{
@@ -95,7 +95,7 @@
 </div>
 
 <div>
-    <a asp-page="./Index" asp-route-eventid="@Model.Puzzle.Event?.ID">Back to List</a>
+    <a asp-page="./Index">Back to List</a>
 </div>
 
 @section Scripts {

--- a/ServerCore/Pages/Puzzles/Edit.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.Models;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Puzzles
 {
-    public class EditModel : PageModel
+    public class EditModel : EventSpecificPageModel
     {
         private readonly ServerCore.Models.PuzzleServerContext _context;
 
@@ -23,15 +19,9 @@ namespace ServerCore.Pages.Puzzles
         [BindProperty]
         public Puzzle Puzzle { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(int? id)
+        public async Task<IActionResult> OnGetAsync(int id)
         {
-            if (id == null)
-            {
-                return NotFound();
-            }
-
             Puzzle = await _context.Puzzles.Where(m => m.ID == id).FirstOrDefaultAsync();
-            ViewData["Event"] = Puzzle?.Event;
 
             if (Puzzle == null)
             {
@@ -65,7 +55,7 @@ namespace ServerCore.Pages.Puzzles
                 }
             }
 
-            return RedirectToPage("./Index", new { eventid = Puzzle.Event?.ID });
+            return RedirectToPage("./Index");
         }
 
         private bool PuzzleExists(int id)

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/{eventId}/Puzzles"
 @model ServerCore.Pages.Puzzles.IndexModel
 
 @{
@@ -8,7 +8,7 @@
 <h2>Index</h2>
 
 <p>
-    <a asp-page="Create" asp-route-eventid="@Model.EventId">Create New</a>
+    <a asp-page="Create">Create New</a>
 </p>
 <table class="table">
     <thead>
@@ -98,9 +98,9 @@
                 @Html.DisplayFor(modelItem => item.MaterialsUrlString)
             </td>
             <td>
-                <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |
-                <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |
-                <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a>
+                <a asp-Page="./Edit" asp-route-id="@item.ID">Edit</a> |
+                <a asp-Page="./Details" asp-route-id="@item.ID">Details</a> |
+                <a asp-Page="./Delete" asp-route-id="@item.ID">Delete</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Puzzles/Index.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Index.cshtml.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.Models;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Puzzles
 {
-    public class IndexModel : PageModel
+    public class IndexModel : EventSpecificPageModel
     {
         private readonly ServerCore.Models.PuzzleServerContext _context;
 
@@ -21,15 +18,11 @@ namespace ServerCore.Pages.Puzzles
 
         public IList<Puzzle> Puzzles { get; set; }
 
-        public int? EventId { get; set; }
-
-        public async Task OnGetAsync(int? eventid)
+        public async Task OnGetAsync()
         {
-            if (eventid != null)
+            if (Event != null)
             {
-                Puzzles = await _context.Puzzles.Where((p) => p.Event != null && p.Event.ID == eventid).ToListAsync();
-                EventId = eventid;
-                ViewData["Event"] = await _context.Events.Where(e => e.ID == eventid).FirstAsync();
+                Puzzles = await _context.Puzzles.Where((p) => p.Event != null && p.Event.ID == Event.ID).ToListAsync();
             }
             else
             {

--- a/ServerCore/Pages/_Layout.cshtml
+++ b/ServerCore/Pages/_Layout.cshtml
@@ -23,7 +23,7 @@
 </head>
 <body>
     @{ 
-        var Event = ViewData["Event"] as ServerCore.DataModel.Event;
+        var Event = (Model as ServerCore.ModelBases.EventSpecificPageModel)?.Event;
     }
     <nav class="navbar navbar-inverse navbar-fixed-top">
         <div class="container">


### PR DESCRIPTION
I've shrunk the work required for event awareness down to the very
small.

1. When declaring event-specific pages, derive page models from
ServerCore.ModelBases.EventSpecificModelBase. This adds an Event
property of type Event, and the menus will use it. Example:

public class DetailsModel : EventSpecificModelBase

2. Change the @page attribute to provide a specific routing path, e.g.
this one for puzzle details:

@page "{eventId}/Puzzles/Details/{id}"

[Note: we can probably remove this eventually, in favor of routing
conventions.]

3. When navigating from a page not in the event specific zone, add an
asp-route-eventId parameter, like this one in Events/Index that uses the
ID of the chosen event:

<a asp-page="/Puzzles/Index" asp-route-eventId="@item.ID">

That is currently the only place that asp-route-eventId is needed,
so these should be rare.