### PR TITLE
Puzzle State Administration

### DIFF
--- a/Data/DataModel/PuzzleStatePerTeam.cs
+++ b/Data/DataModel/PuzzleStatePerTeam.cs
@@ -24,7 +24,13 @@ namespace ServerCore.DataModel
         public bool IsUnlocked
         {
             get { return UnlockedTime != null; }
-            set { UnlockedTime = value ? (DateTime?)DateTime.UtcNow : null; }
+            set
+            {
+                if (IsUnlocked != value)
+                {
+                    UnlockedTime = value ? (DateTime?)DateTime.UtcNow : null;
+                }
+            }
         }
 
         /// <summary>
@@ -34,7 +40,13 @@ namespace ServerCore.DataModel
         public bool IsSolved
         {
             get { return SolvedTime != null; }
-            set { SolvedTime = value ? (DateTime?)DateTime.UtcNow : null; }
+            set
+            {
+                if (IsSolved != value)
+                {
+                    SolvedTime = value ? (DateTime?)DateTime.UtcNow : null;
+                }
+            }
         }
 
         /// <summary>

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -100,7 +100,8 @@
             <td>
                 <a asp-Page="./Edit" asp-route-id="@item.ID">Edit</a> |
                 <a asp-Page="./Details" asp-route-id="@item.ID">Details</a> |
-                <a asp-Page="./Delete" asp-route-id="@item.ID">Delete</a>
+                <a asp-Page="./Delete" asp-route-id="@item.ID">Delete</a> |
+                <a asp-page="./Status" asp-route-id="@item.ID">Status</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Puzzles/Status.cshtml
+++ b/ServerCore/Pages/Puzzles/Status.cshtml
@@ -1,0 +1,94 @@
+﻿@page "/{eventId}/Puzzles/Status"
+@model ServerCore.Pages.Puzzles.StatusModel
+
+@{
+    ViewData["Title"] = "Status";
+}
+
+<h2>Puzzle Status for @Model.Puzzle.Name</h2>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Team) @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Team.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].UnlockedTime)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].SolvedTime)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Printed)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Notes)
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Model.PuzzleStatePerTeam)
+        {
+            <tr>
+                <td>
+                    <a asp-page="../Teams/Status" asp-route-id="@item.Team.ID">@Html.DisplayFor(modelItem => item.Team.Name)</a>
+                </td>
+                <td>
+                    @if (item.UnlockedTime == null)
+                    {
+                        <a asp-page-handler="UnlockState" asp-route-teamId="@item.Team.ID" asp-route-id="@Model.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Team.Name) as unlocked?')">Unlock</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.UnlockedTime)
+                        <a asp-page-handler="UnlockState" asp-route-teamId="@item.Team.ID" asp-route-id="@Model.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Team.Name) as locked?')"> X</a>
+                    }
+                </td>
+                <td>
+                    @if (item.SolvedTime == null)
+                    {
+                        <a asp-page-handler="SolveState" asp-route-teamId="@item.Team.ID" asp-route-id="@Model.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Team.Name) as solved?')">Solve</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.SolvedTime)
+                        <a asp-page-handler="SolveState" asp-route-teamId="@item.Team.ID" asp-route-id="@Model.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Team.Name) as unsolved?')"> X</a>
+                    }
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Printed)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Notes)
+                </td>
+            </tr>
+        }
+
+        <tr>
+            <td></td>
+            <td>
+                <a asp-page-handler="UnlockState" asp-route-id="@Model.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark all teams as unlocked?')">Unlock All</a>
+            </td>
+            <td>
+                <a asp-page-handler="SolveState" asp-route-id="@Model.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark all teams as solved?')">Solve All</a>
+            </td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td>
+                <a asp-page-handler="UnlockState" asp-route-id="@Model.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark all teams as locked?')">Lock All</a>
+            </td>
+            <td>
+                <a asp-page-handler="SolveState" asp-route-id="@Model.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark all teams as unsolved?')">Unsolve All</a>
+            </td>
+            <td></td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>
+<div>
+    <a asp-page="./Index">Back to List</a>
+</div>

--- a/ServerCore/Pages/Puzzles/Status.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Status.cshtml.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Puzzles
+{
+    public class StatusModel : EventSpecificPageModel
+    {
+        private readonly ServerCore.Models.PuzzleServerContext _context;
+
+        public StatusModel(ServerCore.Models.PuzzleServerContext context)
+        {
+            _context = context;
+        }
+
+        public Puzzle Puzzle { get; set; }
+
+        public IList<PuzzleStatePerTeam> PuzzleStatePerTeam { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            Puzzle = await _context.Puzzles.FirstOrDefaultAsync(m => m.ID == id);
+
+            if (Puzzle == null)
+            {
+                return NotFound();
+            }
+
+            await EnsurePuzzleStateForPuzzleAsync();
+
+            PuzzleStatePerTeam = await _context.PuzzleStatePerTeam.Where(state => state.Puzzle == Puzzle).ToListAsync();
+            return Page();
+        }
+
+        // TODO: Not entirely sure this should be a Get but I can't figure out how to have an anchor tag do a post.
+        public async Task<IActionResult> OnGetUnlockStateAsync(int id, int? teamId, bool value)
+        {
+            var states = await this.GetStates(id, teamId);
+
+            for (int i = 0; i < states.Count; i++)
+            {
+                states[i].IsUnlocked = value;
+            }
+            await _context.SaveChangesAsync();
+
+            // TODO: Is there a cleaner way to do this part?
+            return await OnGetAsync(id);
+        }
+
+        // TODO: Not entirely sure this should be a Get but I can't figure out how to have an anchor tag do a post.
+        public async Task<IActionResult> OnGetSolveStateAsync(int id, int? teamId, bool value)
+        {
+            var states = await this.GetStates(id, teamId);
+
+            for (int i = 0; i < states.Count; i++)
+            {
+                states[i].IsSolved = value;
+            }
+            await _context.SaveChangesAsync();
+
+            // TODO: Is there a cleaner way to do this part?
+            return await OnGetAsync(id);
+        }
+
+        private Task<List<PuzzleStatePerTeam>> GetStates(int puzzleId, int? teamId)
+        {
+            var stateQ = _context.PuzzleStatePerTeam.Where(s => s.Puzzle.ID == puzzleId);
+
+            if (teamId.HasValue)
+            {
+                stateQ = stateQ.Where(s => s.Puzzle.ID == teamId.Value);
+            }
+
+            return stateQ.ToListAsync();
+        }
+
+        private async Task EnsurePuzzleStateForPuzzleAsync()
+        {
+            // TODO: Surely there is some magic join here that works, but despite reading and rereading, I do not understand how join syntax works. At all.
+            // I am looking for all Puzzles in this event for which this team has no PuzzleStatePerTeam.
+            //
+            // If there is an efficient way to validate full PuzzleStatePerTeam integrity across all puzzles/teams in an event,
+            // we could run that at app start, puzzle add/delete, and team add/delete.
+            var teamsQ = _context.Teams.Where(team => team.Event == Event);
+            var puzzleStateTeamsQ = _context.PuzzleStatePerTeam.Where(state => state.Puzzle == Puzzle).Select(state => state.Team);
+            var teamsWithoutState = await teamsQ.Except(puzzleStateTeamsQ).ToListAsync();
+
+            if (teamsWithoutState.Count > 0)
+            {
+                for (int i = 0; i < teamsWithoutState.Count; i++)
+                {
+                    _context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Puzzle = Puzzle, Team = teamsWithoutState[i] });
+                }
+
+                await _context.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/ServerCore/Pages/Puzzles/Status.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Status.cshtml.cs
@@ -72,7 +72,7 @@ namespace ServerCore.Pages.Puzzles
 
             if (teamId.HasValue)
             {
-                stateQ = stateQ.Where(s => s.Puzzle.ID == teamId.Value);
+                stateQ = stateQ.Where(s => s.Team.ID == teamId.Value);
             }
 
             return stateQ.ToListAsync();

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -58,7 +58,8 @@
             <td>
                 <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |
                 <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |
-                <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a>
+                <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a> |
+                <a asp-page="./Status" asp-route-id="@item.ID">Status</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Teams/Status.cshtml
+++ b/ServerCore/Pages/Teams/Status.cshtml
@@ -1,0 +1,94 @@
+﻿@page "/{eventId}/Teams/Status"
+@model ServerCore.Pages.Teams.StatusModel
+
+@{
+    ViewData["Title"] = "Status";
+}
+
+<h2>Puzzle Status for @Model.Team.Name</h2>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Puzzle) @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Puzzle.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].UnlockedTime)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].SolvedTime)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Printed)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Notes)
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Model.PuzzleStatePerTeam)
+        {
+            <tr>
+                <td>
+                    <a asp-page="../Puzzles/Status" asp-route-id="@item.Puzzle.ID">@Html.DisplayFor(modelItem => item.Puzzle.Name)</a>
+                </td>
+                <td>
+                    @if (item.UnlockedTime == null)
+                    {
+                        <a asp-page-handler="UnlockState" asp-route-puzzleId="@item.Puzzle.ID" asp-route-id="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as unlocked?')">Unlock</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.UnlockedTime)
+                        <a asp-page-handler="UnlockState" asp-route-puzzleId="@item.Puzzle.ID" asp-route-id="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as locked?')"> X</a>
+                    }
+                </td>
+                <td>
+                    @if (item.SolvedTime == null)
+                    {
+                        <a asp-page-handler="SolveState" asp-route-puzzleId="@item.Puzzle.ID" asp-route-id="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as solved?')">Solve</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.SolvedTime)
+                        <a asp-page-handler="SolveState" asp-route-puzzleId="@item.Puzzle.ID" asp-route-id="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as unsolved?')"> X</a>
+                    }
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Printed)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Notes)
+                </td>
+            </tr>
+        }
+
+        <tr>
+            <td></td>
+            <td>
+                <a asp-page-handler="UnlockState" asp-route-id="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark all puzzles as unlocked?')">Unlock All</a>
+            </td>
+            <td>
+                <a asp-page-handler="SolveState" asp-route-id="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark all puzzles as solved?')">Solve All</a>
+            </td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td>
+                <a asp-page-handler="UnlockState" asp-route-id="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark all puzzles as locked?')">Lock All</a>
+            </td>
+            <td>
+                <a asp-page-handler="SolveState" asp-route-id="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark all puzzles as unsolved?')">Unsolve All</a>
+            </td>
+            <td></td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>
+<div>
+    <a asp-page="./Index">Back to List</a>
+</div>

--- a/ServerCore/Pages/Teams/Status.cshtml.cs
+++ b/ServerCore/Pages/Teams/Status.cshtml.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Teams
+{
+    public class StatusModel : EventSpecificPageModel
+    {
+        private readonly ServerCore.Models.PuzzleServerContext _context;
+
+        public StatusModel(ServerCore.Models.PuzzleServerContext context)
+        {
+            _context = context;
+        }
+
+        public Team Team { get; set; }
+
+        public IList<PuzzleStatePerTeam> PuzzleStatePerTeam { get;set; }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            Team = await _context.Teams.FirstOrDefaultAsync(m => m.ID == id);
+
+            if (Team == null)
+            {
+                return NotFound();
+            }
+
+            await EnsurePuzzleStateForTeamAsync();
+
+            PuzzleStatePerTeam = await _context.PuzzleStatePerTeam.Where(state => state.Team == Team).ToListAsync();
+            return Page();
+        }
+
+        // TODO: Not entirely sure this should be a Get but I can't figure out how to have an anchor tag do a post.
+        public async Task<IActionResult> OnGetUnlockStateAsync(int id, int? puzzleId, bool value)
+        {
+            var states = await this.GetStates(id, puzzleId);
+
+            for (int i = 0; i < states.Count; i++)
+            {
+                states[i].IsUnlocked = value;
+            }
+            await _context.SaveChangesAsync();
+
+            // TODO: Is there a cleaner way to do this part?
+            return await OnGetAsync(id);
+        }
+
+        // TODO: Not entirely sure this should be a Get but I can't figure out how to have an anchor tag do a post.
+        public async Task<IActionResult> OnGetSolveStateAsync(int id, int? puzzleId, bool value)
+        {
+            var states = await this.GetStates(id, puzzleId);
+
+            for (int i = 0; i < states.Count; i++)
+            {
+                states[i].IsSolved = value;
+            }
+            await _context.SaveChangesAsync();
+
+            // TODO: Is there a cleaner way to do this part?
+            return await OnGetAsync(id);
+        }
+
+        private Task<List<PuzzleStatePerTeam>> GetStates(int teamId, int? puzzleId)
+        {
+            var stateQ = _context.PuzzleStatePerTeam.Where(s => s.Team.ID == teamId);
+
+            if (puzzleId.HasValue)
+            {
+                stateQ = stateQ.Where(s => s.Puzzle.ID == puzzleId.Value);
+            }
+
+            return stateQ.ToListAsync();
+        }
+
+        private async Task EnsurePuzzleStateForTeamAsync()
+        {
+            // TODO: Surely there is some magic join here that works, but despite reading and rereading, I do not understand how join syntax works. At all.
+            // I am looking for all Puzzles in this event for which this team has no PuzzleStatePerTeam.
+            //
+            // If there is an efficient way to validate full PuzzleStatePerTeam integrity across all puzzles/teams in an event,
+            // we could run that at app start, puzzle add/delete, and team add/delete.
+            var puzzlesQ = _context.Puzzles.Where(puzzle => puzzle.Event == Event);
+            var puzzleStatePuzzlesQ = _context.PuzzleStatePerTeam.Where(state => state.Team == Team).Select(state => state.Puzzle);
+            var puzzlesWithoutState = await puzzlesQ.Except(puzzleStatePuzzlesQ).ToListAsync();
+
+            if (puzzlesWithoutState.Count > 0)
+            {
+                for (int i = 0; i < puzzlesWithoutState.Count; i++)
+                {
+                    _context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Puzzle = puzzlesWithoutState[i], Team = Team });
+                }
+
+                await _context.SaveChangesAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This starts to drive puzzle state by offering two views: puzzle state
for all teams in reference to a puzzle, and puzzle state for all puzzles
in reference to a team. The two views are cross-linked and offer
confirmation dialogs since the action is somewhat destructive if used
improperly.