### PR TITLE
Ensure PuzzleStatePerTeam on Write Only

### DIFF
--- a/Data/DataModel/PuzzleStatePerTeam.cs
+++ b/Data/DataModel/PuzzleStatePerTeam.cs
@@ -5,11 +5,7 @@ namespace ServerCore.DataModel
 {
     public class PuzzleStatePerTeam
     {
-        /// <summary>
-        /// Row ID
-        /// </summary>
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public int ID { get; set; }
+        // Note: No ID here. See PuzzleServerContext.OnModelCreating for the declaration of the key.
 
         public int PuzzleID { get; set; }
         public virtual Puzzle Puzzle { get; set; }

--- a/Data/Migrations/20180918162310_PuzzleStatePerTeamKey.Designer.cs
+++ b/Data/Migrations/20180918162310_PuzzleStatePerTeamKey.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServerCore.Models;
 
 namespace Data.Migrations
 {
     [DbContext(typeof(PuzzleServerContext))]
-    partial class PuzzleServerContextModelSnapshot : ModelSnapshot
+    [Migration("20180918162310_PuzzleStatePerTeamKey")]
+    partial class PuzzleStatePerTeamKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20180918162310_PuzzleStatePerTeamKey.cs
+++ b/Data/Migrations/20180918162310_PuzzleStatePerTeamKey.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Data.Migrations
+{
+    public partial class PuzzleStatePerTeamKey : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleStatePerTeam_Puzzles_PuzzleID",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleStatePerTeam_Teams_TeamID",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_PuzzleStatePerTeam",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PuzzleStatePerTeam_PuzzleID",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.DropColumn(
+                name: "ID",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "TeamID",
+                table: "PuzzleStatePerTeam",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PuzzleID",
+                table: "PuzzleStatePerTeam",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_PuzzleStatePerTeam",
+                table: "PuzzleStatePerTeam",
+                columns: new[] { "PuzzleID", "TeamID" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleStatePerTeam_Puzzles_PuzzleID",
+                table: "PuzzleStatePerTeam",
+                column: "PuzzleID",
+                principalTable: "Puzzles",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleStatePerTeam_Teams_TeamID",
+                table: "PuzzleStatePerTeam",
+                column: "TeamID",
+                principalTable: "Teams",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleStatePerTeam_Puzzles_PuzzleID",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleStatePerTeam_Teams_TeamID",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_PuzzleStatePerTeam",
+                table: "PuzzleStatePerTeam");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "TeamID",
+                table: "PuzzleStatePerTeam",
+                nullable: true,
+                oldClrType: typeof(int));
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PuzzleID",
+                table: "PuzzleStatePerTeam",
+                nullable: true,
+                oldClrType: typeof(int));
+
+            migrationBuilder.AddColumn<int>(
+                name: "ID",
+                table: "PuzzleStatePerTeam",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_PuzzleStatePerTeam",
+                table: "PuzzleStatePerTeam",
+                column: "ID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PuzzleStatePerTeam_PuzzleID",
+                table: "PuzzleStatePerTeam",
+                column: "PuzzleID");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleStatePerTeam_Puzzles_PuzzleID",
+                table: "PuzzleStatePerTeam",
+                column: "PuzzleID",
+                principalTable: "Puzzles",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleStatePerTeam_Teams_TeamID",
+                table: "PuzzleStatePerTeam",
+                column: "TeamID",
+                principalTable: "Teams",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/Data/PuzzleServerContext.cs
+++ b/Data/PuzzleServerContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using ServerCore.DataModel;
 
@@ -53,6 +54,7 @@ namespace ServerCore.Models
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<ContentFile>().HasIndex(contentFile => new { contentFile.EventID, contentFile.ShortName }).IsUnique();
+            modelBuilder.Entity<PuzzleStatePerTeam>().HasKey(state => new { state.PuzzleID, state.TeamID });
 
             base.OnModelCreating(modelBuilder);
         }

--- a/ServerCore/ModelBases/PuzzleStatePerTeamPageModel.cs
+++ b/ServerCore/ModelBases/PuzzleStatePerTeamPageModel.cs
@@ -25,7 +25,7 @@ namespace ServerCore.ModelBases
 
         public async Task InitializeModelAsync(Puzzle puzzle, Team team, SortOrder? sort)
         {
-            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper.GetReadOnlyQuery(this.Context, this.Event, puzzle, team);
+            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper.GetFullReadOnlyQuery(this.Context, this.Event, puzzle, team);
             this.Sort = sort;
 
             switch(sort ?? this.DefaultSort)
@@ -80,7 +80,7 @@ namespace ServerCore.ModelBases
 
         public async Task SetUnlockStateAsync(Puzzle puzzle, Team team, bool value)
         {
-            var statesQ = await PuzzleStateHelper.GetReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
+            var statesQ = await PuzzleStateHelper.GetFullReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
             var states = await statesQ.ToListAsync();
 
             for (int i = 0; i < states.Count; i++)
@@ -92,7 +92,7 @@ namespace ServerCore.ModelBases
 
         public async Task SetSolveStateAsync(Puzzle puzzle, Team team, bool value)
         {
-            var statesQ = await PuzzleStateHelper.GetReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
+            var statesQ = await PuzzleStateHelper.GetFullReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
             var states = await statesQ.ToListAsync();
 
             for (int i = 0; i < states.Count; i++)

--- a/ServerCore/ModelBases/PuzzleStatePerTeamPageModel.cs
+++ b/ServerCore/ModelBases/PuzzleStatePerTeamPageModel.cs
@@ -23,19 +23,9 @@ namespace ServerCore.ModelBases
 
         protected abstract SortOrder DefaultSort { get; }
 
-        public async Task InitializeModelAsync(int? puzzleId, int? teamId, SortOrder? sort)
+        public async Task InitializeModelAsync(Puzzle puzzle, Team team, SortOrder? sort)
         {
-            if (puzzleId.HasValue)
-            {
-                await this.EnsureStateForPuzzleAsync(puzzleId.Value);
-            }
-
-            if (teamId.HasValue)
-            {
-                await this.EnsureStateForTeamAsync(teamId.Value);
-            }
-
-            var statesQ = this.GetPuzzleStatePerTeamQuery(puzzleId, teamId);
+            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper.GetReadOnlyQuery(this.Context, this.Event, puzzle, team);
             this.Sort = sort;
 
             switch(sort ?? this.DefaultSort)
@@ -88,9 +78,10 @@ namespace ServerCore.ModelBases
             return result;
         }
 
-        public async Task SetUnlockStateAsync(int? puzzleId, int? teamId, bool value)
+        public async Task SetUnlockStateAsync(Puzzle puzzle, Team team, bool value)
         {
-            var states = await this.GetPuzzleStatePerTeamQuery(puzzleId, teamId).ToListAsync();
+            var statesQ = await PuzzleStateHelper.GetReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
+            var states = await statesQ.ToListAsync();
 
             for (int i = 0; i < states.Count; i++)
             {
@@ -99,70 +90,16 @@ namespace ServerCore.ModelBases
             await Context.SaveChangesAsync();
         }
 
-        public async Task SetSolveStateAsync(int? puzzleId, int? teamId, bool value)
+        public async Task SetSolveStateAsync(Puzzle puzzle, Team team, bool value)
         {
-            var states = await this.GetPuzzleStatePerTeamQuery(puzzleId, teamId).ToListAsync();
+            var statesQ = await PuzzleStateHelper.GetReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
+            var states = await statesQ.ToListAsync();
 
             for (int i = 0; i < states.Count; i++)
             {
                 states[i].IsSolved = value;
             }
             await Context.SaveChangesAsync();
-        }
-
-        private IQueryable<PuzzleStatePerTeam> GetPuzzleStatePerTeamQuery(int? puzzleId, int? teamId)
-        {
-            if (!puzzleId.HasValue && !teamId.HasValue)
-            {
-                throw new ArgumentException("Should never query all states across all events");
-            }
-
-            IQueryable<PuzzleStatePerTeam> puzzleStatePerTeamQ = Context.PuzzleStatePerTeam;
-
-            if (puzzleId.HasValue)
-            {
-                puzzleStatePerTeamQ = puzzleStatePerTeamQ.Where(state => state.PuzzleID == puzzleId.Value);
-            }
-            if (teamId.HasValue)
-            {
-                puzzleStatePerTeamQ = puzzleStatePerTeamQ.Where(state => state.TeamID == teamId.Value);
-            }
-
-            return puzzleStatePerTeamQ;
-        }
-
-        private async Task EnsureStateForPuzzleAsync(int puzzleId)
-        {
-            var teamsQ = this.Context.Teams.Where(team => team.Event == this.Event).Select(team => team.ID);
-            var puzzleStateTeamsQ = this.Context.PuzzleStatePerTeam.Where(state => state.PuzzleID == puzzleId).Select(state => state.TeamID);
-            var teamsWithoutState = await teamsQ.Except(puzzleStateTeamsQ).ToListAsync();
-
-            if (teamsWithoutState.Count > 0)
-            {
-                for (int i = 0; i < teamsWithoutState.Count; i++)
-                {
-                    this.Context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { PuzzleID = puzzleId, TeamID = teamsWithoutState[i] });
-                }
-
-                await this.Context.SaveChangesAsync();
-            }
-        }
-
-        private async Task EnsureStateForTeamAsync(int teamId)
-        {
-            var puzzlesQ = this.Context.Puzzles.Where(puzzle => puzzle.Event == this.Event).Select(puzzle => puzzle.ID);
-            var puzzleStatePuzzlesQ = this.Context.PuzzleStatePerTeam.Where(state => state.TeamID == teamId).Select(state => state.PuzzleID);
-            var puzzlesWithoutState = await puzzlesQ.Except(puzzleStatePuzzlesQ).ToListAsync();
-
-            if (puzzlesWithoutState.Count > 0)
-            {
-                for (int i = 0; i < puzzlesWithoutState.Count; i++)
-                {
-                    this.Context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { TeamID = teamId, PuzzleID = puzzlesWithoutState[i] });
-                }
-
-                await this.Context.SaveChangesAsync();
-            }
         }
 
         public enum SortOrder

--- a/ServerCore/Pages/Puzzles/Status.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Status.cshtml.cs
@@ -8,7 +8,7 @@ namespace ServerCore.Pages.Puzzles
 {
     /// <summary>
     /// Model for author/admin's puzzle-centric Status page.
-    /// /used for tracking what each team's progress is and altering that progress manually if needed.
+    /// used for tracking what each team's progress is and altering that progress manually if needed.
     /// </summary>
     public class StatusModel : PuzzleStatePerTeamPageModel
     {
@@ -29,13 +29,16 @@ namespace ServerCore.Pages.Puzzles
                 return NotFound();
             }
 
-            await InitializeModelAsync(puzzleId: id, teamId: null, sort: sort);
+            await InitializeModelAsync(Puzzle, null, sort: sort);
             return Page();
         }
 
         public async Task<IActionResult> OnGetUnlockStateAsync(int id, int? teamId, bool value, string sort)
         {
-            await SetUnlockStateAsync(puzzleId: id, teamId: teamId, value: value);
+            var puzzle = await Context.Puzzles.FirstAsync(m => m.ID == id);
+            var team = teamId == null ? null : await Context.Teams.FirstAsync(m => m.ID == teamId.Value);
+
+            await SetUnlockStateAsync(puzzle, team, value);
 
             // redirect without the unlock info to keep the URL clean
             return RedirectToPage(new { id, sort });
@@ -43,7 +46,10 @@ namespace ServerCore.Pages.Puzzles
 
         public async Task<IActionResult> OnGetSolveStateAsync(int id, int? teamId, bool value, string sort)
         {
-            await SetSolveStateAsync(puzzleId: id, teamId: teamId, value: value);
+            var puzzle = await Context.Puzzles.FirstAsync(m => m.ID == id);
+            var team = teamId == null ? null : await Context.Teams.FirstAsync(m => m.ID == teamId.Value);
+
+            await SetSolveStateAsync(puzzle, team, value);
 
             // redirect without the solve info to keep the URL clean
             return RedirectToPage(new { id, sort });

--- a/ServerCore/Pages/Teams/Status.cshtml.cs
+++ b/ServerCore/Pages/Teams/Status.cshtml.cs
@@ -8,7 +8,7 @@ namespace ServerCore.Pages.Teams
 {
     /// <summary>
     /// Model for author/admin's team-centric Status page.
-    /// /used for tracking what each team's progress is and altering that progress manually if needed.
+    /// used for tracking what each team's progress is and altering that progress manually if needed.
     /// An author's view should be filtered to puzzles where they are an author (NYI so far though).
     /// </summary>
     public class StatusModel : PuzzleStatePerTeamPageModel
@@ -30,13 +30,16 @@ namespace ServerCore.Pages.Teams
                 return NotFound();
             }
 
-            await InitializeModelAsync(puzzleId: null, teamId: id, sort: sort);
+            await InitializeModelAsync(null, Team, sort: sort);
             return Page();
         }
 
         public async Task<IActionResult> OnGetUnlockStateAsync(int id, int? puzzleId, bool value, string sort)
         {
-            await SetUnlockStateAsync(puzzleId: puzzleId, teamId: id, value: value);
+            var puzzle = puzzleId == null ? null : await Context.Puzzles.FirstAsync(m => m.ID == puzzleId.Value);
+            var team = await Context.Teams.FirstAsync(m => m.ID == id);
+
+            await SetUnlockStateAsync(puzzle, team, value);
 
             // redirect without the unlock info to keep the URL clean
             return RedirectToPage(new { id, sort });
@@ -44,7 +47,10 @@ namespace ServerCore.Pages.Teams
 
         public async Task<IActionResult> OnGetSolveStateAsync(int id, int? puzzleId, bool value, string sort)
         {
-            await SetSolveStateAsync(puzzleId: puzzleId, teamId: id, value: value);
+            var puzzle = puzzleId == null ? null : await Context.Puzzles.FirstAsync(m => m.ID == puzzleId.Value);
+            var team = await Context.Teams.FirstAsync(m => m.ID == id);
+
+            await SetSolveStateAsync(puzzle, team, value);
 
             // redirect without the solve info to keep the URL clean
             return RedirectToPage(new { id, sort });

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -1,0 +1,162 @@
+﻿using ServerCore.DataModel;
+using ServerCore.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace ServerCore
+{
+    public class PuzzleStateHelper
+    {
+        /// <summary>
+        /// Get a read-only query of puzzle state. You won't be able to write to these values, but the query will be resilient to state records that are missing on the server.
+        /// </summary>
+        /// <param name="context">The puzzle DB context</param>
+        /// <param name="eventObj">The event we are querying from</param>
+        /// <param name="puzzle">The puzzle; if null, get all puzzles in the event.</param>
+        /// <param name="team">The team; if null, get all the teams in the event.</param>
+        /// <returns>A query of PuzzleStatePerTeam objects that can be sorted and instantiated, but you can't edit the results.</returns>
+        public static IQueryable<PuzzleStatePerTeam> GetReadOnlyQuery(PuzzleServerContext context, Event eventObj, Puzzle puzzle, Team team)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("Context required.");
+            }
+
+            if (eventObj == null)
+            {
+                throw new ArgumentNullException("Event required.");
+            }
+
+            if (puzzle != null && team != null)
+            {
+                return context.PuzzleStatePerTeam
+                    .Where(state => state.Puzzle == puzzle && state.Team == team)
+                    .DefaultIfEmpty(new DataModel.PuzzleStatePerTeam()
+                    {
+                        Puzzle = puzzle,
+                        PuzzleID = puzzle.ID,
+                        Team = team,
+                        TeamID = team.ID
+                    });
+            }
+
+            if (puzzle != null)
+            {
+                var teams = context.Teams.Where(t => t.Event == eventObj);
+                var states = context.PuzzleStatePerTeam.Where(state => state.Puzzle == puzzle);
+
+                return from t in teams
+                       join state in states on t.ID equals state.TeamID into tmp
+                       from teamstate in tmp.DefaultIfEmpty()
+                       select new PuzzleStatePerTeam
+                       {
+                           Puzzle = puzzle,
+                           PuzzleID = puzzle.ID,
+                           Team = t,
+                           TeamID = t.ID,
+                           UnlockedTime = teamstate == null ? null : teamstate.UnlockedTime,
+                           SolvedTime = teamstate == null ? null : teamstate.SolvedTime,
+                           Printed = teamstate == null ? false : teamstate.Printed,
+                           Notes = teamstate == null ? null : teamstate.Notes
+                       };
+            }
+
+            if (team != null)
+            {
+                var puzzles = context.Puzzles.Where(p => p.Event == eventObj);
+                var states = context.PuzzleStatePerTeam.Where(state => state.Team == team);
+
+                return from p in puzzles
+                       join state in states on p.ID equals state.PuzzleID into tmp
+                       from teamstate in tmp.DefaultIfEmpty()
+                       select new PuzzleStatePerTeam
+                       {
+                           Puzzle = p,
+                           PuzzleID = p.ID,
+                           Team = team,
+                           TeamID = team.ID,
+                           UnlockedTime = teamstate == null ? null : teamstate.UnlockedTime,
+                           SolvedTime = teamstate == null ? null : teamstate.SolvedTime,
+                           Printed = teamstate == null ? false : teamstate.Printed,
+                           Notes = teamstate == null ? null : teamstate.Notes
+                       };
+            }
+
+            throw new NotImplementedException("Full event query is NYI but needed for puzzle state map");
+        }
+
+        /// <summary>
+        /// Get a writable query of puzzle state. In the course of constructing the query, it will instantiate any state records that are missing on the server.
+        /// </summary>
+        /// <param name="context">The puzzle DB context</param>
+        /// <param name="eventObj">The event we are querying from</param>
+        /// <param name="puzzle">The puzzle; if null, get all puzzles in the event.</param>
+        /// <param name="team">The team; if null, get all the teams in the event.</param>
+        /// <returns>A query of PuzzleStatePerTeam objects that can be sorted and instantiated, but you can't edit the results.</returns>
+        public static async Task<IQueryable<PuzzleStatePerTeam>> GetReadWriteQueryAsync(PuzzleServerContext context, Event eventObj, Puzzle puzzle, Team team)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("Context required.");
+            }
+
+            if (eventObj == null)
+            {
+                throw new ArgumentNullException("Event required.");
+            }
+
+            if (puzzle != null && team != null)
+            {
+                PuzzleStatePerTeam state = await context.PuzzleStatePerTeam.Where(s => s.Puzzle == puzzle && s.Team == team).FirstOrDefaultAsync();
+                if (state == null)
+                {
+                    context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Puzzle = puzzle, Team = team });
+                    await context.SaveChangesAsync(); // query below will not return this unless we save
+                }
+
+                return context.PuzzleStatePerTeam.Where(s => s.Puzzle == puzzle && s.Team == team);
+            }
+
+            if (puzzle != null)
+            {
+                var teamIdsQ = context.Teams.Where(p => p.Event == eventObj).Select(p => p.ID);
+                var puzzleStateTeamIdsQ = context.PuzzleStatePerTeam.Where(s => s.Puzzle == puzzle).Select(s => s.TeamID);
+                var teamIdsWithoutState = await teamIdsQ.Except(puzzleStateTeamIdsQ).ToListAsync();
+
+                if (teamIdsWithoutState.Count > 0)
+                {
+                    for (int i = 0; i < teamIdsWithoutState.Count; i++)
+                    {
+                        context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Puzzle = puzzle, TeamID = teamIdsWithoutState[i] });
+                    }
+                    await context.SaveChangesAsync(); // query below will not return these unless we save
+                }
+
+                return context.PuzzleStatePerTeam.Where(state => state.Puzzle == puzzle);
+            }
+
+            if (team != null)
+            {
+                var puzzleIdsQ = context.Puzzles.Where(p => p.Event == eventObj).Select(p => p.ID);
+                var puzzleStatePuzzleIdsQ = context.PuzzleStatePerTeam.Where(s => s.Team == team).Select(s => s.PuzzleID);
+                var puzzleIdsWithoutState = await puzzleIdsQ.Except(puzzleStatePuzzleIdsQ).ToListAsync();
+
+                if (puzzleIdsWithoutState.Count > 0)
+                {
+                    for (int i = 0; i < puzzleIdsWithoutState.Count; i++)
+                    {
+                        context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Team = team, PuzzleID = puzzleIdsWithoutState[i] });
+                    }
+                    await context.SaveChangesAsync(); // query below will not return these unless we save
+                }
+
+                return context.PuzzleStatePerTeam.Where(state => state.Team == team);
+            }
+
+            throw new NotImplementedException("Full event query is NYI and may never be needed");
+        }
+    }
+}

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -154,8 +154,7 @@ namespace ServerCore
                     context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Puzzle = puzzle, Team = team });
                 }
             }
-
-            if (puzzle != null)
+            else if (puzzle != null)
             {
                 var teamIdsQ = context.Teams.Where(p => p.Event == eventObj).Select(p => p.ID);
                 var puzzleStateTeamIdsQ = context.PuzzleStatePerTeam.Where(s => s.Puzzle == puzzle).Select(s => s.TeamID);
@@ -169,8 +168,7 @@ namespace ServerCore
                     }
                 }
             }
-
-            if (team != null)
+            else if (team != null)
             {
                 var puzzleIdsQ = context.Puzzles.Where(p => p.Event == eventObj).Select(p => p.ID);
                 var puzzleStatePuzzleIdsQ = context.PuzzleStatePerTeam.Where(s => s.Team == team).Select(s => s.PuzzleID);
@@ -184,8 +182,7 @@ namespace ServerCore
                     }
                 }
             }
-
-            if (puzzle == null && team == null)
+            else if (puzzle == null && team == null)
             {
                 throw new NotImplementedException("Full event query is NYI and may never be needed");
             }


### PR DESCRIPTION
Trying lots of things to get better perf out of this table without
sacrificing correctness.

Several changes here:

1. I've removed the ID property of the PuzzleStatePerTeam table and made
the PuzzleID+TeamID into the key.

2. I've moved all state access into PuzzleStateHelper so it can be
shared across pages.

3. I've made a readonly accessor that is resilient to missing states. It
performs joins - but, since the joins make untracked results, they can't
be used for edits.

4. I've made a writable accessor that ensures that states exist. It is
possible that some extremely rare timing issue will cause the write to
fail, but it will not break the event longterm.

If someone can write these better, they are more than welcome to do so,
but this is the best I can figure out and I've gone down several blind
alleys just to get here.