### PR TITLE
Dev/kennyy/prequisite editing

### DIFF
--- a/Data/DataModel/Prerequisites.cs
+++ b/Data/DataModel/Prerequisites.cs
@@ -13,9 +13,19 @@ namespace ServerCore.DataModel
         public int ID { get; set; }
 
         /// <summary>
+        /// The puzzle ID that depends on others.
+        /// </summary>
+        public int PuzzleID { get; set; }
+
+        /// <summary>
         /// The puzzle that depends on others.
         /// </summary>
         public virtual Puzzle Puzzle { get; set; }
+
+        /// <summary>
+        /// A potential prerequisite ID of the puzzle named in Puzzle, which may need to be solved before Puzzle will be unlocked.
+        /// </summary>
+        public int PrerequisiteID { get; set; }
 
         /// <summary>
         /// A potential prerequisite of the puzzle named in Puzzle, which may need to be solved before Puzzle will be unlocked.

--- a/Data/DataModel/PuzzleStatePerTeam.cs
+++ b/Data/DataModel/PuzzleStatePerTeam.cs
@@ -14,38 +14,6 @@ namespace ServerCore.DataModel
         public virtual Team Team { get; set; }
 
         /// <summary>
-        /// Whether or not the puzzle has been unlocked
-        /// </summary>
-        [NotMapped]
-        public bool IsUnlocked
-        {
-            get { return UnlockedTime != null; }
-            set
-            {
-                if (IsUnlocked != value)
-                {
-                    UnlockedTime = value ? (DateTime?)DateTime.UtcNow : null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Whether or not the puzzle has been solved
-        /// </summary>
-        [NotMapped]
-        public bool IsSolved
-        {
-            get { return SolvedTime != null; }
-            set
-            {
-                if (IsSolved != value)
-                {
-                    SolvedTime = value ? (DateTime?)DateTime.UtcNow : null;
-                }
-            }
-        }
-
-        /// <summary>
         /// Whether or not the puzzle has been unlocked by this team, and if so when
         /// </summary>
         public DateTime? UnlockedTime { get; set; }

--- a/ServerCore/ModelBases/PuzzleStatePerTeamPageModel.cs
+++ b/ServerCore/ModelBases/PuzzleStatePerTeamPageModel.cs
@@ -15,7 +15,7 @@ namespace ServerCore.ModelBases
 
         public PuzzleStatePerTeamPageModel(PuzzleServerContext context)
         {
-            this.Context = context;
+            Context = context;
         }
 
         public IList<PuzzleStatePerTeam> PuzzleStatePerTeam { get; set; }
@@ -24,10 +24,10 @@ namespace ServerCore.ModelBases
 
         public async Task InitializeModelAsync(Puzzle puzzle, Team team, SortOrder? sort)
         {
-            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper.GetFullReadOnlyQuery(this.Context, this.Event, puzzle, team);
-            this.Sort = sort;
+            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper.GetFullReadOnlyQuery(Context, Event, puzzle, team);
+            Sort = sort;
 
-            switch(sort ?? this.DefaultSort)
+            switch(sort ?? DefaultSort)
             {
                 case SortOrder.PuzzleAscending:
                     statesQ = statesQ.OrderBy(state => state.Puzzle.Name);
@@ -64,7 +64,7 @@ namespace ServerCore.ModelBases
         {
             SortOrder result = ascendingSort;
 
-            if (result == (this.Sort ?? DefaultSort))
+            if (result == (Sort ?? DefaultSort))
             {
                 result = descendingSort;
             }
@@ -77,28 +77,14 @@ namespace ServerCore.ModelBases
             return result;
         }
 
-        public async Task SetUnlockStateAsync(Puzzle puzzle, Team team, bool value)
+        public Task SetUnlockStateAsync(Puzzle puzzle, Team team, bool value)
         {
-            var statesQ = await PuzzleStateHelper.GetFullReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
-            var states = await statesQ.ToListAsync();
-
-            for (int i = 0; i < states.Count; i++)
-            {
-                states[i].IsUnlocked = value;
-            }
-            await Context.SaveChangesAsync();
+            return PuzzleStateHelper.SetUnlockStateAsync(Context, Event, puzzle, team, value ? (DateTime?)DateTime.UtcNow : null);
         }
 
-        public async Task SetSolveStateAsync(Puzzle puzzle, Team team, bool value)
+        public Task SetSolveStateAsync(Puzzle puzzle, Team team, bool value)
         {
-            var statesQ = await PuzzleStateHelper.GetFullReadWriteQueryAsync(this.Context, this.Event, puzzle, team);
-            var states = await statesQ.ToListAsync();
-
-            for (int i = 0; i < states.Count; i++)
-            {
-                states[i].IsSolved = value;
-            }
-            await Context.SaveChangesAsync();
+            return PuzzleStateHelper.SetSolveStateAsync(Context, Event, puzzle, team, value ? (DateTime?)DateTime.UtcNow : null);
         }
 
         public enum SortOrder

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -9,6 +9,7 @@
 
 <h4>Puzzle</h4>
 <hr />
+<h3>Properties</h3>
 <div class="row">
     <div class="col-md-4">
         <form method="post" enctype="multipart/form-data">
@@ -75,6 +76,73 @@
             <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-default" />
             </div>
+        </form>
+        <hr />
+        <h3>Prerequisites</h3>
+        <h4>These puzzles help to unlock me:</h4>
+        <form method="post" enctype="multipart/form-data">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Prerequisite</th>
+                        <th>Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var pre in Model.CurrentPrerequisites)
+                {
+                    <tr>
+                        <td>
+                            <a asp-page="./Edit" asp-route-id="@(pre.ID)">@(pre.Name)</a>
+                        </td>
+                        <td>
+                            <a asp-page-handler="RemovePrerequisite" asp-route-id="@Model.Puzzle.ID" asp-route-prerequisite="@(pre.ID)">Remove</a>
+                        </td>
+                    </tr>
+                }
+                    <tr>
+                        <td>
+                            <select class="form-control" asp-for="NewPrerequisiteID" asp-items="@(new SelectList(Model.PotentialPrerequisites, "ID", "Name"))"></select>
+                        </td>
+                        <td>
+                            <input type="submit" value="Add" asp-page-handler="AddPrerequisite" class="btn btn-default" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </form>
+        <br />
+        <h4>I help to unlock these puzzles:</h4>
+        <form method="post" enctype="multipart/form-data">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Puzzle</th>
+                        <th>Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var p in Model.CurrentPrerequisitesOf)
+                {
+                    <tr>
+                        <td>
+                            <a asp-page="./Edit" asp-route-id="@(p.ID)">@(p.Name)</a>
+                        </td>
+                        <td>
+                            <a asp-page-handler="RemovePrerequisiteOf" asp-route-id="@Model.Puzzle.ID" asp-route-prerequisiteOf="@(p.ID)">Remove</a>
+                        </td>
+                    </tr>
+                }
+                    <tr>
+                        <td>
+                            <select class="form-control" asp-for="NewPrerequisiteOfID" asp-items="@(new SelectList(Model.PotentialPrerequisitesOf, "ID", "Name"))"></select>
+                        </td>
+                        <td>
+                            <input type="submit" value="Add" asp-page-handler="AddPrerequisiteOf" class="btn btn-default" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </form>
     </div>
 </div>

--- a/ServerCore/Pages/Puzzles/Edit.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml.cs
@@ -1,8 +1,10 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
 using ServerCore.ModelBases;
@@ -21,6 +23,20 @@ namespace ServerCore.Pages.Puzzles
         [BindProperty]
         public Puzzle Puzzle { get; set; }
 
+        [BindProperty]
+        public int NewPrerequisiteID { get; set; }
+
+        [BindProperty]
+        public int NewPrerequisiteOfID { get; set; }
+
+        public List<Puzzle> PotentialPrerequisites { get; set; }
+
+        public List<Puzzle> CurrentPrerequisites { get; set; }
+
+        public List<Puzzle> PotentialPrerequisitesOf { get; set; }
+
+        public List<Puzzle> CurrentPrerequisitesOf { get; set; }
+
         public async Task<IActionResult> OnGetAsync(int id)
         {
             Puzzle = await _context.Puzzles.Where(m => m.ID == id).FirstOrDefaultAsync();
@@ -29,6 +45,19 @@ namespace ServerCore.Pages.Puzzles
             {
                 return NotFound();
             }
+
+            IQueryable<Puzzle> currentPrerequisitesQ = _context.Prerequisites.Where(m => m.Puzzle == Puzzle).Select(m => m.Prerequisite);
+            IQueryable<Puzzle> potentialPrerequitesQ = _context.Puzzles.Where(m => m.Event == Event && m != Puzzle).Except(currentPrerequisitesQ);
+
+            CurrentPrerequisites = await currentPrerequisitesQ.ToListAsync();
+            PotentialPrerequisites = await potentialPrerequitesQ.ToListAsync();
+
+            IQueryable<Puzzle> currentPrerequisitesOfQ = _context.Prerequisites.Where(m => m.Prerequisite == Puzzle).Select(m => m.Puzzle);
+            IQueryable<Puzzle> potentialPrerequitesOfQ = _context.Puzzles.Where(m => m.Event == Event && m != Puzzle).Except(currentPrerequisitesOfQ);
+
+            CurrentPrerequisitesOf = await currentPrerequisitesOfQ.ToListAsync();
+            PotentialPrerequisitesOf = await potentialPrerequitesOfQ.ToListAsync();
+
             return Page();
         }
 
@@ -60,9 +89,68 @@ namespace ServerCore.Pages.Puzzles
             return RedirectToPage("./Index");
         }
 
+        public async Task<IActionResult> OnPostAddPrerequisiteAsync()
+        {
+            if (!PuzzleExists(NewPrerequisiteID) || PrerequisiteExists(Puzzle.ID, NewPrerequisiteID))
+            {
+                return NotFound();
+            }
+
+            _context.Prerequisites.Add(new Prerequisites() { PuzzleID = Puzzle.ID, PrerequisiteID = NewPrerequisiteID });
+            await _context.SaveChangesAsync();
+
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnPostAddPrerequisiteOfAsync()
+        {
+            if (!PuzzleExists(NewPrerequisiteOfID) || PrerequisiteExists(NewPrerequisiteOfID, Puzzle.ID))
+            {
+                return NotFound();
+            }
+
+            _context.Prerequisites.Add(new Prerequisites() { PuzzleID = NewPrerequisiteOfID, PrerequisiteID = Puzzle.ID });
+            await _context.SaveChangesAsync();
+
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnGetRemovePrerequisiteAsync(int id, int prerequisite)
+        {
+            Prerequisites toRemove = await _context.Prerequisites.Where(m => m.PuzzleID == id && m.PrerequisiteID == prerequisite).FirstOrDefaultAsync();
+
+            if (toRemove != null)
+            {
+                _context.Prerequisites.Remove(toRemove);
+                await _context.SaveChangesAsync();
+            }
+
+            // redirect without the prerequisite info to keep the URL clean
+            return RedirectToPage(new { id });
+        }
+
+        public async Task<IActionResult> OnGetRemovePrerequisiteOfAsync(int id, int prerequisiteOf)
+        {
+            Prerequisites toRemove = await _context.Prerequisites.Where(m => m.PuzzleID == prerequisiteOf && m.PrerequisiteID == id).FirstOrDefaultAsync();
+
+            if (toRemove != null)
+            {
+                _context.Prerequisites.Remove(toRemove);
+                await _context.SaveChangesAsync();
+            }
+
+            // redirect without the prerequisite info to keep the URL clean
+            return RedirectToPage(new { id });
+        }
+
         private bool PuzzleExists(int id)
         {
             return _context.Puzzles.Any(e => e.ID == id);
+        }
+
+        private bool PrerequisiteExists(int puzzleId, int prerequisiteId)
+        {
+            return _context.Prerequisites.Any(pr => pr.Puzzle.ID == puzzleId && pr.Prerequisite.ID == prerequisiteId);
         }
     }
 }

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -47,10 +47,7 @@ namespace ServerCore.Pages.Submissions
             // Update puzzle state if submission was correct
             if (Submission.Response != null && Submission.Response.IsSolution)
             {
-                var statesQ = await PuzzleStateHelper.GetFullReadWriteQueryAsync(_context, this.Event, Submission.Puzzle, Submission.Team);
-                PuzzleStatePerTeam puzzleState = await statesQ.FirstOrDefaultAsync();
-                puzzleState.IsSolved = true;
-                Submission.TimeSubmitted = (DateTime)puzzleState.SolvedTime;
+                await PuzzleStateHelper.SetSolveStateAsync(_context, Event, Submission.Puzzle, Submission.Team, Submission.TimeSubmitted);
             }
             
             _context.Submissions.Add(Submission);
@@ -65,7 +62,7 @@ namespace ServerCore.Pages.Submissions
             PuzzleId = puzzleId;
             TeamId = teamId;
 
-            Submission correctSubmission = this.Submissions?.Where((s) => s.Response != null && s.Response.IsSolution).FirstOrDefault();
+            Submission correctSubmission = Submissions?.Where((s) => s.Response != null && s.Response.IsSolution).FirstOrDefault();
             if (correctSubmission != null)
             {
                 AnswerToken = correctSubmission.SubmissionText;

--- a/ServerCore/Pages/Teams/Play.cshtml
+++ b/ServerCore/Pages/Teams/Play.cshtml
@@ -63,7 +63,7 @@
             }
             <td>
                 <a asp-page="/Submissions/Index" asp-route-puzzleid="@item.Puzzle.ID" asp-route-teamid="@Model.TeamID">
-                    @if (item.State.IsSolved)
+                    @if (item.State.SolvedTime != null)
                     {
                         <text>Solved at </text>@item.State.SolvedTime
                     }


### PR DESCRIPTION
Commit 1: Prerequisite Editing

Allows prerequisites to be edited on the puzzle's Edit page. I've chosen to put them here rather than on their own page, which would have been a bit easier. This is the page they were edited on in the old site, and it was helpful to see the chosen prerequisites next to the min count to make sure that everything lined up.

Commit 2: Consolidate all state setters into PuzzleStateHelper

In preparation for prerequisite-based unlocking, force all setters of unlock/solved state do do their set operations via PuzzleStateHelper, so that we can ultimately use that to perform the prerequisite unlock.

I also removed the IsUnlocked and IsSolved bools from PuzzleStatePerTeam to discourage others from using these, since they don't perform well in queries.

Finally, I fixed all compiler messages in files I touched - all just cosmetic stuff.