### PR TITLE
Prevent team creation if event team registration is closed.

### DIFF
--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -30,6 +30,11 @@ namespace ServerCore.Pages.Teams
 
         public async Task<IActionResult> OnPostAsync()
         {
+            if (!Event.IsTeamRegistrationActive)
+            {
+                return NotFound();
+            }
+
             if (!ModelState.IsValid)
             {
                 return Page();

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -16,7 +16,12 @@ namespace ServerCore.Pages.Teams
         }
 
         public IActionResult OnGet()
-        {
+        {        
+            if (!Event.IsTeamRegistrationActive)
+            {
+                return NotFound();
+            }
+
             return Page();
         }
 

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -8,7 +8,16 @@
 <h2>Index</h2>
 
 <p>
-    <a asp-page="Create">Create New</a>
+    @if (Model.Event.IsTeamRegistrationActive) // Or current user is admin
+    {
+        <a asp-page="Create">Create New</a>
+    }
+    else
+    {
+        <div class="alert alert-danger" role="alert">
+            This event is not currently open for registration.
+        </div>
+    }
 </p>
 <table class="table">
     <thead>


### PR DESCRIPTION
Whoops forgot to make a PR for this. Should be a simple change -- is there anything else I need to lock down if team registration isn't active?