### PR TITLE
Make first user admin in development envrionments

### DIFF
--- a/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -121,7 +123,7 @@ namespace ServerCore.Areas.Identity.Pages.Account
                         if (ModelState.IsValid)
                         {
                             // If there are no GlobalAdmins make them the GlobalAdmin
-                            if (!_context.PuzzleUsers.Where(u => u.IsGlobalAdmin).Any())
+                            if ((Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == EnvironmentName.Development) && !_context.PuzzleUsers.Where(u => u.IsGlobalAdmin).Any())
                             {
                                 Input.IsGlobalAdmin = true;
                             }

--- a/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -120,12 +120,19 @@ namespace ServerCore.Areas.Identity.Pages.Account
 
                         if (ModelState.IsValid)
                         {
+                            // If this is the first user make them the GlobalAdmin
+                            if (_context.PuzzleUsers.Local.Count == 0)
+                            {
+                                Input.IsGlobalAdmin = true;
+                            }
+
                             _context.PuzzleUsers.Add(Input);
                             await _context.SaveChangesAsync(true);
                             transaction.Commit();
 
                             await _signInManager.SignInAsync(user, isPersistent: false);
                             _logger.LogInformation("User created an account using {Name} provider.", info.LoginProvider);
+
                             return LocalRedirect(returnUrl);
                         }
                     }

--- a/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Linq;
+﻿using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -122,7 +121,7 @@ namespace ServerCore.Areas.Identity.Pages.Account
                         if (ModelState.IsValid)
                         {
                             // If there are no GlobalAdmins make them the GlobalAdmin
-                            if (!_context.PuzzleUsers.Where(u=> u.IsGlobalAdmin).Any())
+                            if (!_context.PuzzleUsers.Where(u => u.IsGlobalAdmin).Any())
                             {
                                 Input.IsGlobalAdmin = true;
                             }

--- a/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -120,8 +121,8 @@ namespace ServerCore.Areas.Identity.Pages.Account
 
                         if (ModelState.IsValid)
                         {
-                            // If this is the first user make them the GlobalAdmin
-                            if (_context.PuzzleUsers.Local.Count == 0)
+                            // If there are no GlobalAdmins make them the GlobalAdmin
+                            if (!_context.PuzzleUsers.Where(u=> u.IsGlobalAdmin).Any())
                             {
                                 Input.IsGlobalAdmin = true;
                             }


### PR DESCRIPTION
If there are no GlobalAdmins in a development environment the next user to register becomes a GlobalAdmin - this is to prevent us from getting locked out.