### PR TITLE
Authors Per Puzzle

### DIFF
--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -21,4 +21,10 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Migrations\20181213040335_PuzzleAuthors_IDs.Designer.cs">
+      <DependentUpon>20181213040335_PuzzleAuthors_IDs.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/Data/DataModel/PuzzleAuthors.cs
+++ b/Data/DataModel/PuzzleAuthors.cs
@@ -8,10 +8,12 @@ namespace ServerCore.DataModel
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
 
-        [ForeignKey("Puzzle.ID")]
+        public int PuzzleID { get; set; }
+
         public virtual Puzzle Puzzle { get; set; }
 
-        [ForeignKey("User.ID")]
+        public int AuthorID { get; set; }
+
         public virtual PuzzleUser Author { get; set; }
     }
 }

--- a/Data/Migrations/20181213040335_PuzzleAuthors_IDs.Designer.cs
+++ b/Data/Migrations/20181213040335_PuzzleAuthors_IDs.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServerCore.DataModel;
 
 namespace Data.Migrations
 {
     [DbContext(typeof(PuzzleServerContext))]
-    partial class PuzzleServerContextModelSnapshot : ModelSnapshot
+    [Migration("20181213040335_PuzzleAuthors_IDs")]
+    partial class PuzzleAuthors_IDs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20181213040335_PuzzleAuthors_IDs.cs
+++ b/Data/Migrations/20181213040335_PuzzleAuthors_IDs.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Data.Migrations
+{
+    public partial class PuzzleAuthors_IDs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleAuthors_Puzzles_Puzzle.ID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleAuthors_PuzzleUsers_User.ID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PuzzleAuthors_Puzzle.ID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PuzzleAuthors_User.ID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropColumn(
+                name: "Puzzle.ID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropColumn(
+                name: "User.ID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.AddColumn<int>(
+                name: "AuthorID",
+                table: "PuzzleAuthors",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PuzzleID",
+                table: "PuzzleAuthors",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PuzzleAuthors_AuthorID",
+                table: "PuzzleAuthors",
+                column: "AuthorID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PuzzleAuthors_PuzzleID",
+                table: "PuzzleAuthors",
+                column: "PuzzleID");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleAuthors_PuzzleUsers_AuthorID",
+                table: "PuzzleAuthors",
+                column: "AuthorID",
+                principalTable: "PuzzleUsers",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleAuthors_Puzzles_PuzzleID",
+                table: "PuzzleAuthors",
+                column: "PuzzleID",
+                principalTable: "Puzzles",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleAuthors_PuzzleUsers_AuthorID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PuzzleAuthors_Puzzles_PuzzleID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PuzzleAuthors_AuthorID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PuzzleAuthors_PuzzleID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropColumn(
+                name: "AuthorID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.DropColumn(
+                name: "PuzzleID",
+                table: "PuzzleAuthors");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Puzzle.ID",
+                table: "PuzzleAuthors",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "User.ID",
+                table: "PuzzleAuthors",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PuzzleAuthors_Puzzle.ID",
+                table: "PuzzleAuthors",
+                column: "Puzzle.ID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PuzzleAuthors_User.ID",
+                table: "PuzzleAuthors",
+                column: "User.ID");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleAuthors_Puzzles_Puzzle.ID",
+                table: "PuzzleAuthors",
+                column: "Puzzle.ID",
+                principalTable: "Puzzles",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PuzzleAuthors_PuzzleUsers_User.ID",
+                table: "PuzzleAuthors",
+                column: "User.ID",
+                principalTable: "PuzzleUsers",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -149,6 +149,39 @@
                 </tbody>
             </table>
         </form>
+		<hr/>
+        <h3>Authors</h3>
+        <form method="post" enctype="multipart/form-data">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Author</th>
+                        <th>Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var author in Model.CurrentAuthors)
+                {
+                    <tr>
+                        <td>
+                            @(author.Name)
+                        </td>
+                        <td>
+                            <a asp-page-handler="RemoveAuthor" asp-route-id="@Model.Puzzle.ID" asp-route-author="@(author.ID)">Remove</a>
+                        </td>
+                    </tr>
+                }
+                    <tr>
+                        <td>
+                            <select class="form-control" asp-for="NewAuthorID" asp-items="@(new SelectList(Model.PotentialAuthors, "ID", "Name"))"></select>
+                        </td>
+                        <td>
+                            <input type="submit" value="Add" asp-page-handler="AddAuthor" class="btn btn-default" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </form>
     </div>
 </div>
 

--- a/ServerCore/Pages/Puzzles/Edit.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml.cs
@@ -24,10 +24,17 @@ namespace ServerCore.Pages.Puzzles
         public Puzzle Puzzle { get; set; }
 
         [BindProperty]
+        public int NewAuthorID { get; set; }
+
+        [BindProperty]
         public int NewPrerequisiteID { get; set; }
 
         [BindProperty]
         public int NewPrerequisiteOfID { get; set; }
+
+        public List<PuzzleUser> PotentialAuthors { get; set; }
+
+        public List<PuzzleUser> CurrentAuthors { get; set; }
 
         public List<Puzzle> PotentialPrerequisites { get; set; }
 
@@ -45,6 +52,12 @@ namespace ServerCore.Pages.Puzzles
             {
                 return NotFound();
             }
+
+            IQueryable<PuzzleUser> currentAuthorsQ = _context.PuzzleAuthors.Where(m => m.Puzzle == Puzzle).Select(m => m.Author);
+            IQueryable<PuzzleUser> potentialAuthorsQ = _context.EventAuthors.Where(m => m.Event == Event).Select(m => m.Author).Except(currentAuthorsQ);
+
+            CurrentAuthors = await currentAuthorsQ.OrderBy(p => p.Name).ToListAsync();
+            PotentialAuthors = await potentialAuthorsQ.OrderBy(p => p.Name).ToListAsync();
 
             IQueryable<Puzzle> currentPrerequisitesQ = _context.Prerequisites.Where(m => m.Puzzle == Puzzle).Select(m => m.Prerequisite);
             IQueryable<Puzzle> potentialPrerequitesQ = _context.Puzzles.Where(m => m.Event == Event && m != Puzzle).Except(currentPrerequisitesQ);
@@ -89,6 +102,22 @@ namespace ServerCore.Pages.Puzzles
             return RedirectToPage("./Index");
         }
 
+        public async Task<IActionResult> OnPostAddAuthorAsync()
+        {
+            if (!(await _context.EventAuthors.Select(m => m.Author.ID == NewAuthorID).AnyAsync()))
+            {
+                return NotFound();
+            }
+
+            if (!(await _context.PuzzleAuthors.Select(m => m.PuzzleID == Puzzle.ID && m.AuthorID == NewAuthorID).AnyAsync()))
+            {
+                _context.PuzzleAuthors.Add(new PuzzleAuthors() { PuzzleID = Puzzle.ID, AuthorID = NewAuthorID });
+                await _context.SaveChangesAsync();
+            }
+
+            return RedirectToPage();
+        }
+
         public async Task<IActionResult> OnPostAddPrerequisiteAsync()
         {
             if (!PuzzleExists(NewPrerequisiteID))
@@ -119,6 +148,20 @@ namespace ServerCore.Pages.Puzzles
             }
 
             return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnGetRemoveAuthorAsync(int id, int author)
+        {
+            PuzzleAuthors toRemove = await _context.PuzzleAuthors.Where(m => m.PuzzleID == id && m.AuthorID == author).FirstOrDefaultAsync();
+
+            if (toRemove != null)
+            {
+                _context.PuzzleAuthors.Remove(toRemove);
+                await _context.SaveChangesAsync();
+            }
+
+            // redirect without the prerequisite info to keep the URL clean
+            return RedirectToPage(new { id });
         }
 
         public async Task<IActionResult> OnGetRemovePrerequisiteAsync(int id, int prerequisite)

--- a/ServerCore/Pages/Puzzles/Edit.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml.cs
@@ -104,7 +104,7 @@ namespace ServerCore.Pages.Puzzles
 
         public async Task<IActionResult> OnPostAddAuthorAsync()
         {
-            if (!(await _context.EventAuthors.Select(m => m.Author.ID == NewAuthorID).AnyAsync()))
+            if (!(await _context.EventAuthors.Select(m => m.Author.ID == NewAuthorID && m.Event == Event).AnyAsync()))
             {
                 return NotFound();
             }


### PR DESCRIPTION
Allow the list of authors per puzzle to be edited, as a prelude to actual filtering.

Note that EventAuthors still needs to be edited directly in SQL, but that is more rarely needed and still needs some design thinking.