### PR TITLE
Feedback -- role awareness

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Puzzleday/bin/Debug/netcoreapp2.1/Puzzleday.dll",
+            "program": "${workspaceFolder}/ServerCore/bin/Debug/netcoreapp2.1/ServerCore.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/Puzzleday",
+            "cwd": "${workspaceFolder}/ServerCore",
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart",
             "launchBrowser": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/Puzzleday/Puzzleday.csproj"
+                "${workspaceFolder}/ServerCore/ServerCore.csproj"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/ServerCore/DataModel/Feedback.cs
+++ b/ServerCore/DataModel/Feedback.cs
@@ -11,7 +11,7 @@ namespace ServerCore.DataModel
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
         public Puzzle Puzzle { get; set; }
-        public User Submitter {get; set;}
+        public PuzzleUser Submitter {get; set;}
         public DateTime SubmissionTime { get; set; }
         public string WrittenFeedback { get; set; }
         public int Difficulty { get; set; }

--- a/ServerCore/Pages/Puzzles/Feedback.cshtml
+++ b/ServerCore/Pages/Puzzles/Feedback.cshtml
@@ -4,52 +4,79 @@
 @{
     ViewData["Title"] = "Feedback";
     var id = ViewContext.RouteData.Values["id"];
+    var role = ViewContext.RouteData.Values["eventRole"].ToString();
 }
 
-<h2>Feedback for @Html.DisplayFor(model => model.Puzzle.Name)</h2>
+@if (role == "admin" || (role == "author" && Model.IsCurrentUserPuzzleAuthor))
+{
+    <h2>Feedback for @Html.DisplayFor(model => model.Puzzle.Name)</h2>
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Submitter)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].SubmissionTime)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].WrittenFeedback)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Difficulty)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Fun)
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-@foreach (var item in Model.Feedbacks) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Submitter.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.SubmissionTime)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.WrittenFeedback)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Difficulty)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Fun)
-            </td>
-        </tr>
+    var sumFun = 0.0;
+    var sumDiff = 0.0;
+    var count = 0;
+    foreach (var item in Model.Feedbacks) {
+        sumFun += item.Fun;
+        sumDiff += item.Difficulty;
+        count++;
+    }
+    sumFun /= count;
+    sumDiff /= count;
+
+    <div>
+        <h3><b>Avg Fun Rating:</b> @sumFun</h3>
+        <br>
+        <h3><b>Avg Difficulty Rating:</b> @sumDiff</h3>
+    </div>
+
+    <br>
+
+    <table class="table">
+        <thead>
+            <tr>
+                <th>
+                    @Html.DisplayNameFor(model => model.Feedbacks[0].Submitter)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Feedbacks[0].SubmissionTime)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Feedbacks[0].WrittenFeedback)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Feedbacks[0].Difficulty)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Feedbacks[0].Fun)
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var item in Model.Feedbacks) {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Submitter.Name)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.SubmissionTime)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.WrittenFeedback)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Difficulty)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Fun)
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
 }
-    </tbody>
-</table>
+else
+{
+    <h2>Can only view feedback as event admin or puzzle author.</h2>
+}
 
 <div>
     <a asp-page="./Index">Back to Puzzles</a>

--- a/ServerCore/Pages/Puzzles/Feedback.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Feedback.cshtml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
@@ -16,26 +17,29 @@ namespace ServerCore.Pages.Puzzles
     {
         private readonly PuzzleServerContext _context;
 
-        public FeedbackModel(PuzzleServerContext context)
+        public FeedbackModel(PuzzleServerContext context, UserManager<IdentityUser> userManager) : base(context, userManager)
         {
             _context = context;
         }
 
         public IList<Feedback> Feedbacks { get; set; }
         public Puzzle Puzzle { get; set; }
+        public bool IsCurrentUserPuzzleAuthor { get; set; }
 
         /// <summary>
         /// Gets the feedback and puzzle associated with the given ID
         /// </summary>
         public async Task<IActionResult> OnGetAsync(int id)
         {
-            Feedbacks = await _context.Feedback.Where((f) => f.Puzzle.ID == id).ToListAsync();
+            Feedbacks = await _context.Feedback.Where((f) => f.Puzzle.ID == id).Include("Submitter").ToListAsync();
             Puzzle = await _context.Puzzles.Where((p) => p.ID == id).FirstOrDefaultAsync();
 
             if (Puzzle == null) 
             { 
                 return NotFound(); 
             } 
+
+            IsCurrentUserPuzzleAuthor = (await _context.PuzzleAuthors.Where((a) => a.Puzzle == Puzzle && a.Author == LoggedInUser).FirstOrDefaultAsync() != null);
 
             return Page();
         }

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -3,6 +3,8 @@
 
 @{
     ViewData["Title"] = "Puzzle Index";
+    var role = ViewContext.RouteData.Values["eventRole"].ToString();
+
 }
 
 <h2>All Puzzles</h2>
@@ -91,8 +93,10 @@
                 <a asp-Page="./Details" asp-route-id="@item.ID">Details</a> |
                 <a asp-Page="./Delete" asp-route-id="@item.ID">Delete</a> |
                 <a asp-page="./Status" asp-route-id="@item.ID">Status</a> |
-                <a asp-Page="./Feedback" asp-route-id="@item.ID">Admin View Feedback</a> |
-                <a asp-Page="./SubmitFeedback" asp-route-id="@item.ID">User Submit Feedback</a> |
+                @{
+                    var feedbackLink = (role == "play") ? "./SubmitFeedback" : "./Feedback";
+                }
+                <a asp-Page=@feedbackLink asp-route-id="@item.ID">Feedback</a> |
                 <a asp-page="/Responses/Index" asp-route-puzzleid="@item.ID">Responses</a> |
                 <a asp-page="/Submissions/AuthorIndex" asp-route-puzzleid="@item.ID">Player Submissions</a> |
                 <a asp-Page="./FileManagement" asp-route-id="@item.ID">File Management</a> |

--- a/ServerCore/Pages/Puzzles/SubmitFeedback.cshtml
+++ b/ServerCore/Pages/Puzzles/SubmitFeedback.cshtml
@@ -4,55 +4,63 @@
 @{
     ViewData["Title"] = "Submit Feedback";
     var id = ViewContext.RouteData.Values["id"];
+    var role = ViewContext.RouteData.Values["eventRole"].ToString();
 }
 
-<h2>Submit Feedback for @Html.DisplayFor(model => model.Puzzle.Name)</h2> 
+@if (role == "play")
+{
+    <h2>Submit Feedback for @Html.DisplayFor(model => model.Puzzle.Name)</h2> 
 
-<div class="row">
-    <div class="col-md-4">
-        <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Feedback.WrittenFeedback" class="control-label"></label>
-                <input asp-for="Feedback.WrittenFeedback" class="form-control" />
-                <span asp-validation-for="Feedback.WrittenFeedback" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Feedback.Difficulty" class="control-label"></label>
-                <input asp-for="Feedback.Difficulty" type="range" min="0" max="10" value="5" step="1" class="slider" id="difficultySlider">
-                <label id="difficultyLabel">NULL</label>
-                <script>
-                    var diffslider = document.getElementById("difficultySlider");
-                    var diffoutput = document.getElementById("difficultyLabel");
-                    diffoutput.innerHTML = diffslider.value; // Display the default slider value
+    <div class="row">
+        <div class="col-md-4">
+            <form method="post">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group">
+                    <label asp-for="Feedback.WrittenFeedback" class="control-label"></label>
+                    <input asp-for="Feedback.WrittenFeedback" class="form-control" />
+                    <span asp-validation-for="Feedback.WrittenFeedback" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Feedback.Difficulty" class="control-label"></label>
+                    <input asp-for="Feedback.Difficulty" type="range" min="0" max="10" value="5" step="1" class="slider" id="difficultySlider">
+                    <label id="difficultyLabel">NULL</label>
+                    <script>
+                        var diffslider = document.getElementById("difficultySlider");
+                        var diffoutput = document.getElementById("difficultyLabel");
+                        diffoutput.innerHTML = diffslider.value; // Display the default slider value
 
-                    // Update the current slider value (each time you drag the slider handle)
-                    diffslider.oninput = function() {
-                        diffoutput.innerHTML = this.value;
-                    }
-                </script>
-            </div>
-            <div class="form-group">
-                <label asp-for="Feedback.Fun" class="control-label"></label>
-                <input asp-for="Feedback.Fun" type="range" min="0" max="10" value="5" step="1" class="slider" id="funSlider">
-                <label id="funLabel">NULL</label>
-                <script>
-                    var funslider = document.getElementById("funSlider");
-                    var funoutput = document.getElementById("funLabel");
-                    funoutput.innerHTML = funslider.value; // Display the default slider value
+                        // Update the current slider value (each time you drag the slider handle)
+                        diffslider.oninput = function() {
+                            diffoutput.innerHTML = this.value;
+                        }
+                    </script>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Feedback.Fun" class="control-label"></label>
+                    <input asp-for="Feedback.Fun" type="range" min="0" max="10" value="5" step="1" class="slider" id="funSlider">
+                    <label id="funLabel">NULL</label>
+                    <script>
+                        var funslider = document.getElementById("funSlider");
+                        var funoutput = document.getElementById("funLabel");
+                        funoutput.innerHTML = funslider.value; // Display the default slider value
 
-                    // Update the current slider value (each time you drag the slider handle)
-                    funslider.oninput = function() {
-                        funoutput.innerHTML = this.value;
-                    }
-                </script>
-            </div>
-            <div class="form-group">
-                <input type="submit" value="Create" class="btn btn-default" />
-            </div>
-        </form>
+                        // Update the current slider value (each time you drag the slider handle)
+                        funslider.oninput = function() {
+                            funoutput.innerHTML = this.value;
+                        }
+                    </script>
+                </div>
+                <div class="form-group">
+                    <input type="submit" value="Create" class="btn btn-default" />
+                </div>
+            </form>
+        </div>
     </div>
-</div>
+}
+else
+{
+    <h2>Can only submit feedback as a player.</h2>
+}
 
 <div>
     <a asp-page="./Index">Back to Puzzles</a>


### PR DESCRIPTION
A few changes here:
1) Updated the VScode project files so that the debugger actually builds and runs the correct project
2) Trying to view feedback for a puzzle routes you to the appropriate page (Submit or View) based on your role. /play/ routes to submit feedback while /author/ and /admin/ route to view feedback. Authors can only view feedback for puzzles they created.
3) Updated the feedback to track the user that submitted it and aggregate all of the fun/difficulty ratings at the top of the view page.
4) When a player that has already submitted feedback on a puzzle tries to submit more feedback, it overwrites the ratings and appends the written feedback. Probably could do with a warning or something here, but for now its good enough.
