### PR TITLE
EventId can be a friendly name instead of an int

### DIFF
--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <Compile Remove="Migrations\20181006003400_CreateIdentitySchema.cs" />
     <Compile Remove="Migrations\20181006003838_CreateIdentitySchema.cs" />
+    <Compile Remove="Migrations\20190111053724_EventId.cs" />
+    <Compile Remove="Migrations\20190111053724_EventId.Designer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Data/DataModel/Event.cs
+++ b/Data/DataModel/Event.cs
@@ -12,18 +12,13 @@ namespace ServerCore.DataModel
         [Required]
         public string Name { get; set; }
 
-        [DataType(DataType.Url)]
         public string UrlString { get; set; }
+
+        [NotMapped]
+        public string EventID => UrlString ?? ID.ToString();
 
         [DataType(DataType.EmailAddress)]
         public string ContactEmail { get; set; }
-
-        [NotMapped]
-        public Uri URL
-        {
-            get { Uri.TryCreate(UrlString, UriKind.RelativeOrAbsolute, out Uri result); return result; }
-            set { UrlString = value?.ToString(); }
-        }
 
         public int MaxNumberOfTeams { get; set; }
         public int MaxTeamSize { get; set; }

--- a/Data/Migrations/20190111054206_EventId.Designer.cs
+++ b/Data/Migrations/20190111054206_EventId.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServerCore.DataModel;
 
 namespace Data.Migrations
 {
     [DbContext(typeof(PuzzleServerContext))]
-    partial class PuzzleServerContextModelSnapshot : ModelSnapshot
+    [Migration("20190111054206_EventId")]
+    partial class EventId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20190111054206_EventId.cs
+++ b/Data/Migrations/20190111054206_EventId.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Data.Migrations
+{
+    public partial class EventId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UrlString",
+                table: "Events",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Events_UrlString",
+                table: "Events",
+                column: "UrlString",
+                unique: true,
+                filter: "[UrlString] IS NOT NULL");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Events_UrlString",
+                table: "Events");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UrlString",
+                table: "Events",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+        }
+    }
+}

--- a/Data/PuzzleServerContext.cs
+++ b/Data/PuzzleServerContext.cs
@@ -56,6 +56,7 @@ namespace ServerCore.DataModel
             modelBuilder.Entity<ContentFile>().HasIndex(contentFile => new { contentFile.EventID, contentFile.ShortName }).IsUnique();
             modelBuilder.Entity<PuzzleStatePerTeam>().HasKey(state => new { state.PuzzleID, state.TeamID });
             modelBuilder.Entity<HintStatePerTeam>().HasKey(state => new { state.TeamID, state.HintID });
+            modelBuilder.Entity<Event>().HasIndex(eventObj => new { eventObj.UrlString }).IsUnique();
 
             base.OnModelCreating(modelBuilder);
         }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -14,18 +14,22 @@ namespace ServerCore.Areas.Identity
     {
         public static async Task<Event> GetEventFromContext(AuthorizationHandlerContext context)
         {
+            Event result = null;
+
             if (context.Resource is AuthorizationFilterContext filterContext)
             {
-                string eventIdAsString = filterContext.RouteData.Values["eventId"] as string;
+                PuzzleServerContext puzzleServerContext = (PuzzleServerContext)filterContext.HttpContext.RequestServices.GetService(typeof(PuzzleServerContext));
+                string eventId = filterContext.RouteData.Values["eventId"] as string;
 
-                if (Int32.TryParse(eventIdAsString, out int eventId))
+                result = await puzzleServerContext.Events.Where(e => e.UrlString == eventId).FirstOrDefaultAsync();
+
+                if (result == null && Int32.TryParse(eventId, out int eventIdAsInt))
                 {
-                    PuzzleServerContext puzzleServerContext = (PuzzleServerContext)filterContext.HttpContext.RequestServices.GetService(typeof(PuzzleServerContext));
-                    return await puzzleServerContext.Events.Where(e => e.ID == eventId).FirstOrDefaultAsync();
+                    result = await puzzleServerContext.Events.Where(e => e.ID == eventIdAsInt).FirstOrDefaultAsync();
                 }
             }
 
-            return null;
+            return result;
         }
 
         public static async Task<Puzzle> GetPuzzleFromContext(AuthorizationHandlerContext context)

--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -30,7 +30,7 @@
 @foreach (var item in Model.Events) {
         <tr>
             <td>
-                <a asp-page="/EventSpecific/Index" asp-route-eventId="@item.ID">
+                <a asp-page="/EventSpecific/Index" asp-route-eventId="@item.EventID">
                     @Html.DisplayFor(modelItem => item.Name)
                 </a>
             </td>
@@ -45,12 +45,12 @@
                 <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |
                 <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a> |
                 <a asp-page="./Import" asp-route-id="@item.ID" asp-route-eventRole="admin">Import</a> |
-                <a asp-page="/Puzzles/Index" asp-route-eventId="@item.ID" asp-route-eventRole="admin">Puzzles</a> |
-                <a asp-page="/Teams/Index" asp-route-eventId="@item.ID" asp-route-eventRole="admin">Teams</a> |
-                <a asp-page="./Players" asp-route-eventId="@item.ID" asp-route-eventRole="admin">Players</a> |
-                <a asp-page="/Events/Standings" asp-route-eventId="@item.ID" asp-route-eventRole="admin">Standings</a> |
-                <a asp-page="/Events/FastestSolves" asp-route-eventId="@item.ID" asp-route-eventRole="admin">Fastest</a> |
-                <a asp-page="/Events/Map" asp-route-eventId="@item.ID" asp-route-eventRole="admin">Map</a>
+                <a asp-page="/Puzzles/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Puzzles</a> |
+                <a asp-page="/Teams/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Teams</a> |
+                <a asp-page="./Players" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Players</a> |
+                <a asp-page="/Events/Standings" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Standings</a> |
+                <a asp-page="/Events/FastestSolves" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Fastest</a> |
+                <a asp-page="/Events/Map" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Map</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Shared/_Layout.cshtml
+++ b/ServerCore/Pages/Shared/_Layout.cshtml
@@ -49,7 +49,7 @@
                     }
                     else
                     {
-                        <a asp-page="/EventSpecific/Index" asp-route-eventId=@Event.ID class="navbar-brand">
+                        <a asp-page="/EventSpecific/Index" asp-route-eventId=@Event.EventID class="navbar-brand">
                             @(Event.Name)
                         </a>
                     }
@@ -74,7 +74,7 @@
                                             <li><a href="#">Solved Puzzles</a></li>
                                         }
                                         <li>
-                                            <a asp-page="/Puzzles/Index" asp-route-eventId="@Event.ID">
+                                            <a asp-page="/Puzzles/Index" asp-route-eventId="@Event.EventID">
                                                 All Puzzles
                                             </a>
                                         </li>
@@ -111,7 +111,7 @@
                                 <ul class="dropdown-menu">
                                     <li><a href="#">MY TEAM NAME <i>(if member)</i></a></li>
                                     <li><a href="#">Matchmaking Zone <i>(if available)</i></a></li>
-                                    <li><a asp-page="/Teams/Index" asp-route-eventId="@Event.ID">Teams</a></li>
+                                    <li><a asp-page="/Teams/Index" asp-route-eventId="@Event.EventID">Teams</a></li>
                                     <li><a href="#">Players <i>(everybody if author/admin)</i></a></li>
                                     <li class="divider"></li>
                                     <li><a href="#">Authors <i>(if author; editable if admin)</i></a></li>
@@ -182,10 +182,10 @@
                     <div class="navbar-collapse collapse">
                         <ul class="nav navbar-nav">
                             <li><a asp-page="/Events/Details" asp-route-id="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.admin">Event</a></li>
-                            <li><a asp-page="/Puzzles/Index" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.admin">Puzzles</a></li>
-                            <li><a asp-page="/Teams/Index" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.admin">Teams</a></li>
-                            <li><a asp-page="/Events/Standings" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.admin">Standings</a></li>
-                            <li><a asp-page="/Events/Players" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.admin">Users</a></li>
+                            <li><a asp-page="/Puzzles/Index" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.admin">Puzzles</a></li>
+                            <li><a asp-page="/Teams/Index" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.admin">Teams</a></li>
+                            <li><a asp-page="/Events/Standings" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.admin">Standings</a></li>
+                            <li><a asp-page="/Events/Players" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.admin">Users</a></li>
                             <li class="dropdown">
                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                     Resources (not implemented)
@@ -226,9 +226,9 @@
                     <div class="navbar-collapse collapse">
                         <ul class="nav navbar-nav">
                             <li><a asp-page="/Events/Details" asp-route-id="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.author">Event</a></li>
-                            <li><a asp-page="/Puzzles/Index" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.author">Puzzles</a></li>
-                            <li><a asp-page="/Teams/Index" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.author">Teams</a></li>
-                            <li><a asp-page="/Events/Standings" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.author">Standings</a></li>
+                            <li><a asp-page="/Puzzles/Index" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.author">Puzzles</a></li>
+                            <li><a asp-page="/Teams/Index" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.author">Teams</a></li>
+                            <li><a asp-page="/Events/Standings" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.author">Standings</a></li>
                             <li class="dropdown">
                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                     Resources (not implemented)
@@ -269,9 +269,9 @@
                     <div class="navbar-collapse collapse">
                         <ul class="nav navbar-nav">
                             <li><a asp-page="/Events/Details" asp-route-id="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.play">Event</a></li>
-                            <li><a asp-page="/Puzzles/Index" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.play">Puzzles</a></li>
-                            <li><a asp-page="/Teams/Details" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.play">Team</a></li>
-                            <li><a asp-page="/Events/Standings" asp-route-eventId="@Event.ID" asp-route-eventRole="@ModelBases.EventRole.play">Standings</a></li>
+                            <li><a asp-page="/Puzzles/Index" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.play">Puzzles</a></li>
+                            <li><a asp-page="/Teams/Details" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.play">Team</a></li>
+                            <li><a asp-page="/Events/Standings" asp-route-eventId="@Event.EventID" asp-route-eventRole="@ModelBases.EventRole.play">Standings</a></li>
                             <li class="dropdown">
                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                     Resources (not implemented)


### PR DESCRIPTION
Now, if you supply a friendly name in the UrlString property, it will become the eventId. If you do not specify one, the ID will be used.

This isn't currently doing any kind of validation that the names are unique or anything. I also did not mark the new property as required because the migration was difficult. We can go back and make it required if we choose to.