### PR TITLE
Event Admin fixups

### DIFF
--- a/ServerCore/Pages/Events/Create.cshtml.cs
+++ b/ServerCore/Pages/Events/Create.cshtml.cs
@@ -8,8 +8,7 @@ using ServerCore.DataModel;
 
 namespace ServerCore.Pages.Events
 {
-    // TODO: Turn this on when it's easy to make yourself a global admin
-    //[Authorize(Policy = "IsGlobalAdmin")]
+    [Authorize(Policy = "IsGlobalAdmin")]
     public class CreateModel : PageModel
     {
         private readonly PuzzleServerContext _context;

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -9,8 +9,7 @@ using ServerCore.DataModel;
 
 namespace ServerCore.Pages.Events
 {
-    // TODO: Turn this on when it's easy to make yourself a global admin
-    //[Authorize(Policy = "IsGlobalAdmin")]
+    [Authorize(Policy = "IsGlobalAdmin")]
     public class CreateDemoModel : PageModel
     {
         private readonly PuzzleServerContext _context;
@@ -62,12 +61,14 @@ namespace ServerCore.Pages.Events
             //
             // Add the event and save, so the event gets an ID.
             //
+            Event.TeamRegistrationBegin = DateTime.UtcNow;
             Event.TeamRegistrationEnd = Event.AnswerSubmissionEnd;
             Event.TeamNameChangeEnd = Event.AnswerSubmissionEnd;
             Event.TeamMembershipChangeEnd = Event.AnswerSubmissionEnd;
             Event.TeamMiscDataChangeEnd = Event.AnswerSubmissionEnd;
             Event.TeamDeleteEnd = Event.AnswerSubmissionEnd;
             Event.AnswersAvailableBegin = Event.AnswerSubmissionEnd;
+            Event.StandingsAvailableBegin = DateTime.UtcNow;
             _context.Events.Add(Event);
 
             await _context.SaveChangesAsync();

--- a/ServerCore/Pages/Events/Delete.cshtml
+++ b/ServerCore/Pages/Events/Delete.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/{eventId}/{eventRole}/Events/Delete"
 @model ServerCore.Pages.Events.DeleteModel
 
 @{
@@ -127,7 +127,7 @@
             @Html.DisplayFor(model => model.Event.AllowFeedback)
         </dd>
     </dl>
-    
+
     <form method="post">
         <input type="hidden" asp-for="Event.ID" />
         <input type="submit" value="Delete" class="btn btn-default" /> |

--- a/ServerCore/Pages/Events/Delete.cshtml.cs
+++ b/ServerCore/Pages/Events/Delete.cshtml.cs
@@ -1,40 +1,26 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Events
 {
-    [Authorize(Policy = "IsGlobalAdmin")]
-    public class DeleteModel : PageModel
+    [Authorize(Policy = "IsEventAdmin")]
+    public class DeleteModel : EventSpecificPageModel
     {
-        private readonly PuzzleServerContext _context;
-
-        public DeleteModel(PuzzleServerContext context)
+        public DeleteModel(PuzzleServerContext context, UserManager<IdentityUser> userManager) : base(context, userManager)
         {
-            _context = context;
         }
 
-        [BindProperty]
-        public Event Event { get; set; }
-
-        public async Task<IActionResult> OnGetAsync(int id)
+        public IActionResult OnGet()
         {
-            Event = await _context.Events.SingleOrDefaultAsync(m => m.ID == id);
-
-            if (Event == null)
-            {
-                return NotFound();
-            }
             return Page();
         }
 
-        public async Task<IActionResult> OnPostAsync(int id)
+        public async Task<IActionResult> OnPostAsync()
         {
-            Event = await _context.Events.FindAsync(id);
-
             if (Event != null)
             {
                 _context.Events.Remove(Event);

--- a/ServerCore/Pages/Events/Details.cshtml
+++ b/ServerCore/Pages/Events/Details.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/{eventId}/{eventRole}/Events/Details"
 @model ServerCore.Pages.Events.DetailsModel
 
 @{

--- a/ServerCore/Pages/Events/Details.cshtml.cs
+++ b/ServerCore/Pages/Events/Details.cshtml.cs
@@ -1,32 +1,20 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Events
 {
-    [Authorize(Policy = "IsGlobalAdmin")]
-    public class DetailsModel : PageModel
+    [Authorize(Policy = "IsEventAdmin")]
+    public class DetailsModel : EventSpecificPageModel
     {
-        private readonly PuzzleServerContext _context;
-
-        public DetailsModel(PuzzleServerContext context)
+        public DetailsModel(PuzzleServerContext context, UserManager<IdentityUser> userManager) : base(context, userManager)
         {
-            _context = context;
         }
 
-        public Event Event { get; set; }
-
-        public async Task<IActionResult> OnGetAsync(int id)
+        public IActionResult OnGet()
         {
-            Event = await _context.Events.SingleOrDefaultAsync(m => m.ID == id);
-
-            if (Event == null)
-            {
-                return NotFound();
-            }
             return Page();
         }
     }

--- a/ServerCore/Pages/Events/Edit.cshtml
+++ b/ServerCore/Pages/Events/Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/{eventId}/{eventRole}/Events/Edit"
 @model ServerCore.Pages.Events.EditModel
 
 @{
@@ -13,107 +13,107 @@
     <div class="col-md-4">
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <input type="hidden" asp-for="Event.ID" />
+            <input type="hidden" asp-for="EditableEvent.ID" />
             <div class="form-group">
-                <label asp-for="Event.Name" class="control-label"></label>
-                <input asp-for="Event.Name" class="form-control" />
-                <span asp-validation-for="Event.Name" class="text-danger"></span>
+                <label asp-for="EditableEvent.Name" class="control-label"></label>
+                <input asp-for="EditableEvent.Name" class="form-control" />
+                <span asp-validation-for="EditableEvent.Name" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.UrlString" class="control-label"></label>
-                <input asp-for="Event.UrlString" class="form-control" />
-                <span asp-validation-for="Event.UrlString" class="text-danger"></span>
+                <label asp-for="EditableEvent.UrlString" class="control-label"></label>
+                <input asp-for="EditableEvent.UrlString" class="form-control" />
+                <span asp-validation-for="EditableEvent.UrlString" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.MaxNumberOfTeams" class="control-label"></label>
-                <input asp-for="Event.MaxNumberOfTeams" class="form-control" />
-                <span asp-validation-for="Event.MaxNumberOfTeams" class="text-danger"></span>
+                <label asp-for="EditableEvent.MaxNumberOfTeams" class="control-label"></label>
+                <input asp-for="EditableEvent.MaxNumberOfTeams" class="form-control" />
+                <span asp-validation-for="EditableEvent.MaxNumberOfTeams" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.MaxTeamSize" class="control-label"></label>
-                <input asp-for="Event.MaxTeamSize" class="form-control" />
-                <span asp-validation-for="Event.MaxTeamSize" class="text-danger"></span>
+                <label asp-for="EditableEvent.MaxTeamSize" class="control-label"></label>
+                <input asp-for="EditableEvent.MaxTeamSize" class="form-control" />
+                <span asp-validation-for="EditableEvent.MaxTeamSize" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.MaxExternalsPerTeam" class="control-label"></label>
-                <input asp-for="Event.MaxExternalsPerTeam" class="form-control" />
-                <span asp-validation-for="Event.MaxExternalsPerTeam" class="text-danger"></span>
+                <label asp-for="EditableEvent.MaxExternalsPerTeam" class="control-label"></label>
+                <input asp-for="EditableEvent.MaxExternalsPerTeam" class="form-control" />
+                <span asp-validation-for="EditableEvent.MaxExternalsPerTeam" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.IsInternEvent" /> @Html.DisplayNameFor(model => model.Event.IsInternEvent)
+                        <input asp-for="EditableEvent.IsInternEvent" /> @Html.DisplayNameFor(model => model.EditableEvent.IsInternEvent)
                     </label>
                 </div>
             </div>
             <div class="form-group">
-                <label asp-for="Event.TeamRegistrationBegin" class="control-label"></label>
-                <input asp-for="Event.TeamRegistrationBegin" class="form-control" />
-                <span asp-validation-for="Event.TeamRegistrationBegin" class="text-danger"></span>
+                <label asp-for="EditableEvent.TeamRegistrationBegin" class="control-label"></label>
+                <input asp-for="EditableEvent.TeamRegistrationBegin" class="form-control" />
+                <span asp-validation-for="EditableEvent.TeamRegistrationBegin" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.TeamRegistrationEnd" class="control-label"></label>
-                <input asp-for="Event.TeamRegistrationEnd" class="form-control" />
-                <span asp-validation-for="Event.TeamRegistrationEnd" class="text-danger"></span>
+                <label asp-for="EditableEvent.TeamRegistrationEnd" class="control-label"></label>
+                <input asp-for="EditableEvent.TeamRegistrationEnd" class="form-control" />
+                <span asp-validation-for="EditableEvent.TeamRegistrationEnd" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.TeamNameChangeEnd" class="control-label"></label>
-                <input asp-for="Event.TeamNameChangeEnd" class="form-control" />
-                <span asp-validation-for="Event.TeamNameChangeEnd" class="text-danger"></span>
+                <label asp-for="EditableEvent.TeamNameChangeEnd" class="control-label"></label>
+                <input asp-for="EditableEvent.TeamNameChangeEnd" class="form-control" />
+                <span asp-validation-for="EditableEvent.TeamNameChangeEnd" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.TeamMembershipChangeEnd" class="control-label"></label>
-                <input asp-for="Event.TeamMembershipChangeEnd" class="form-control" />
-                <span asp-validation-for="Event.TeamMembershipChangeEnd" class="text-danger"></span>
+                <label asp-for="EditableEvent.TeamMembershipChangeEnd" class="control-label"></label>
+                <input asp-for="EditableEvent.TeamMembershipChangeEnd" class="form-control" />
+                <span asp-validation-for="EditableEvent.TeamMembershipChangeEnd" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.TeamMiscDataChangeEnd" class="control-label"></label>
-                <input asp-for="Event.TeamMiscDataChangeEnd" class="form-control" />
-                <span asp-validation-for="Event.TeamMiscDataChangeEnd" class="text-danger"></span>
+                <label asp-for="EditableEvent.TeamMiscDataChangeEnd" class="control-label"></label>
+                <input asp-for="EditableEvent.TeamMiscDataChangeEnd" class="form-control" />
+                <span asp-validation-for="EditableEvent.TeamMiscDataChangeEnd" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.TeamDeleteEnd" class="control-label"></label>
-                <input asp-for="Event.TeamDeleteEnd" class="form-control" />
-                <span asp-validation-for="Event.TeamDeleteEnd" class="text-danger"></span>
+                <label asp-for="EditableEvent.TeamDeleteEnd" class="control-label"></label>
+                <input asp-for="EditableEvent.TeamDeleteEnd" class="form-control" />
+                <span asp-validation-for="EditableEvent.TeamDeleteEnd" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.EventBegin" class="control-label"></label>
-                <input asp-for="Event.EventBegin" class="form-control" />
-                <span asp-validation-for="Event.EventBegin" class="text-danger"></span>
+                <label asp-for="EditableEvent.EventBegin" class="control-label"></label>
+                <input asp-for="EditableEvent.EventBegin" class="form-control" />
+                <span asp-validation-for="EditableEvent.EventBegin" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.AnswerSubmissionEnd" class="control-label"></label>
-                <input asp-for="Event.AnswerSubmissionEnd" class="form-control" />
-                <span asp-validation-for="Event.AnswerSubmissionEnd" class="text-danger"></span>
+                <label asp-for="EditableEvent.AnswerSubmissionEnd" class="control-label"></label>
+                <input asp-for="EditableEvent.AnswerSubmissionEnd" class="form-control" />
+                <span asp-validation-for="EditableEvent.AnswerSubmissionEnd" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.AnswersAvailableBegin" class="control-label"></label>
-                <input asp-for="Event.AnswersAvailableBegin" class="form-control" />
-                <span asp-validation-for="Event.AnswersAvailableBegin" class="text-danger"></span>
+                <label asp-for="EditableEvent.AnswersAvailableBegin" class="control-label"></label>
+                <input asp-for="EditableEvent.AnswersAvailableBegin" class="form-control" />
+                <span asp-validation-for="EditableEvent.AnswersAvailableBegin" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Event.StandingsAvailableBegin" class="control-label"></label>
-                <input asp-for="Event.StandingsAvailableBegin" class="form-control" />
-                <span asp-validation-for="Event.StandingsAvailableBegin" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <div class="checkbox">
-                    <label>
-                        <input asp-for="Event.StandingsOverride" /> @Html.DisplayNameFor(model => model.Event.StandingsOverride)
-                    </label>
-                </div>
+                <label asp-for="EditableEvent.StandingsAvailableBegin" class="control-label"></label>
+                <input asp-for="EditableEvent.StandingsAvailableBegin" class="form-control" />
+                <span asp-validation-for="EditableEvent.StandingsAvailableBegin" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.ShowFastestSolves" /> @Html.DisplayNameFor(model => model.Event.ShowFastestSolves)
+                        <input asp-for="EditableEvent.StandingsOverride" /> @Html.DisplayNameFor(model => model.EditableEvent.StandingsOverride)
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.AllowFeedback" /> @Html.DisplayNameFor(model => model.Event.AllowFeedback)
+                        <input asp-for="EditableEvent.ShowFastestSolves" /> @Html.DisplayNameFor(model => model.EditableEvent.ShowFastestSolves)
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <input asp-for="EditableEvent.AllowFeedback" /> @Html.DisplayNameFor(model => model.EditableEvent.AllowFeedback)
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Events/Import.cshtml
+++ b/ServerCore/Pages/Events/Import.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "/{eventId}/{eventRole}/Events/Import"
 @model ServerCore.Pages.Events.ImportModel
 
 @{

--- a/ServerCore/Pages/Events/Import.cshtml.cs
+++ b/ServerCore/Pages/Events/Import.cshtml.cs
@@ -2,25 +2,20 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
+using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Events
 {
-    [Authorize(Policy = "IsGlobalAdmin")]
-    public class ImportModel : PageModel
+    [Authorize(Policy = "IsEventAdmin")]
+    public class ImportModel : EventSpecificPageModel
     {
-        private readonly PuzzleServerContext _context;
-
-        public ImportModel(PuzzleServerContext context)
+        public ImportModel(PuzzleServerContext context, UserManager<IdentityUser> userManager) : base(context, userManager)
         {
-            _context = context;
         }
-
-        [BindProperty]
-        public Event Event { get; set; }
 
         public IList<Event> Events { get; set; }
 
@@ -29,13 +24,6 @@ namespace ServerCore.Pages.Events
 
         public async Task<IActionResult> OnGetAsync(int id)
         {
-            Event = await _context.Events.SingleOrDefaultAsync(m => m.ID == id);
-
-            if (Event == null)
-            {
-                return NotFound();
-            }
-
             Events = await _context.Events.Where(e => e != Event).ToListAsync();
 
             return Page();
@@ -44,9 +32,7 @@ namespace ServerCore.Pages.Events
         public async Task<IActionResult> OnPostImportAsync()
         {
             // the BindProperty only binds the event ID, let's get the rest
-            Event = await _context.Events.Where((e) => e.ID == Event.ID).FirstOrDefaultAsync();
-
-            if (Event == null || await _context.Events.Where((e) => e.ID == ImportEventID).FirstOrDefaultAsync() == null)
+            if (await _context.Events.Where((e) => e.ID == ImportEventID).FirstOrDefaultAsync() == null)
             {
                 return NotFound();
             }

--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -43,14 +43,14 @@
             <td>
                 <a asp-page="./Edit" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Edit</a> |
                 <a asp-page="./Details" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Details</a> |
-                <a asp-page="/Events/Delete" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Delete</a> |
+                <a asp-page="./Delete" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Delete</a> |
                 <a asp-page="./Import" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Import</a> |
                 <a asp-page="/Puzzles/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Puzzles</a> |
                 <a asp-page="/Teams/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Teams</a> |
                 <a asp-page="./Players" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Players</a> |
-                <a asp-page="/Events/Standings" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Standings</a> |
-                <a asp-page="/Events/FastestSolves" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Fastest</a> |
-                <a asp-page="/Events/Map" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Map</a>
+                <a asp-page="./Standings" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Standings</a> |
+                <a asp-page="./FastestSolves" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Fastest</a> |
+                <a asp-page="./Map" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Map</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -41,10 +41,10 @@
                 @Html.DisplayFor(modelItem => item.IsInternEvent)
             </td>
             <td>
-                <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |
-                <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |
-                <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a> |
-                <a asp-page="./Import" asp-route-id="@item.ID" asp-route-eventRole="admin">Import</a> |
+                <a asp-page="./Edit" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Edit</a> |
+                <a asp-page="./Details" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Details</a> |
+                <a asp-page="/Events/Delete" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Delete</a> |
+                <a asp-page="./Import" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Import</a> |
                 <a asp-page="/Puzzles/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Puzzles</a> |
                 <a asp-page="/Teams/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Teams</a> |
                 <a asp-page="./Players" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Players</a> |

--- a/ServerCore/Pages/Events/Index.cshtml.cs
+++ b/ServerCore/Pages/Events/Index.cshtml.cs
@@ -7,8 +7,7 @@ using ServerCore.DataModel;
 
 namespace ServerCore.Pages.Events
 {
-    // TODO: Can't turn on this attribute because authorization fails before login is requested
-    //[Authorize(Policy = "IsGlobalAdmin")]
+    [Authorize(Policy = "IsGlobalAdmin")]
     public class IndexModel : PageModel
     {
         private readonly PuzzleServerContext _context;

--- a/ServerCore/Pages/Puzzles/Status.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Status.cshtml.cs
@@ -40,7 +40,7 @@ namespace ServerCore.Pages.Puzzles
             var puzzle = await _context.Puzzles.FirstAsync(m => m.ID == puzzleId);
             var team = teamId == null ? null : await _context.Teams.FirstAsync(m => m.ID == teamId.Value);
 
-            if (Puzzle == null)
+            if (puzzle == null)
             {
                 return NotFound();
             }
@@ -56,7 +56,7 @@ namespace ServerCore.Pages.Puzzles
             var puzzle = await _context.Puzzles.FirstAsync(m => m.ID == puzzleId);
             var team = teamId == null ? null : await _context.Teams.FirstAsync(m => m.ID == teamId.Value);
 
-            if (Puzzle == null)
+            if (puzzle == null)
             {
                 return NotFound();
             }

--- a/ServerCore/Pages/Teams/Status.cshtml.cs
+++ b/ServerCore/Pages/Teams/Status.cshtml.cs
@@ -41,7 +41,7 @@ namespace ServerCore.Pages.Teams
             var puzzle = puzzleId == null ? null : await _context.Puzzles.FirstAsync(m => m.ID == puzzleId.Value);
             var team = await _context.Teams.FirstAsync(m => m.ID == id);
 
-            if (Team == null)
+            if (team == null)
             {
                 return NotFound();
             }
@@ -57,7 +57,7 @@ namespace ServerCore.Pages.Teams
             var puzzle = puzzleId == null ? null : await _context.Puzzles.FirstAsync(m => m.ID == puzzleId.Value);
             var team = await _context.Teams.FirstAsync(m => m.ID == id);
 
-            if (Team == null)
+            if (team == null)
             {
                 return NotFound();
             }


### PR DESCRIPTION
Event-specific Event pages now use EventSpecificPageModel so that their auth works properly.

The only event pages that require global admin rights are Create, CreateDemo, and the Index.