### PR TITLE
Timed Unlocks

### DIFF
--- a/Data/DataModel/Puzzle.cs
+++ b/Data/DataModel/Puzzle.cs
@@ -32,6 +32,7 @@ namespace ServerCore.DataModel
             OrderInGroup = source.OrderInGroup;
             IsGloballyVisiblePrerequisite = source.IsGloballyVisiblePrerequisite;
             MinPrerequisiteCount = source.MinPrerequisiteCount;
+            MinutesToAutomaticallySolve = source.MinutesToAutomaticallySolve;
         }
 
         /// <summary>
@@ -103,6 +104,12 @@ namespace ServerCore.DataModel
         /// TODO: When the system is mature, set the default to 1 so new puzzles are not accidentally displayed.
         /// </summary>
         public int MinPrerequisiteCount { get; set; } = 0;
+
+        /// <summary>
+        /// Minutes from the time a puzzle is unlocked until it is automatically marked as solved.
+        /// Note that the actual solve time may be different, as the computation of unlocks is somewhat throttled.
+        /// </summary>
+        public int? MinutesToAutomaticallySolve { get; set; } = null;
 
         /// <summary>
         /// All of the content files associated with this puzzle

--- a/Data/Migrations/20190115023207_MinutesToAutomaticallySolve.Designer.cs
+++ b/Data/Migrations/20190115023207_MinutesToAutomaticallySolve.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServerCore.DataModel;
 
 namespace Data.Migrations
 {
     [DbContext(typeof(PuzzleServerContext))]
-    partial class PuzzleServerContextModelSnapshot : ModelSnapshot
+    [Migration("20190115023207_MinutesToAutomaticallySolve")]
+    partial class MinutesToAutomaticallySolve
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20190115023207_MinutesToAutomaticallySolve.cs
+++ b/Data/Migrations/20190115023207_MinutesToAutomaticallySolve.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Data.Migrations
+{
+    public partial class MinutesToAutomaticallySolve : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MinutesToAutomaticallySolve",
+                table: "Puzzles",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MinutesToAutomaticallySolve",
+                table: "Puzzles");
+        }
+    }
+}

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -96,6 +96,8 @@ namespace ServerCore.Areas.Identity
             {
                 authContext.Succeed(requirement);
             }
+
+            dbContext.Entry(puzzle).State = EntityState.Detached;
         }
 
         public static async Task IsEventAuthorCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -103,14 +103,15 @@ namespace ServerCore.Pages.Events
 
             Puzzle intermediate = new Puzzle
             {
-                Name = "Rabbit Run",
+                Name = "Rabbit Run (automatically solves itself)",
                 Event = Event,
                 IsPuzzle = true,
                 SolveValue = 10,
                 HintCoinsForSolve = 2,
                 Group = "Thumper's Stumpers",
                 OrderInGroup = 2,
-                MinPrerequisiteCount = 1
+                MinPrerequisiteCount = 1,
+                MinutesToAutomaticallySolve = 3
             };
             _context.Puzzles.Add(intermediate);
 

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -103,7 +103,7 @@ namespace ServerCore.Pages.Events
 
             Puzzle intermediate = new Puzzle
             {
-                Name = "Rabbit Run (automatically solves itself)",
+                Name = "Rabbit Run (automatically solves in ~3 mins)",
                 Event = Event,
                 IsPuzzle = true,
                 SolveValue = 10,

--- a/ServerCore/Pages/Puzzles/Create.cshtml
+++ b/ServerCore/Pages/Puzzles/Create.cshtml
@@ -77,6 +77,11 @@
                 <span asp-validation-for="Puzzle.MinPrerequisiteCount" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Puzzle.MinutesToAutomaticallySolve" class="control-label"></label>
+                <input asp-for="Puzzle.MinutesToAutomaticallySolve" class="form-control" />
+                <span asp-validation-for="Puzzle.MinutesToAutomaticallySolve" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="Puzzle.SupportEmailAlias" class="control-label"></label>
                 <input asp-for="Puzzle.SupportEmailAlias" class="form-control" />
                 <span asp-validation-for="Puzzle.SupportEmailAlias" class="text-danger"></span>

--- a/ServerCore/Pages/Puzzles/Delete.cshtml
+++ b/ServerCore/Pages/Puzzles/Delete.cshtml
@@ -72,6 +72,12 @@
         <dd>
             @Html.DisplayFor(model => model.Puzzle.MinPrerequisiteCount)
         </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.Puzzle.MinutesToAutomaticallySolve)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Puzzle.MinutesToAutomaticallySolve)
+        </dd>
     </dl>
 
     <form method="post">

--- a/ServerCore/Pages/Puzzles/Details.cshtml
+++ b/ServerCore/Pages/Puzzles/Details.cshtml
@@ -78,6 +78,12 @@
             @Html.DisplayFor(model => model.Puzzle.MinPrerequisiteCount)
         </dd>
         <dt>
+            @Html.DisplayNameFor(model => model.Puzzle.MinutesToAutomaticallySolve)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Puzzle.MinutesToAutomaticallySolve)
+        </dd>
+        <dt>
             @Html.DisplayNameFor(model => model.Puzzle.SupportEmailAlias)
         </dt>
         <dd>

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -79,6 +79,11 @@
                 <span asp-validation-for="Puzzle.MinPrerequisiteCount" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Puzzle.MinutesToAutomaticallySolve" class="control-label"></label>
+                <input asp-for="Puzzle.MinutesToAutomaticallySolve" class="form-control" />
+                <span asp-validation-for="Puzzle.MinutesToAutomaticallySolve" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="Puzzle.SupportEmailAlias" class="control-label"></label>
                 <input asp-for="Puzzle.SupportEmailAlias" class="form-control" />
                 <span asp-validation-for="Puzzle.SupportEmailAlias" class="text-danger"></span>

--- a/ServerCore/Pages/Teams/Play.cshtml.cs
+++ b/ServerCore/Pages/Teams/Play.cshtml.cs
@@ -33,6 +33,8 @@ namespace ServerCore.Pages.Teams
             this.TeamID = teamId;
             this.Sort = sort;
 
+            await PuzzleStateHelper.CheckForTimedUnlocksAsync(_context, Event, teamId);
+
             // all puzzles for this event that are real puzzles
             var puzzlesInEventQ = _context.Puzzles.Where(puzzle => puzzle.Event.ID == this.Event.ID && puzzle.IsPuzzle);
 

--- a/ServerCore/Pages/Teams/Play.cshtml.cs
+++ b/ServerCore/Pages/Teams/Play.cshtml.cs
@@ -37,14 +37,13 @@ namespace ServerCore.Pages.Teams
             if (myTeam != null)
             {
                 this.TeamID = myTeam.ID;
+                await PuzzleStateHelper.CheckForTimedUnlocksAsync(_context, Event, myTeam);
             }
             else
             {
                 throw new Exception("Not currently registered for a team");
             }
             this.Sort = sort;
-
-            await PuzzleStateHelper.CheckForTimedUnlocksAsync(_context, Event, teamId);
 
             // all puzzles for this event that are real puzzles
             var puzzlesInEventQ = _context.Puzzles.Where(puzzle => puzzle.Event.ID == this.Event.ID && puzzle.IsPuzzle);


### PR DESCRIPTION
Implementing timed unlocks the way the old site did them, which is not nearly as cool as a wave-based approach but is better than poking the puzzle status manually during all betas and the live event.

The unlocking computation has a 10-minute throttle that is applied per team.