### PR TITLE
Submissions Improvements

### DIFF
--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -97,7 +97,10 @@ namespace ServerCore.Areas.Identity
                 authContext.Succeed(requirement);
             }
 
-            dbContext.Entry(puzzle).State = EntityState.Detached;
+            if (puzzle != null)
+            {
+                dbContext.Entry(puzzle).State = EntityState.Detached;
+            }
         }
 
         public static async Task IsEventAuthorCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)

--- a/ServerCore/Pages/Events/Map.cshtml
+++ b/ServerCore/Pages/Events/Map.cshtml
@@ -53,8 +53,8 @@
             {
                 var teamState = Model.StateMap[x, y] ?? MapModel.StateStats.Default;
 
-                    <td @if(teamState.DisplayLightness < 30) { <text> class= "dark"</text> }  style="background-color: hsl(@teamState.DisplayHue, 100%, @teamState.DisplayLightness%)">
-                        <a href="">@teamState.DisplayText</a>
+                    <td @if (teamState.DisplayLightness < 30) { <text> class= "dark"</text> }  style="background-color: hsl(@teamState.DisplayHue, 100%, @teamState.DisplayLightness%)">
+                        <a asp-page="/Submissions/AuthorIndex" asp-route-puzzleId="@Model.Puzzles[x].Puzzle.ID" asp-route-teamId="@Model.Teams[y].Team.ID">@teamState.DisplayText</a>
                     </td>
             }
                 </tr>

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -11,7 +11,8 @@
 <h2>All Puzzles</h2>
 
 <p>
-    <a asp-page="Create">Create New</a>
+    <a asp-page="Create">Create New</a> | 
+    <a asp-page="/Submissions/AuthorIndex">View All Submissions</a>
 </p>
 <table class="table">
     <thead>

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/{eventId}/{eventRole}/AuthorSubmissions/{puzzleId}"
+﻿@page "/{eventId}/{eventRole}/AuthorIndex/{puzzleId?}"
 @model ServerCore.Pages.Submissions.AuthorIndexModel
 @{
     ViewData["Title"] = "AuthorIndex";
@@ -6,10 +6,26 @@
     ViewData["AuthorRoute"] = "../Submissions/AuthorIndex";
     // TODO: Needs to handle implicit teams - ViewData["PlayRoute"] = "../Submissions/Index";
     ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
-    Layout = "../Puzzles/_puzzleManagementLayout.cshtml";
+
+    if (Model.Puzzle != null)
+    {
+        Layout = "../Puzzles/_puzzleManagementLayout.cshtml";
+    }
+    else if (Model.Team != null)
+    {
+        Layout = "../Teams/_teamLayout.cshtml";
+    }
+    // TODO: Do we need a combined layout, or is that rare enough as to be unnecessary? Maybe those bar layouts should be sections/components?
 }
 
-<h2>@Model.Puzzle.Name: Submissions</h2>
+<h2>@if (Model.Puzzle != null) { <text>@Model.Puzzle.Name:</text> } Submissions @if (Model.Team != null) { <text>by @Model.Team.Name</text> }</h2>
+
+<div>
+    @if(Model.Puzzle != null) { <a asp-page="./AuthorIndex" asp-route-puzzleId="" asp-route-teamId="@Model.Team?.ID">Clear Puzzle Filter</a> }
+    @if(Model.Puzzle != null && Model.Team != null) { <text>|</text> }  
+    @if(Model.Team != null) { <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="">Clear Team Filter</a> }  
+    @if(Model.Puzzle != null && Model.Team != null) { <text>|</text> <a asp-page="./AuthorIndex" asp-route-puzzleId="" asp-route-teamId="">Clear All Filters</a> }  
+</div>
 
 <br />
 <div>
@@ -21,6 +37,9 @@
                 </th>
                 <th>
                     Team Name
+                </th>
+                <th>
+                    Puzzle
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => model.Submissions[0].Response.ResponseText)
@@ -42,7 +61,10 @@
                     @Html.DisplayFor(modelItem => item.Submitter.Name)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Team.Name)
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@item.Team.ID">@Html.DisplayFor(modelItem => item.Team.Name)</a>
+                </td>
+                <td>
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team?.ID">@Html.DisplayFor(modelItem => item.Puzzle.Name)</a>
                 </td>
                 <td>
                     @Html.DisplayFor(modelItem => item.Response.ResponseText)

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml
@@ -33,22 +33,34 @@
         <thead>
             <tr>
                 <th>
-                    Player
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.PlayerAscending, AuthorIndexModel.SortOrder.PlayerDescending))">
+                        Player
+                    </a>
                 </th>
                 <th>
-                    Team Name
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TeamAscending, AuthorIndexModel.SortOrder.TeamDescending))">
+                        Team Name
+                    </a>
                 </th>
                 <th>
-                    Puzzle
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.PuzzleAscending, AuthorIndexModel.SortOrder.PuzzleDescending))">
+                        Puzzle
+                    </a>
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Submissions[0].Response.ResponseText)
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.ResponseAscending, AuthorIndexModel.SortOrder.ResponseDescending))">
+                        @Html.DisplayNameFor(model => model.Submissions[0].Response.ResponseText)
+                    </a>
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Submissions[0].SubmissionText)
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.SubmissionAscending, AuthorIndexModel.SortOrder.SubmissionDescending))">
+                        @Html.DisplayNameFor(model => model.Submissions[0].SubmissionText)
+                    </a>
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Submissions[0].TimeSubmitted)
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TimeAscending, AuthorIndexModel.SortOrder.TimeDescending))">
+                        @Html.DisplayNameFor(model => model.Submissions[0].TimeSubmitted)
+                    </a>
                 </th>
                 <th></th>
             </tr>

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
@@ -18,14 +18,20 @@ namespace ServerCore.Pages.Submissions
         {
         }
 
-        public IList<Submission> Submissions { get; set; }
+        public List<Submission> Submissions { get; set; }
 
         public Puzzle Puzzle { get; set; }
 
         public Team  Team { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(int? puzzleId, int? teamId)
+        public SortOrder? Sort { get; set; }
+
+        public const SortOrder DefaultSort = SortOrder.TimeDescending;
+
+        public async Task<IActionResult> OnGetAsync(int? puzzleId, int? teamId, SortOrder? sort)
         {
+            Sort = sort;
+
             if (puzzleId == null)
             {
                 if (EventRole == EventRole.admin)
@@ -89,7 +95,80 @@ namespace ServerCore.Pages.Submissions
                 Team = await _context.Teams.Where(m => m.ID == teamId).FirstOrDefaultAsync();
             }
 
+            switch (sort ?? DefaultSort)
+            {
+                case SortOrder.PlayerAscending:
+                    Submissions.Sort((a, b) => a.Submitter.Name.CompareTo(b.Submitter.Name));
+                    break;
+                case SortOrder.PlayerDescending:
+                    Submissions.Sort((a, b) => -a.Submitter.Name.CompareTo(b.Submitter.Name));
+                    break;
+                case SortOrder.TeamAscending:
+                    Submissions.Sort((a, b) => a.Team.Name.CompareTo(b.Team.Name));
+                    break;
+                case SortOrder.TeamDescending:
+                    Submissions.Sort((a, b) => -a.Team.Name.CompareTo(b.Team.Name));
+                    break;
+                case SortOrder.PuzzleAscending:
+                    Submissions.Sort((a, b) => a.Puzzle.Name.CompareTo(b.Puzzle.Name));
+                    break;
+                case SortOrder.PuzzleDescending:
+                    Submissions.Sort((a, b) => -a.Puzzle.Name.CompareTo(b.Puzzle.Name));
+                    break;
+                case SortOrder.ResponseAscending:
+                    Submissions.Sort((a, b) => a.Response.ResponseText.CompareTo(b.Response.ResponseText));
+                    break;
+                case SortOrder.ResponseDescending:
+                    Submissions.Sort((a, b) => -a.Response.ResponseText.CompareTo(b.Response.ResponseText));
+                    break;
+                case SortOrder.SubmissionAscending:
+                    Submissions.Sort((a, b) => a.SubmissionText.CompareTo(b.SubmissionText));
+                    break;
+                case SortOrder.SubmissionDescending:
+                    Submissions.Sort((a, b) => -a.SubmissionText.CompareTo(b.SubmissionText));
+                    break;
+                case SortOrder.TimeAscending:
+                    Submissions.Sort((a, b) => a.TimeSubmitted.CompareTo(b.TimeSubmitted));
+                    break;
+                case SortOrder.TimeDescending:
+                    Submissions.Sort((a, b) => -a.TimeSubmitted.CompareTo(b.TimeSubmitted));
+                    break;
+            }
+
             return Page();
+        }
+
+        public SortOrder? SortForColumnLink(SortOrder ascendingSort, SortOrder descendingSort)
+        {
+            SortOrder result = ascendingSort;
+
+            if (result == (Sort ?? DefaultSort))
+            {
+                result = descendingSort;
+            }
+
+            if (result == DefaultSort)
+            {
+                return null;
+            }
+
+            return result;
+        }
+
+        public enum SortOrder
+        {
+            PlayerAscending,
+            PlayerDescending,
+            TeamAscending,
+            TeamDescending,
+            PuzzleAscending,
+            PuzzleDescending,
+            ResponseAscending,
+            ResponseDescending,
+            SubmissionAscending,
+            SubmissionDescending,
+            TimeAscending,
+            TimeDescending
         }
     }
 }

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
@@ -3,13 +3,15 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
+using ServerCore.Helpers;
 using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Submissions
 {
-    [Authorize(Policy = "IsEventAdminOrAuthorOfPuzzle")]
+    [Authorize(Policy = "IsEventAdminOrEventAuthor")]
     public class AuthorIndexModel : EventSpecificPageModel
     {
         public AuthorIndexModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
@@ -19,18 +21,75 @@ namespace ServerCore.Pages.Submissions
         public IList<Submission> Submissions { get; set; }
 
         public Puzzle Puzzle { get; set; }
-                        
-        public async Task OnGetAsync(int? puzzleId)
+
+        public Team  Team { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int? puzzleId, int? teamId)
         {
             if (puzzleId == null)
             {
-                Submissions = await _context.Submissions.ToListAsync();
+                if (EventRole == EventRole.admin)
+                {
+                    if (teamId == null)
+                    {
+                        Submissions = await _context.Submissions.ToListAsync();
+                    }
+                    else
+                    {
+                        Submissions = await _context.Submissions.Where((s) => s.Team.ID == teamId).ToListAsync();
+                    }
+                }
+                else
+                {
+                    var submissions = new List<Submission>();
+
+                    if (teamId == null)
+                    {
+                        List<List<Submission>> submissionsList = await UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser).Select((p) => p.Submissions).ToListAsync();
+
+                        foreach (var list in submissionsList)
+                        {
+                            submissions.AddRange(list);
+                        }
+                    }
+                    else
+                    {
+                        List<IEnumerable<Submission>> submissionsList = await UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser).Select((p) => p.Submissions.Where((s) => s.Team.ID == teamId)).ToListAsync();
+
+                        foreach (var list in submissionsList)
+                        {
+                            submissions.AddRange(list);
+                        }
+                    }
+
+                    Submissions = submissions;
+                }
             }
             else
             {
-                Submissions = await _context.Submissions.Where((s) => s.Puzzle != null && s.Puzzle.ID == puzzleId).ToListAsync();
                 Puzzle = await _context.Puzzles.Where(m => m.ID == puzzleId).FirstOrDefaultAsync();
+
+                if (!await UserEventHelper.IsAuthorOfPuzzle(_context, Puzzle, LoggedInUser))
+                {
+                    return Forbid();
+                }
+
+                if (teamId == null)
+                {
+                    Submissions = await _context.Submissions.Where((s) => s.Puzzle != null && s.Puzzle.ID == puzzleId).ToListAsync();
+                }
+                else
+                {
+                    Submissions = await _context.Submissions.Where((s) => s.Puzzle != null && s.Puzzle.ID == puzzleId && s.Team.ID == teamId).ToListAsync();
+                }
             }
+
+            if (teamId != null)
+            {
+                Team = await _context.Teams.Where(m => m.ID == teamId).FirstOrDefaultAsync();
+            }
+
+            return Page();
         }
     }
 }

--- a/ServerCore/Pages/Teams/_teamLayout.cshtml
+++ b/ServerCore/Pages/Teams/_teamLayout.cshtml
@@ -5,24 +5,27 @@
 @if (Model.EventRole == ModelBases.EventRole.admin)
 {
     <div>
-        <a asp-page="./Index">Back to team list</a> ||
-        <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Details</a> |
-        <a asp-page="./Members" asp-route-teamId="@Model.Team.ID">Members</a> |
-        <a asp-page="./Status" asp-route-teamId="@Model.Team.ID">Status</a>
+        <a asp-page="/Teams/Index">Back to team list</a> ||
+        <a asp-page="/Teams/Details" asp-route-teamId="@Model.Team.ID">Details</a> |
+        <a asp-page="/Teams/Members" asp-route-teamId="@Model.Team.ID">Members</a> |
+        <a asp-page="/Submissions/AuthorIndex" asp-route-teamId="@Model.Team.ID">Submissions</a> |
+        <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a>
     </div>
 }
 @if (Model.EventRole == ModelBases.EventRole.author)
 {
     <div>
-        <a asp-page="./Index">Back to team list</a>
+        <a asp-page="/Teams/Index">Back to team list</a> ||
+        <a asp-page="/Submissions/AuthorIndex" asp-route-teamId="@Model.Team.ID">Submissions</a> |
+        <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a>
     </div>
 }
 <!-- Players can have a null team and still reach a default team page -->
 @if (Model.EventRole == ModelBases.EventRole.play && Model.Team != null)
 {
     <div>
-        <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Details</a> |
-        <a asp-page="./Members" asp-route-teamId="@Model.Team.ID">Members</a>
+        <a asp-page="/Teams/Details" asp-route-teamId="@Model.Team.ID">Details</a> |
+        <a asp-page="/Teams/Members" asp-route-teamId="@Model.Team.ID">Members</a>
     </div>
 }
 


### PR DESCRIPTION
Submissions Improvements (#9)

Ability to view submissions either filtered to specific puzzles or teams, or broadly for all puzzles - filtered as appropriate to whether the mode is author or admin. Also added links to the submissions list in a few key places to drive visibility/efficiency.

Submissions are also now sortable by all categories.