### PR TITLE
Team Registration Limits (#228)

### DIFF
--- a/ServerCore/Pages/Events/Create.cshtml.cs
+++ b/ServerCore/Pages/Events/Create.cshtml.cs
@@ -41,6 +41,9 @@ namespace ServerCore.Pages.Events
             Event.LockoutIncorrectGuessPeriod = 1;
             Event.LockoutDurationMultiplier = 2;
             Event.MaxSubmissionCount = 50;
+            Event.MaxNumberOfTeams = 120;
+            Event.MaxExternalsPerTeam = 9;
+            Event.MaxTeamSize = 12;
 
             return Page();
         }

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -72,6 +72,9 @@ namespace ServerCore.Pages.Events
             Event.LockoutIncorrectGuessPeriod = 1;
             Event.LockoutDurationMultiplier = 2;
             Event.MaxSubmissionCount = 50;
+            Event.MaxNumberOfTeams = 120;
+            Event.MaxExternalsPerTeam = 9;
+            Event.MaxTeamSize = 12;
             _context.Events.Add(Event);
 
             await _context.SaveChangesAsync();

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -78,6 +78,11 @@ namespace ServerCore.Pages.Teams
 
             using (IDbContextTransaction transaction = _context.Database.BeginTransaction(System.Data.IsolationLevel.Serializable))
             {
+                if (await _context.Teams.Where((t) => t.Event == Event).CountAsync() >= Event.MaxNumberOfTeams)
+                {
+                    return NotFound("Registration is full. No further teams may be created at the present time.");
+                }
+
                 _context.Teams.Add(Team);
 
                 if (EventRole == EventRole.play)

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -11,77 +11,90 @@
 <h2>All Teams</h2>
 
 <p>
-    @if (Model.Event.IsTeamRegistrationActive && Model.EventRole == ModelBases.EventRole.admin)
+    @if (Model.EventRole == ModelBases.EventRole.admin)
     {
+        if (!Model.Event.IsTeamRegistrationActive)
+        {
+            <div class="alert alert-danger" role="alert">
+                This event is not currently open for registration.
+            </div>
+        }
+        else if (Model.Event.MaxNumberOfTeams <= Model.Teams.Count)
+        {
+            <div class="alert alert-danger" role="alert">
+                This event is full.
+            </div>
+        }
+
         <a asp-page="Create">Create New</a>
     }
-    else
-    {
-        <div class="alert alert-danger" role="alert">
-            This event is not currently open for registration.
-        </div>
-    }
 </p>
+<h4>Registered Teams: @Model.Teams.Count/@Model.Event.MaxNumberOfTeams, Registered Players: @Model.PlayerCount/@(Model.Event.MaxNumberOfTeams * Model.Event.MaxTeamSize)</h4>
 <table class="table">
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Teams[0].Name)
+                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Key.Name)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams[0].RoomID)
+                Size
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams[0].CustomRoom)
+                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Key.RoomID)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams[0].PrimaryContactEmail)
+                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Key.CustomRoom)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams[0].PrimaryPhoneNumber)
+                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Key.PrimaryContactEmail)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams[0].SecondaryPhoneNumber)
+                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Key.PrimaryPhoneNumber)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Key.SecondaryPhoneNumber)
             </th>
             <th></th>
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model.Teams) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.RoomID)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.CustomRoom)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.PrimaryContactEmail)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.PrimaryPhoneNumber)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.SecondaryPhoneNumber)
-            </td>
-            <td>
-
-            </td>
-            <td>
-                <a asp-page="./Status" asp-route-teamId="@item.ID">Status</a>
-                @if (Model.EventRole == ModelBases.EventRole.admin)
-                {
-                <div>
-                    |
-                    <a asp-page="./Details" asp-route-teamId="@item.ID">View</a> |
-                    <a asp-page="./Members" asp-route-teamId="@item.ID">Members</a>
-                </div>
-                }
-            </td>
-        </tr>
-}
+        @foreach (var item in Model.Teams)
+        {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Key.Name)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Value)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Key.RoomID)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Key.CustomRoom)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Key.PrimaryContactEmail)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Key.PrimaryPhoneNumber)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Key.SecondaryPhoneNumber)
+                </td>
+                <td></td>
+                <td>
+                    <a asp-page="./Status" asp-route-teamId="@item.Key.ID">Status</a>
+                    @if (Model.EventRole == ModelBases.EventRole.admin)
+                    {
+                        <div>
+                            |
+                            <a asp-page="./Details" asp-route-teamId="@item.Key.ID">View</a> |
+                            <a asp-page="./Members" asp-route-teamId="@item.Key.ID">Members</a>
+                        </div>
+                    }
+                </td>
+            </tr>
+        }
     </tbody>
 </table>

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -19,7 +19,7 @@
                 This event is not currently open for registration.
             </div>
         }
-        else if (Model.Event.MaxNumberOfTeams <= Model.Teams.Count)
+        else if (Model.Teams.Count >= Model.Event.MaxNumberOfTeams)
         {
             <div class="alert alert-danger" role="alert">
                 This event is full.

--- a/ServerCore/Pages/Teams/Index.cshtml.cs
+++ b/ServerCore/Pages/Teams/Index.cshtml.cs
@@ -1,27 +1,21 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Teams
 {
     [Authorize(Policy = "IsEventAdminOrEventAuthor")]    
-    public class IndexModel : EventSpecificPageModel
+    public class IndexModel : TeamListBase
     {
         public IndexModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
         {
         }
 
-        public IList<Team> Teams { get;set; }
-
         public async Task<IActionResult> OnGetAsync()
         {
-            Teams = await _context.Teams.Where(team => team.Event == Event).ToListAsync();
+            await LoadTeamDataAsync();
             return Page();
         }
     }

--- a/ServerCore/Pages/Teams/List.cshtml
+++ b/ServerCore/Pages/Teams/List.cshtml
@@ -9,7 +9,21 @@
 }
 
 <p>
-    @if (Model.Event.IsTeamRegistrationActive)
+    @if (!Model.Event.IsTeamRegistrationActive)
+    {
+        <h2>Registration closed</h2>
+        <div>
+            You are not part of a team for this event, and unfortuantely we're no longer accepting new teams into the event. :(
+        </div>
+    }
+    else if (Model.Event.MaxNumberOfTeams <= Model.Teams.Count)
+    {
+        <h2>Registration full</h2>
+        <div>
+            You are not part of a team for this event, and unfortuantely we're no longer accepting new teams into the event. :(
+        </div>
+    }
+    else
     {
         <h2>Register for @Model.Event.Name</h2>
         <div>
@@ -17,14 +31,8 @@
         </div>
         <a asp-page="Create">Create a new team</a>
     }
-    else
-    {
-        <h2>Registration closed</h2>
-        <div>
-            You are not part of a team for this event, and unfortuantely we're no longer accepting new teams into the event. :(
-        </div>
-    }
 </p>
+<h4>Registered Teams: @Model.Teams.Count/@Model.Event.MaxNumberOfTeams, Registered Players: @Model.PlayerCount/@(Model.Event.MaxNumberOfTeams * Model.Event.MaxTeamSize)</h4>
 @if (Model.Event.IsTeamRegistrationActive)
 {
     <table class="table">

--- a/ServerCore/Pages/Teams/List.cshtml
+++ b/ServerCore/Pages/Teams/List.cshtml
@@ -16,7 +16,7 @@
             You are not part of a team for this event, and unfortuantely we're no longer accepting new teams into the event. :(
         </div>
     }
-    else if (Model.Event.MaxNumberOfTeams <= Model.Teams.Count)
+    else if (Model.Teams.Count >= Model.Event.MaxNumberOfTeams)
     {
         <h2>Registration full</h2>
         <div>

--- a/ServerCore/Pages/Teams/List.cshtml.cs
+++ b/ServerCore/Pages/Teams/List.cshtml.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
 
 namespace ServerCore.Pages.Teams

--- a/ServerCore/Pages/Teams/List.cshtml.cs
+++ b/ServerCore/Pages/Teams/List.cshtml.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Teams
 {
@@ -16,16 +10,11 @@ namespace ServerCore.Pages.Teams
     /// Player-facing list of all teams
     /// </summary>
     [AllowAnonymous]
-    public class ListModel : EventSpecificPageModel
+    public class ListModel : TeamListBase
     {
         public ListModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
         {
         }
-
-        /// <summary>
-        /// All teams
-        /// </summary>
-        public Dictionary<Team, int> Teams { get;set; }
 
         /// <summary>
         /// True if the current user is on a team
@@ -48,24 +37,7 @@ namespace ServerCore.Pages.Teams
                 UserOnTeam = false;
             }
 
-            //Teams = await _context.Teams.ToListAsync();
-            List<Team> allTeams = await (from team in _context.Teams
-                                      where team.Event == Event
-                                      select team).ToListAsync();
-
-            Teams = await (from team in _context.Teams
-                           where team.Event == Event
-                           join teamMember in _context.TeamMembers on team equals teamMember.Team
-                           group teamMember by teamMember.Team into teamCounts
-                           select new { Team = teamCounts.Key, Count = teamCounts.Count() }).ToDictionaryAsync(x => x.Team, x => x.Count);
-
-            foreach (Team team in allTeams)
-            {
-                if (!Teams.ContainsKey(team))
-                {
-                    Teams[team] = 0;
-                }
-            }
+            await LoadTeamDataAsync();
 
             return Page();
         }

--- a/ServerCore/Pages/Teams/Members.cshtml
+++ b/ServerCore/Pages/Teams/Members.cshtml
@@ -8,20 +8,32 @@
     Layout = "_teamLayout.cshtml";
 }
 
-<h2>@Html.DisplayFor(model => model.Team.Name): Members</h2>
+<h2>@Html.DisplayFor(model => model.Team.Name): @(Model.Members.Count) Members</h2>
 
 <p>
-    @if (Model.Event.IsTeamMembershipChangeActive || Model.EventRole == ModelBases.EventRole.admin)
-    {
-        <div>
-            <a asp-page="./AddMember" asp-route-teamId="@Model.Team.ID">Add a member</a>
-        </div>
+    @{ bool canAdd = Model.EventRole == ModelBases.EventRole.admin; }
 
-    }
-    else
+    @if (!Model.Event.IsTeamMembershipChangeActive)
     {
         <div class="alert alert-danger" role="alert">
             This event is not currently open for registration.
+        </div>
+    }
+    else if (Model.Members.Count >= Model.Event.MaxTeamSize)
+    {
+        <div class="alert alert-danger" role="alert">
+            This team is full.
+        </div>
+    }
+    else
+    {
+        canAdd = true;
+    }
+
+    @if (canAdd)
+    {
+        <div>
+            <a asp-page="./AddMember" asp-route-teamId="@Model.Team.ID">Add a member</a>
         </div>
     }
 </p>
@@ -35,6 +47,9 @@
             <th>
                 @Html.DisplayNameFor(model => model.Members[0].Member.Email)
             </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Members[0].Member.EmployeeAlias)
+            </th>
             <th>Remove</th>
         </tr>
     </thead>
@@ -47,6 +62,9 @@
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Member.Email)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Member.EmployeeAlias)
             </td>
 
             @if (Model.EventRole == ModelBases.EventRole.play && Model.Members.Count == 1)

--- a/ServerCore/Pages/Teams/Members.cshtml
+++ b/ServerCore/Pages/Teams/Members.cshtml
@@ -33,7 +33,7 @@
     @if (canAdd)
     {
         <div>
-            <a asp-page="./AddMember" asp-route-teamId="@Model.Team.ID">Add a member</a>
+            <a asp-page="./AddMember" asp-route-teamId="@Model.Team.ID">Add a member</a> |
             <a asp-page="./Apply" asp-route-eventRole="play" asp-route-teamId="@Model.Team.ID">Application link (copy me and email me!)</a>
         </div>
     }

--- a/ServerCore/Pages/Teams/TeamListBase.cs
+++ b/ServerCore/Pages/Teams/TeamListBase.cs
@@ -19,6 +19,9 @@ namespace ServerCore.Pages.Teams
         /// </summary>
         public Dictionary<Team, int> Teams { get; set; }
 
+        /// <summary>
+        /// Count of all players on teams
+        /// </summary>
         public int PlayerCount { get; set; }
 
         protected async Task LoadTeamDataAsync()

--- a/ServerCore/Pages/Teams/TeamListBase.cs
+++ b/ServerCore/Pages/Teams/TeamListBase.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Teams
+{
+    public class TeamListBase : EventSpecificPageModel
+    {
+        public TeamListBase(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
+        {
+        }
+
+        /// <summary>
+        /// All teams
+        /// </summary>
+        public Dictionary<Team, int> Teams { get; set; }
+
+        public int PlayerCount { get; set; }
+
+        protected async Task LoadTeamDataAsync()
+        {
+            List<Team> allTeams = await (from team in _context.Teams
+                                         where team.Event == Event
+                                         select team).ToListAsync();
+
+            Teams = await (from team in _context.Teams
+                           where team.Event == Event
+                           join teamMember in _context.TeamMembers on team equals teamMember.Team
+                           group teamMember by teamMember.Team into teamCounts
+                           select new { Team = teamCounts.Key, Count = teamCounts.Count() }).ToDictionaryAsync(x => x.Team, x => x.Count);
+
+            foreach (Team team in allTeams)
+            {
+                if (!Teams.ContainsKey(team))
+                {
+                    Teams[team] = 0;
+                }
+                else
+                {
+                    PlayerCount += Teams[team];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Applying limits on number of teams, number of players, and number of externals per team.

Admins have god powers and can add teams over the limit, players over the limit, and externals over the limit - but players cannot.

[We aren't validating the employee aliases but we could choose to manually audit them if desired.]