### PR TITLE
Hint Tweaks (#222, #227)

### DIFF
--- a/ServerCore/Pages/Teams/Hints.cshtml
+++ b/ServerCore/Pages/Teams/Hints.cshtml
@@ -44,7 +44,14 @@ You have @Model.Team.HintCoinCount hint ticket(s).
                 <td>
                     @if (!hint.IsUnlocked)
                     {
-                        @Html.DisplayFor(modelItem => hint.Hint.Cost)
+                        if (hint.Hint.Cost == 0)
+                        {
+                            <text>FREE</text>
+                        }
+                        else
+                        {
+                            @Html.DisplayFor(modelItem => hint.Hint.Cost)
+                        }
                     }
                 </td>
                 <td>

--- a/ServerCore/Pages/Teams/Hints.cshtml.cs
+++ b/ServerCore/Pages/Teams/Hints.cshtml.cs
@@ -99,7 +99,7 @@ namespace ServerCore.Pages.Teams
 
             await PopulateUI(puzzleID, teamID);
             
-            return Page();
+            return RedirectToPage(new { puzzleID, teamID });
         }
     }
 }


### PR DESCRIPTION
#227 was caused by incorrect routing that stripped the puzzleID property from the URL. #222 was trivial while I was in the neighborhood.