### PR TITLE
Edit Player Properties (#184)

### DIFF
--- a/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml
+++ b/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml
@@ -16,6 +16,7 @@
     <div class="col-md-4">
         <form method="post" asp-route-returnUrl="@Model.ReturnUrl">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            @* NOTE: If you add more properties here, please add them to ExternalLogin.cshtml as well! *@
             <input type="hidden" asp-for="PuzzleUser.ID" />
             <input type="hidden" asp-for="PuzzleUser.IdentityUserId" />
             <input type="hidden" asp-for="PuzzleUser.IsGlobalAdmin" />
@@ -49,6 +50,7 @@
                 <input asp-for="PuzzleUser.TShirtSize" class="form-control" />
                 <span asp-validation-for="PuzzleUser.TShirtSize" class="text-danger"></span>
             </div>
+            @* NOTE: If you add more properties here, please add them to ExternalLogin.cshtml as well! *@
             <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-default" />
             </div>

--- a/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml
+++ b/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml
@@ -1,0 +1,62 @@
+﻿@page
+@model EditModel
+@{
+    ViewData["Title"] = "Edit User Properties";
+}
+
+<h2>@ViewData["Title"]</h2>
+<h4>Edit Properties for @Model.PuzzleUser.Name</h4>
+<hr />
+
+<p class="text-info">
+    This profile is shared between all events.
+</p>
+
+<div class="row">
+    <div class="col-md-4">
+        <form method="post" asp-route-returnUrl="@Model.ReturnUrl">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="PuzzleUser.ID" />
+            <input type="hidden" asp-for="PuzzleUser.IdentityUserId" />
+            <input type="hidden" asp-for="PuzzleUser.IsGlobalAdmin" />
+            <div class="form-group">
+                <label asp-for="PuzzleUser.Email"></label>
+                <input asp-for="PuzzleUser.Email" class="form-control" />
+                <span asp-validation-for="PuzzleUser.Email" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="PuzzleUser.Name"></label>
+                <input asp-for="PuzzleUser.Name" class="form-control" />
+                <span asp-validation-for="PuzzleUser.Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="PuzzleUser.EmployeeAlias"></label>
+                <input asp-for="PuzzleUser.EmployeeAlias" class="form-control" />
+                <span asp-validation-for="PuzzleUser.EmployeeAlias" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="PuzzleUser.PhoneNumber"></label>
+                <input asp-for="PuzzleUser.PhoneNumber" class="form-control" />
+                <span asp-validation-for="PuzzleUser.PhoneNumber" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="PuzzleUser.VisibleToOthers"></label>
+                <input asp-for="PuzzleUser.VisibleToOthers" class="form-control" />
+                <span asp-validation-for="PuzzleUser.VisibleToOthers" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="PuzzleUser.TShirtSize"></label>
+                <input asp-for="PuzzleUser.TShirtSize" class="form-control" />
+                <span asp-validation-for="PuzzleUser.TShirtSize" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Save" class="btn btn-default" />
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}
+

--- a/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml.cs
@@ -1,0 +1,79 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+
+namespace ServerCore.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class EditModel : PageModel
+    {
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly PuzzleServerContext _context;
+
+        public EditModel(
+            UserManager<IdentityUser> userManager,
+            PuzzleServerContext context)
+        {
+            _userManager = userManager;
+            _context = context;
+        }
+
+        [BindProperty]
+        public PuzzleUser PuzzleUser { get; set; }
+
+        public string ReturnUrl { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int userId, string returnUrl = null)
+        {
+            var thisPuzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, _userManager);
+
+            if (thisPuzzleUser == null)
+            {
+                return Forbid();
+            }
+
+            PuzzleUser = await _context.PuzzleUsers.Where((p) => p.ID == userId).FirstOrDefaultAsync();
+
+            if (thisPuzzleUser.ID != PuzzleUser.ID && !thisPuzzleUser.IsGlobalAdmin)
+            {
+                return Forbid();
+            }
+
+            ReturnUrl = returnUrl;
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+        {
+            if (!ModelState.IsValid)
+            {
+                // TODO: For some reason the ID property is not reported as valid. No clue how validation works and all other properties are strings anyway. Ignore for now?
+                return Page();
+            }
+
+            var thisPuzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, _userManager);
+
+            if (thisPuzzleUser == null)
+            {
+                return Forbid();
+            }
+
+            if (thisPuzzleUser.ID != PuzzleUser.ID && !thisPuzzleUser.IsGlobalAdmin)
+            {
+                return Forbid();
+            }
+
+            _context.Entry(thisPuzzleUser).State = EntityState.Detached;
+            _context.Attach(PuzzleUser).State = EntityState.Modified;
+
+            await _context.SaveChangesAsync();
+            return Redirect(returnUrl);
+        }
+    }
+}

--- a/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml
+++ b/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml
@@ -18,6 +18,7 @@
     <div class="col-md-4">
         <form asp-page-handler="Confirmation" asp-route-returnUrl="@Model.ReturnUrl" method="post">
             <div asp-validation-summary="All" class="text-danger"></div>
+            @* NOTE: If you add more properties here, please add them to Edit.cshtml as well! *@
             <div class="form-group">
                 <label asp-for="Input.Email"></label>
                 <input asp-for="Input.Email" class="form-control" />
@@ -48,6 +49,7 @@
                 <input asp-for="Input.TShirtSize" class="form-control" />
                 <span asp-validation-for="Input.TShirtSize" class="text-danger"></span>
             </div>
+            @* NOTE: If you add more properties here, please add them to Edit.cshtml as well! *@
             <input type="hidden" asp-for="Input.IdentityUserId" />
             <button type="submit" class="btn btn-default">Register</button>
         </form>

--- a/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -27,18 +27,32 @@
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Input.Name"></label>
+                <input asp-for="Input.Name" class="form-control" />
+                <span asp-validation-for="Input.Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="Input.EmployeeAlias"></label>
                 <input asp-for="Input.EmployeeAlias" class="form-control" />
                 <span asp-validation-for="Input.EmployeeAlias" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="Input.PhoneNumber"></label>
                 <input asp-for="Input.PhoneNumber" class="form-control" />
                 <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
             </div>
-
+            <div class="form-group">
+                <label asp-for="Input.VisibleToOthers"></label>
+                <input asp-for="Input.VisibleToOthers" class="form-control" />
+                <span asp-validation-for="Input.VisibleToOthers" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.TShirtSize"></label>
+                <input asp-for="Input.TShirtSize" class="form-control" />
+                <span asp-validation-for="Input.TShirtSize" class="text-danger"></span>
+            </div>
             <input type="hidden" asp-for="Input.IdentityUserId" />
+            <input type="hidden" asp-for="Input.IsGlobalAdmin" />
 
             <button type="submit" class="btn btn-default">Save</button>
         </form>

--- a/ServerCore/Pages/Events/Players.cshtml
+++ b/ServerCore/Pages/Events/Players.cshtml
@@ -35,7 +35,7 @@
         {
             <tr>
                 <td>
-                    @if (item.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
                         <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Name)</a>
                     }
@@ -91,7 +91,7 @@
         {
             <tr>
                 <td>
-                    @if (item.Item1.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
                         <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Item1.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Item1.Name)</a>
                     }
@@ -147,7 +147,7 @@
         {
             <tr>
                 <td>
-                    @if (item.Member.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
                         <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Member.Name)</a>
                     }

--- a/ServerCore/Pages/Events/Players.cshtml
+++ b/ServerCore/Pages/Events/Players.cshtml
@@ -6,6 +6,7 @@
     ViewData["AuthorRoute"] = "/EventSpecific/Index";
     ViewData["PlayRoute"] = "/EventSpecific/Index";
 }
+@using Microsoft.AspNetCore.Http.Extensions @* for GetEncodedUrl *@
 
 <h2>Users</h2>
 
@@ -34,7 +35,14 @@
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Name)
+                    @if (item.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    {
+                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Name)</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.Name)
+                    }
                 </td>
                 <td>
                     @Html.DisplayFor(modelItem => item.Email)
@@ -83,7 +91,14 @@
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Item1.Name)
+                    @if (item.Item1.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    {
+                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Item1.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Item1.Name)</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.Item1.Name)
+                    }
                 </td>
                 <td>
                     @Html.DisplayFor(modelItem => item.Item1.Email)
@@ -132,7 +147,14 @@
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Member.Name)
+                    @if (item.Member.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    {
+                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Member.Name)</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.Member.Name)
+                    }
                 </td>
                 <td>
                     @Html.DisplayFor(modelItem => item.Member.Email)

--- a/ServerCore/Pages/Teams/Members.cshtml
+++ b/ServerCore/Pages/Teams/Members.cshtml
@@ -7,6 +7,7 @@
     //Needs route data - ViewData["PlayRoute"] = "/Teams/Members";
     Layout = "_teamLayout.cshtml";
 }
+@using Microsoft.AspNetCore.Http.Extensions @* for GetEncodedUrl *@
 
 <h2>@Html.DisplayFor(model => model.Team.Name): @(Model.Members.Count) Members</h2>
 
@@ -57,30 +58,37 @@
     <tbody>
         @foreach (var item in Model.Members)
         {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Member.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Member.Email)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Member.EmployeeAlias)
-            </td>
+            <tr>
+                <td>
+                    @if (item.Member.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    {
+                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Member.Name)</a>
+                    }
+                    else
+                    {
+                        @Html.DisplayFor(modelItem => item.Member.Name)
+                    }
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Member.Email)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Member.EmployeeAlias)
+                </td>
 
-            @if (Model.EventRole == ModelBases.EventRole.play && Model.Members.Count == 1)
-            {
-                <td>
-                    (Can't remove last member)
-                </td>
-            }
-            else
-            {
-                <td>
-                    <a asp-page-handler="RemoveMember" asp-route-teamId="@Model.Team.ID" asp-route-teamMemberId="@item.ID" onclick="return confirm('Are you sure you want to remove @item.Member.Name from @Model.Team.Name?')">Remove</a>
-                </td>
-            }
-        </tr>
+                @if (Model.EventRole == ModelBases.EventRole.play && Model.Members.Count == 1)
+                {
+                    <td>
+                        (Can't remove last member)
+                    </td>
+                }
+                else
+                {
+                    <td>
+                        <a asp-page-handler="RemoveMember" asp-route-teamId="@Model.Team.ID" asp-route-teamMemberId="@item.ID" onclick="return confirm('Are you sure you want to remove @item.Member.Name from @Model.Team.Name?')">Remove</a>
+                    </td>
+                }
+            </tr>
         }
     </tbody>
 </table>

--- a/ServerCore/Pages/Teams/Members.cshtml
+++ b/ServerCore/Pages/Teams/Members.cshtml
@@ -60,7 +60,7 @@
         {
             <tr>
                 <td>
-                    @if (item.Member.ID == Model.LoggedInUser.ID || Model.LoggedInUser.IsGlobalAdmin)
+                    @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
                         <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Member.Name)</a>
                     }


### PR DESCRIPTION
Updated the profile page for the logged in user to update all their properties.

Also added a page that can be accessed from the team members list or the admin users list, which allows editing if the user is the current user or a global admin.

Along the way, fixed a bug where editing could clear the global admin flag.