### PR TITLE
Impersonation support

### DIFF
--- a/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml.cs
@@ -43,7 +43,7 @@ namespace ServerCore.Areas.Identity.Pages.Account
                 return Page();
             }
 
-            var thisPuzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, _userManager);
+            var thisPuzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, HttpContext, User, _userManager);
 
             if (thisPuzzleUser != null)
             {

--- a/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -73,7 +73,7 @@ namespace ServerCore.Areas.Identity.Pages.Account.Manage
                 return NotFound($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
             }
 
-            var thisPuzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, _userManager);
+            var thisPuzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, HttpContext, User, _userManager);
 
             // enforce access rights, do not let these change!
             Input.ID = thisPuzzleUser.ID;

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -75,7 +75,7 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsEventAdminCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, (authContext.Resource as AuthorizationFilterContext)?.HttpContext, authContext.User, userManager);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
             EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
 
@@ -87,7 +87,7 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsPuzzleAuthorCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, (authContext.Resource as AuthorizationFilterContext)?.HttpContext, authContext.User, userManager);
             Puzzle puzzle = await AuthorizationHelper.GetPuzzleFromContext(authContext);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
             EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
@@ -105,7 +105,7 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsEventAuthorCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, (authContext.Resource as AuthorizationFilterContext)?.HttpContext, authContext.User, userManager);
             EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
 
             if (authContext.Resource is AuthorizationFilterContext filterContext)
@@ -121,7 +121,7 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsEventPlayerCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, (authContext.Resource as AuthorizationFilterContext)?.HttpContext, authContext.User, userManager);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
             EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
 
@@ -133,7 +133,7 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsPlayerOnTeamCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, (authContext.Resource as AuthorizationFilterContext)?.HttpContext, authContext.User, userManager);
             Team team = await AuthorizationHelper.GetTeamFromContext(authContext);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
             EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsGlobalAdmin.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsGlobalAdmin.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Filters;
 using ServerCore.DataModel;
 
 namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
@@ -29,7 +30,7 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsGlobalAdminRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, (authContext.Resource as AuthorizationFilterContext)?.HttpContext, authContext.User, userManager);
 
             if (puzzleUser.IsGlobalAdmin)
             {

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/PlayerCanSeePuzzle.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/PlayerCanSeePuzzle.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Filters;
 using ServerCore.DataModel;
 using ServerCore.Helpers;
 
@@ -31,7 +32,7 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        PlayerCanSeePuzzleRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, (authContext.Resource as AuthorizationFilterContext)?.HttpContext, authContext.User, userManager);
             Puzzle puzzle = await AuthorizationHelper.GetPuzzleFromContext(authContext);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
 

--- a/ServerCore/Helpers/UserEventHelper.cs
+++ b/ServerCore/Helpers/UserEventHelper.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
@@ -52,9 +53,9 @@ namespace ServerCore.Helpers
         /// <param name="user">The claim for the user being checked</param>
         /// <param name="userManager">The UserManager for the current context</param>
         /// <returns>The user's team for this event</returns>
-        public static async Task<Team> GetTeamForCurrentPlayer(PuzzleServerContext puzzleServerContext, Event thisEvent, ClaimsPrincipal user, UserManager<IdentityUser> userManager)
+        public static async Task<Team> GetTeamForCurrentPlayer(PuzzleServerContext puzzleServerContext, HttpContext httpContext, Event thisEvent, ClaimsPrincipal user, UserManager<IdentityUser> userManager)
         {
-            PuzzleUser pUser = await PuzzleUser.GetPuzzleUserForCurrentUser(puzzleServerContext, user, userManager);
+            PuzzleUser pUser = await PuzzleUser.GetPuzzleUserForCurrentUser(puzzleServerContext, httpContext, user, userManager);
             return await GetTeamForPlayer(puzzleServerContext, thisEvent, pUser);
         }
     }

--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -32,7 +32,7 @@ namespace ServerCore.ModelBases
             {
                 if (loggedInUser == null)
                 {
-                    loggedInUser = PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, userManager).Result;
+                    loggedInUser = PuzzleUser.GetPuzzleUserForCurrentUser(_context, HttpContext, User, userManager).Result;
                 }
                 return loggedInUser;
             }
@@ -60,6 +60,18 @@ namespace ServerCore.ModelBases
         public async Task<bool> IsEventAdmin()
         {
             return await LoggedInUser.IsAdminForEvent(_context, Event);
+        }
+
+        public IActionResult OnGetUnimpersonate()
+        {
+            if (!LoggedInUser.IsGlobalAdmin)
+            {
+                return NotFound("Must be a global administrator to impersonate.");
+            }
+
+            PuzzleUser.Impersonate(HttpContext, null);
+
+            return RedirectToPage("/EventSpecific/Index", new { eventRole = EventRole.admin });
         }
 
         public class EventBinder : IModelBinder

--- a/ServerCore/Pages/Events/Create.cshtml.cs
+++ b/ServerCore/Pages/Events/Create.cshtml.cs
@@ -57,7 +57,7 @@ namespace ServerCore.Pages.Events
 
             _context.Events.Add(Event);
 
-            var loggedInUser = PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, _userManager).Result;
+            var loggedInUser = PuzzleUser.GetPuzzleUserForCurrentUser(_context, HttpContext, User, _userManager).Result;
 
             if (loggedInUser != null)
             {

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -275,7 +275,7 @@ namespace ServerCore.Pages.Events
                     _context.Teams.Add(teamLoneWolf);
                 }
 
-                var demoCreatorUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, _userManager);
+                var demoCreatorUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, HttpContext, User, _userManager);
                 if (demoCreatorUser != null)
                 {
                     //

--- a/ServerCore/Pages/Events/Players.cshtml
+++ b/ServerCore/Pages/Events/Players.cshtml
@@ -37,7 +37,7 @@
                 <td>
                     @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
-                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Name)</a>
+                        <a asp-page-handler="ImpersonateMember" asp-route-memberId="@item.ID" onclick="return confirm('Are you sure you want to impersonate @item.Name?')">@item.Name</a>
                     }
                     else
                     {
@@ -93,7 +93,7 @@
                 <td>
                     @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
-                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Item1.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Item1.Name)</a>
+                        <a asp-page-handler="ImpersonateMember" asp-route-memberId="@item.Item1.ID" onclick="return confirm('Are you sure you want to impersonate @item.Item1.Name?')">@item.Item1.Name</a>
                     }
                     else
                     {
@@ -149,7 +149,7 @@
                 <td>
                     @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
-                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Member.Name)</a>
+                        <a asp-page-handler="ImpersonateMember" asp-route-memberId="@item.Member.ID" onclick="return confirm('Are you sure you want to impersonate @item.Member.Name?')">@item.Member.Name</a>
                     }
                     else
                     {

--- a/ServerCore/Pages/Events/Players.cshtml.cs
+++ b/ServerCore/Pages/Events/Players.cshtml.cs
@@ -109,5 +109,18 @@ namespace ServerCore.Pages.Events
             await _context.SaveChangesAsync();
             return RedirectToPage("/Events/Players");
         }
+
+        public async Task<IActionResult> OnGetImpersonateMemberAsync(int memberId)
+        {
+            if (!LoggedInUser.IsGlobalAdmin)
+            {
+                return NotFound("Must be a global administrator to impersonate.");
+            }
+
+            PuzzleUser member = await _context.PuzzleUsers.FirstOrDefaultAsync(m => m.ID == memberId);
+            PuzzleUser.Impersonate(HttpContext, member);
+
+            return RedirectToPage("/EventSpecific/Index", new { eventRole = EventRole.play });
+        }
     }
 }

--- a/ServerCore/Pages/FilesController.cs
+++ b/ServerCore/Pages/FilesController.cs
@@ -65,7 +65,7 @@ namespace ServerCore.Pages
             Event currentEvent = await (from ev in context.Events
                                         where ev.ID == eventId
                                         select ev).SingleAsync();
-            PuzzleUser user = await PuzzleUser.GetPuzzleUserForCurrentUser(context, User, userManager);
+            PuzzleUser user = await PuzzleUser.GetPuzzleUserForCurrentUser(context, HttpContext, User, userManager);
 
             // Admins can see all files
             if (await user.IsAdminForEvent(context, currentEvent))

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -60,6 +60,10 @@
 
                 <ul class="nav navbar-nav navbar-right">
                     <partial name="/Pages/Shared/_LoginPartial.cshtml" />
+                    @if (ServerCore.DataModel.PuzzleUser.IsImpersonating(Model.HttpContext))
+                    {
+                        <li><a asp-page="/EventSpecific/Index" asp-page-handler="Unimpersonate">Unimpersonate</a></li>
+                    }
                 </ul>
             </div>
         </div>
@@ -120,6 +124,10 @@
 
                 <ul class="nav navbar-nav navbar-right">
                     <partial name="/Pages/Shared/_LoginPartial.cshtml" />
+                    @if (ServerCore.DataModel.PuzzleUser.IsImpersonating(Model.HttpContext))
+                    {
+                        <li><a asp-page="/EventSpecific/Index" asp-page-handler="Unimpersonate">Unimpersonate</a></li>
+                    }
                 </ul>
             </div>
         </div>
@@ -178,6 +186,10 @@
 
                 <ul class="nav navbar-nav navbar-right">
                     <partial name="/Pages/Shared/_LoginPartial.cshtml" />
+                    @if (ServerCore.DataModel.PuzzleUser.IsImpersonating(Model.HttpContext))
+                    {
+                        <li><a asp-page="/EventSpecific/Index" asp-page-handler="Unimpersonate">Unimpersonate</a></li>
+                    }
                 </ul>
             </div>
         </div>
@@ -224,6 +236,10 @@
 
                 <ul class="nav navbar-nav navbar-right">
                     <partial name="/Pages/Shared/_LoginPartial.cshtml" />
+                    @if (ServerCore.DataModel.PuzzleUser.IsImpersonating(Model.HttpContext))
+                    {
+                        <li><a asp-page="/EventSpecific/Index" asp-page-handler="Unimpersonate">Unimpersonate</a></li>
+                    }
                 </ul>
             </div>
         </div>

--- a/ServerCore/Pages/Teams/Members.cshtml
+++ b/ServerCore/Pages/Teams/Members.cshtml
@@ -62,7 +62,7 @@
                 <td>
                     @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
-                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Member.Name)</a>
+                        <a asp-page-handler="ImpersonateMember" asp-route-memberId="@item.Member.ID" onclick="return confirm('Are you sure you want to impersonate @item.Member.Name from @Model.Team.Name?')">@item.Member.Name</a>
                     }
                     else
                     {

--- a/ServerCore/Pages/Teams/Members.cshtml.cs
+++ b/ServerCore/Pages/Teams/Members.cshtml.cs
@@ -74,5 +74,18 @@ namespace ServerCore.Pages.Teams
             await _context.SaveChangesAsync();
             return RedirectToPage("./Members", new { teamId = teamId });
         }
+
+        public async Task<IActionResult> OnGetImpersonateMemberAsync(int memberId)
+        {
+            if (!LoggedInUser.IsGlobalAdmin)
+            {
+                return NotFound("Must be a global administrator to impersonate.");
+            }
+
+            PuzzleUser member = await _context.PuzzleUsers.FirstOrDefaultAsync(m => m.ID == memberId);
+            PuzzleUser.Impersonate(HttpContext, member);
+
+            return RedirectToPage("/EventSpecific/Index", new { eventRole = EventRole.play });
+        }
     }
 }


### PR DESCRIPTION
Using session cookies (not permanent ones) to allow global admins to impersonate any player. This could probably be enhanced to permit event-specific impersonation by event admins (by adding the event code to the cookie and validating that the impersonator is an event admin) but this will likely do for the short term.