### PR TITLE
Fixing team create experience

### DIFF
--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -122,9 +122,10 @@ namespace ServerCore.Pages.Teams
                 transaction.Commit();
             }
 
-            if(EventRole == ModelBases.EventRole.play)
+            int teamId = GetTeamId().Result;
+            if (EventRole == ModelBases.EventRole.play)
             {
-                return RedirectToPage("./Details");
+                return RedirectToPage("./Details", new { teamId = teamId });
             }
             return RedirectToPage("./Index");
         }

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -122,7 +122,7 @@ namespace ServerCore.Pages.Teams
                 transaction.Commit();
             }
 
-            int teamId = GetTeamId().Result;
+            int teamId = await GetTeamId();
             if (EventRole == ModelBases.EventRole.play)
             {
                 return RedirectToPage("./Details", new { teamId = teamId });


### PR DESCRIPTION
Missed updating the redirect to the 'details' page after creating a team when I added teamId as a required parameter. Fixing that.