### PR TITLE
Fix redirect from puzzle picker to puzzle list missing team id

### DIFF
--- a/ServerCore/Pages/EventSpecific/PH20/PuzzlePicker.cshtml.cs
+++ b/ServerCore/Pages/EventSpecific/PH20/PuzzlePicker.cshtml.cs
@@ -133,7 +133,7 @@ namespace ServerCore.Pages.EventSpecific.PH20
                 transaction.Commit();
             }
 
-            return RedirectToPage("../../Teams/Play", new { EventId = Event.ID, EventRole = EventRole });
+            return RedirectToPage("../../Teams/Play", new { EventId = Event.ID, EventRole = EventRole, teamId = team.ID });
         }
     }
 }


### PR DESCRIPTION
The puzzle picker is supposed to redirect to the puzzle list, but the puzzle list now requires a team id, so add that in.