### PR TITLE
Add check for eventRole  parsing failure

### DIFF
--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -66,8 +66,10 @@ namespace ServerCore.Areas.Identity
             {
                 string eventRole = filterContext.RouteData.Values["eventRole"] as string;
 
-                Enum.TryParse<EventRole>(eventRole, out EventRole role);
-                return role;
+                if (Enum.TryParse<EventRole>(eventRole, out EventRole role))
+                {
+                    return role;
+                }
             }
 
             return EventRole.play;


### PR DESCRIPTION
Only use the parsed EventRole if it parsed correctly.