### PR TITLE
Adds creditable hints

### DIFF
--- a/ServerCore/Pages/Hints/Edit.cshtml
+++ b/ServerCore/Pages/Hints/Edit.cshtml
@@ -13,6 +13,10 @@
     <a asp-page="./Index">Cancel</a>
 </div>
 
+<div>
+    A negative hint cost is treated as the equivalent positive cost
+    and is credited to the cost of other hints. 
+</div>
 <hr />
 <div class="row">
     <div class="col-md-4">

--- a/ServerCore/Pages/Teams/Hints.cshtml
+++ b/ServerCore/Pages/Teams/Hints.cshtml
@@ -81,12 +81,8 @@ You have <b>
         </tr>
     </thead>
     <tbody>
-        @{int discount = Model.Hints.Count == 0 ? 0
-                      : Model.Hints.Min(hws => (hws.IsUnlocked && hws.Hint.Cost < 0) ? hws.Hint.Cost : 0); }
         @foreach (var hint in Model.Hints)
         {
-            int baseCost = Math.Abs(hint.Hint.Cost);
-            int adjustedCost = Math.Max(0, baseCost + discount);
             <tr>
                 <td>
                     @Html.DisplayFor(modelItem => hint.Hint.Description)
@@ -99,43 +95,43 @@ You have <b>
                     else
                     {
                         <b>Cost:</b>
-                        if (discount != 0)
+                        if (hint.AdjustedCost < hint.BaseCost)
                         {
-                            <span class="strike1 strike2">&nbsp;@baseCost&nbsp;</span>
+                            <span class="strike1 strike2">&nbsp;@hint.BaseCost&nbsp;</span>
                         }
-                        if (adjustedCost == 0)
+                        if (hint.AdjustedCost == 0)
                         {
                             <text>FREE</text>
                         }
                         else
                         {
-                            @adjustedCost
+                            @hint.AdjustedCost
                         }
                     }
 
                     @if (!hint.IsUnlocked)
                     {
                         <form method="post" style="display:inline-block">
-                            @if (Model.Team.HintCoinCount >= adjustedCost)
+                            @if (Model.Team.HintCoinCount >= hint.AdjustedCost)
                             {
                                 <button type="submit" asp-route-hintId="@hint.Hint.Id" 
                                     asp-route-teamId="@Model.Team.ID" 
                                     asp-route-puzzleId="@Model.PuzzleID" 
                                     asp-page-handler="Unlock" 
-                                    onclick="return confirm('Are you sure you want to spend @adjustedCost tickets to find out &quot;@hint.Hint.Description&quot;?')" 
+                                    onclick="return confirm('Are you sure you want to spend @hint.AdjustedCost tickets to find out &quot;@hint.Hint.Description&quot;?')" 
                                     style="margin-left: 5px; margin-right: 5px;">Unlock</button>
                             }
                             else
                             {
                                 <button type="submit" disabled 
                                     style="margin-left: 5px; margin-right: 5px;">Unlock</button>
-                                if (adjustedCost - Model.Team.HintCoinCount == 1)
+                                if (hint.AdjustedCost - Model.Team.HintCoinCount == 1)
                                 {
                                     <text>You need 1 more ticket to unlock.</text>
                                 }
                                 else
                                 {
-                                    <text>You need @(adjustedCost - Model.Team.HintCoinCount) more tickets to unlock.</text>
+                                    <text>You need @(hint.AdjustedCost - Model.Team.HintCoinCount) more tickets to unlock.</text>
                                 }
                             }
                         </form>

--- a/ServerCore/Pages/Teams/Hints.cshtml
+++ b/ServerCore/Pages/Teams/Hints.cshtml
@@ -1,6 +1,48 @@
 ﻿@page "/{eventId}/{eventRole}/Teams/{teamId}/Hints/{puzzleId}"
 @model ServerCore.Pages.Teams.HintsModel
 
+<style>
+    button:disabled {
+        color: #aaaaaa;
+    }
+
+    /*
+     * Strikeout style for hints
+     */
+    .strike1 {
+        position: relative;
+    }
+    .strike1:before {
+        color: red;
+        position: absolute;
+        content: "";
+        left: 0;
+        top: 50%;
+        right: 0;
+        border-top: 1px solid;
+        border-color: inherit;
+        -webkit-transform: rotate(-35deg);
+        -moz-transform: rotate(-35deg);
+        -ms-transform: rotate(-35deg);
+        -o-transform: rotate(-35deg);
+        transform: rotate(-35deg);
+    }
+    .strike2:after {
+        color: red;
+        position: absolute;
+        content: "";
+        left: 0;
+        top: 50%;
+        right: 0;
+        border-top: 1px solid;
+        border-color: inherit;
+        -webkit-transform: rotate(35deg);
+        -moz-transform: rotate(35deg);
+        -ms-transform: rotate(35deg);
+        -o-transform: rotate(35deg);
+        transform: rotate(35deg);
+    }
+</style>
 @{
     ViewData["Title"] = "Hints";
     ViewData["AdminRoute"] = "/Puzzles/Index";
@@ -14,7 +56,16 @@
     <a asp-page="/Teams/Play">Back to puzzle list</a>
 </div>
 
-You have @Model.Team.HintCoinCount hint ticket(s).
+You have <b>
+    @if (Model.Team.HintCoinCount > 0)
+    {
+        @Model.Team.HintCoinCount
+    }
+    else
+    {
+        <text>no</text>
+    }
+</b> hint tickets.
 
 <table class="table">
     <thead>
@@ -23,18 +74,19 @@ You have @Model.Team.HintCoinCount hint ticket(s).
                 @Html.DisplayNameFor(model => model.Hints[0].Hint.Description)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Hints[0].Hint.Content)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Hints[0].Hint.Cost)
+                <text>Hint</text>
             </th>
             <th></th>
             <th></th>
         </tr>
     </thead>
     <tbody>
+        @{int discount = Model.Hints.Count == 0 ? 0
+                      : Model.Hints.Min(hws => (hws.IsUnlocked && hws.Hint.Cost < 0) ? hws.Hint.Cost : 0); }
         @foreach (var hint in Model.Hints)
         {
+            int baseCost = Math.Abs(hint.Hint.Cost);
+            int adjustedCost = Math.Max(0, baseCost + discount);
             <tr>
                 <td>
                     @Html.DisplayFor(modelItem => hint.Hint.Description)
@@ -44,41 +96,52 @@ You have @Model.Team.HintCoinCount hint ticket(s).
                     {
                         @Html.DisplayFor(modelItem => hint.Hint.Content)
                     }
-                </td>
-                <td>
-                    @if (!hint.IsUnlocked)
+                    else
                     {
-                        if (hint.Hint.Cost == 0)
+                        <b>Cost:</b>
+                        if (discount != 0)
+                        {
+                            <span class="strike1 strike2">&nbsp;@baseCost&nbsp;</span>
+                        }
+                        if (adjustedCost == 0)
                         {
                             <text>FREE</text>
                         }
                         else
                         {
-                            @Html.DisplayFor(modelItem => hint.Hint.Cost)
+                            @adjustedCost
                         }
                     }
-                </td>
-                <td>
+
                     @if (!hint.IsUnlocked)
                     {
-                    <form method="post">
-                        @if (Model.Team.HintCoinCount >= hint.Hint.Cost)
-                        {
-                            <button type="submit" asp-route-hintId="@hint.Hint.Id" asp-route-teamId="@Model.Team.ID" asp-route-puzzleId="@Model.PuzzleID" asp-page-handler="Unlock" onclick="return confirm('Are you sure you want to spend @hint.Hint.Cost tickets to find out &quot;@hint.Hint.Description&quot;?')">Unlock</button>
-                        }
-                        else
-                        {
-                            <button type="submit" asp-page-handler="Unlock" disabled>Unlock</button>
-                        }
-                    </form>
+                        <form method="post" style="display:inline-block">
+                            @if (Model.Team.HintCoinCount >= adjustedCost)
+                            {
+                                <button type="submit" asp-route-hintId="@hint.Hint.Id" 
+                                    asp-route-teamId="@Model.Team.ID" 
+                                    asp-route-puzzleId="@Model.PuzzleID" 
+                                    asp-page-handler="Unlock" 
+                                    onclick="return confirm('Are you sure you want to spend @adjustedCost tickets to find out &quot;@hint.Hint.Description&quot;?')" 
+                                    style="margin-left: 5px; margin-right: 5px;">Unlock</button>
+                            }
+                            else
+                            {
+                                <button type="submit" disabled 
+                                    style="margin-left: 5px; margin-right: 5px;">Unlock</button>
+                                if (adjustedCost - Model.Team.HintCoinCount == 1)
+                                {
+                                    <text>You need 1 more ticket to unlock.</text>
+                                }
+                                else
+                                {
+                                    <text>You need @(adjustedCost - Model.Team.HintCoinCount) more tickets to unlock.</text>
+                                }
+                            }
+                        </form>
                     }
                 </td>
-                <td>
-                    @if (Model.Team.HintCoinCount < hint.Hint.Cost)
-                    {
-                        <div>@(hint.Hint.Cost - Model.Team.HintCoinCount) more ticket(s) required</div>
-                    }
-                </td>
+                <td></td>
             </tr>
         }
     </tbody>


### PR DESCRIPTION
A hint with negative cost is credited towards the cost of other hints. Note that we compute the discount for other hints as the largest negative hint they've unlocked (Math.Min that is). That's because if they've unlocked two creditable hints, than one of those was credited with the cost of the other one and the net amount they paid was the largest one.

Also reduces the number of columns in the hints page to make the layout simpler. I'll send out a screenshot.