### PR TITLE
Refer to team that IsLookingForTeammmates as accepting "unsolicited" applications

### DIFF
--- a/ServerCore/Pages/Teams/Create.cshtml
+++ b/ServerCore/Pages/Teams/Create.cshtml
@@ -62,10 +62,18 @@ else
                 <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow anonymous applications</label>
-                <p>Checking this box will cause your team to show up in the list of teams that players who are looking for a team can request to join. If you want to manually invite your teammates instead, do not check this box. You will have the opportunity to approve all requests on the website.</p>
-                <input asp-for="Team.IsLookingForTeammates" class="form-control" />
-                <span asp-validation-for="Team.IsLookingForTeammates" class="text-danger"></span>
+                <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow unsolicited applications</label>
+                <table>
+                    <tr>
+                        <td style="width:50px;vertical-align:top;">
+                            <input asp-for="Team.IsLookingForTeammates" class="form-control" />
+                        </td>
+                        <td>
+                            <p>Checking this box will cause your team to show up in the list of teams that players who are looking for a team can request to join. If you want to manually invite your teammates instead, do not check this box. You will have the opportunity to approve all requests on the website.</p>
+                            <span asp-validation-for="Team.IsLookingForTeammates" class="text-danger"></span>
+                        </td>
+                    </tr>
+                </table>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />

--- a/ServerCore/Pages/Teams/Delete.cshtml
+++ b/ServerCore/Pages/Teams/Delete.cshtml
@@ -86,7 +86,7 @@
             }
         </dd>
         <dt>
-            Allow anonymous applications
+            Allow unsolicited applications
         </dt>
         <dd>
             @if (Model.Team.IsLookingForTeammates)

--- a/ServerCore/Pages/Teams/Details.cshtml
+++ b/ServerCore/Pages/Teams/Details.cshtml
@@ -110,7 +110,7 @@
                     }
                 </dd>
                 <dt>
-                    Allow anonymous applications
+                    Allow unsolicited applications
                 </dt>
                 <dd>
                     @if (Model.Team.IsLookingForTeammates)
@@ -216,12 +216,12 @@
                 <br />
                 @if (Model.Team.IsLookingForTeammates)
                 {
-                    <p>Note: Your team is currently marked as looking for anonymous teammates. You may get applications from people who you did not send the link to. To change this, edit your team details <a asp-page="./Edit" asp-route-teamId="@Model.Team.ID"> here</a>.</p>
+                    <p>Note: Your team is currently marked as looking for unsolicited teammates. You may get applications from people who you did not send the link to. To change this, edit your team details <a asp-page="./Edit" asp-route-teamId="@Model.Team.ID"> here</a>.</p>
 
                 }
                 else
                 {
-                    <p>Note: Your team is currently marked as not looking for anonymous teammates. Sending this link is the only way people will find your team. To change this, edit your team details <a asp-page="./Edit" asp-route-teamId="@Model.Team.ID"> here</a>.</p>
+                    <p>Note: Your team is currently marked as not looking for unsolicited teammates. Sending this link is the only way people will find your team. To change this, edit your team details <a asp-page="./Edit" asp-route-teamId="@Model.Team.ID"> here</a>.</p>
                 }
 
 

--- a/ServerCore/Pages/Teams/Edit.cshtml
+++ b/ServerCore/Pages/Teams/Edit.cshtml
@@ -53,10 +53,18 @@
                 <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow anonymous applications</label>
-                <p>Checking this box will cause your team to show up in the list of teams that players who are looking for a team can request to join. If you want to manually invite your teammates instead, do not check this box. You will have the opportunity to approve all requests on the website.</p>
-                <input asp-for="Team.IsLookingForTeammates" class="form-control" />
-                <span asp-validation-for="Team.IsLookingForTeammates" class="text-danger"></span>
+                <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow unsolicited applications</label>
+                <table>
+                    <tr>
+                        <td style="width:50px;vertical-align:top;">
+                            <input asp-for="Team.IsLookingForTeammates" class="form-control"/>
+                        </td>
+                        <td>
+                            <p>Checking this box will cause your team to show up in the list of teams that players who are looking for a team can request to join. If you want to manually invite your teammates instead, do not check this box. You will have the opportunity to approve all requests on the website.</p>
+                            <span asp-validation-for="Team.IsLookingForTeammates" class="text-danger"></span>
+                        </td>
+                    </tr>
+                </table>
             </div>
             <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-default" />


### PR DESCRIPTION
Refer to team that IsLookingForTeammmates as accepting "unsolicited" applications,
not "anonymous" applications as the team members are not anonymous.

Also rearrange to put checkbox to the left of the explanation.