### PR TITLE
Fix blob content type

### DIFF
--- a/ServerCore/FileManager.cs
+++ b/ServerCore/FileManager.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 
@@ -10,6 +11,8 @@ namespace ServerCore
     public class FileManager
     {
         public static string ConnectionString { get; set; }
+
+        static readonly FileExtensionContentTypeProvider fileExtensionProvider = new FileExtensionContentTypeProvider();
 
         /// <summary>
         /// Uploads a file to blob storage
@@ -30,6 +33,10 @@ namespace ServerCore
             CloudBlobDirectory puzzleDirectory = eventContainer.GetDirectoryReference(mangledString);
 
             CloudBlockBlob blob = puzzleDirectory.GetBlockBlobReference(fileName);
+            if (fileExtensionProvider.TryGetContentType(fileName, out string contentType))
+            {
+                blob.Properties.ContentType = contentType;
+            }
             await blob.UploadFromStreamAsync(contents);
             return blob.Uri;
         }


### PR DESCRIPTION
Fix the content type for uploaded blobs. This allows files to run in the browser instead of downloading. 

This still doesn't fix embedding media files (which seems to be triggering an auth redirect for some reason).