### PR TITLE
Zip file upload

### DIFF
--- a/ServerCore/FileManager.cs
+++ b/ServerCore/FileManager.cs
@@ -50,7 +50,7 @@ namespace ServerCore
 
         private static async Task<CloudBlockBlob> CreateNewBlob(string fileName, int eventId)
         {
-            CloudBlobContainer eventContainer = await GetOrCreateEventContainerAsync(eventId);
+            CloudBlobDirectory puzzleDirectory = await GetRandomDirectoryAsync(eventId);
 
             CloudBlockBlob blob = puzzleDirectory.GetBlockBlobReference(fileName);
             if (fileExtensionProvider.TryGetContentType(fileName, out string contentType))

--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml
@@ -19,8 +19,8 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Puzzle.ID" />
             <p>
-                Check this box to automatically extract the contents of zip files in materials or solve tokens into the same directory.
                 <input type="checkbox" asp-for="ExpandZipFiles" />
+                &lt;- Check this box to automatically extract the contents of zip files in materials or solve tokens into the same directory.
             </p>
             <label class="control-label">Puzzle File</label>
             <div>
@@ -57,7 +57,7 @@
             <hr />
 
             <label class="control-label">Materials</label>
-            @foreach (var material in Model.Puzzle.Materials)
+            @foreach (var material in Model.Puzzle.Materials.OrderBy(file => file.ShortName))
             {
                 <p>
                     @Html.ActionLink(material.ShortName, "Index", "Files", new { eventId = Model.Event.ID, filename = material.ShortName })
@@ -70,7 +70,7 @@
             <hr />
 
             <label class="control-label">Solve Token Files</label>
-            @foreach (var solveFile in Model.Puzzle.SolveTokenFiles)
+            @foreach (var solveFile in Model.Puzzle.SolveTokenFiles.OrderBy(file => file.ShortName))
             {
                 <p>
                     @Html.ActionLink(solveFile.ShortName, "Index", "Files", new { eventId = Model.Event.ID, filename = solveFile.ShortName })

--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml
@@ -18,6 +18,10 @@
         <form method="post" enctype="multipart/form-data">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Puzzle.ID" />
+            <p>
+                Check this box to automatically extract the contents of zip files in materials or solve tokens into the same directory.
+                <input type="checkbox" asp-for="ExpandZipFiles" />
+            </p>
             <label class="control-label">Puzzle File</label>
             <div>
                 @{                    


### PR DESCRIPTION
Allow zip files to be uploaded and expanded into a single directory. This is mostly useful for static pages that want to use relative links (e.g. to embed images).

Fixes #65. Fixes #490 