### PR TITLE
Fix exception when there are no hints for a puzzle.

### DIFF
--- a/ServerCore/Pages/Teams/Hints.cshtml.cs
+++ b/ServerCore/Pages/Teams/Hints.cshtml.cs
@@ -59,9 +59,13 @@ namespace ServerCore.Pages.Teams
                              orderby hint.DisplayOrder, hint.Description
                              select new HintWithState { Hint = hint, IsUnlocked = state.IsUnlocked }).ToListAsync();
 
-            int discount = Hints.Min(hws => (hws.IsUnlocked && hws.Hint.Cost < 0) ? hws.Hint.Cost : 0);
-            foreach (HintWithState hint in Hints) {
-                hint.Discount = discount;
+            if (Hints.Count > 0)
+            {
+                int discount = Hints.Min(hws => (hws.IsUnlocked && hws.Hint.Cost < 0) ? hws.Hint.Cost : 0);
+                foreach (HintWithState hint in Hints)
+                {
+                    hint.Discount = discount;
+                }
             }
             return Hints;
         }


### PR DESCRIPTION
Fix an exception when trying to show the hints for a puzzle and there are no hints. Sorry about this.