### PR TITLE
During the beta, once a puzzle is solved, all other hints become free.

### DIFF
--- a/ServerCore/Pages/Teams/Hints.cshtml.cs
+++ b/ServerCore/Pages/Teams/Hints.cshtml.cs
@@ -15,8 +15,6 @@ namespace ServerCore.Pages.Teams
     [Authorize(Policy = "PlayerIsOnTeam")]
     public class HintsModel : EventSpecificPageModel
     {
-        private static bool IsBeta = true;  // TODO: I don't know how to tell if this is a beta; this code seems not to have the event object available
-
         public HintsModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
         {
         }
@@ -65,9 +63,12 @@ namespace ServerCore.Pages.Teams
             if (Hints.Count > 0)
             {
                 int discount = Hints.Min(hws => (hws.IsUnlocked && hws.Hint.Cost < 0) ? hws.Hint.Cost : 0);
+                bool IsBeta = Event.Name.ToLower().Contains("beta");
                 if (solved && IsBeta)
                 {
-                    // During the beta, once a puzzle is solved, all other hints become free.
+                    // During a beta, once a puzzle is solved, all other hints become free.
+                    // There's no IsBeta flag on an event, so check the name.
+                    // We can change this in the unlikely event there's a beta-themed hunt.
                     discount = -999;
                 }
                 foreach (HintWithState hint in Hints)

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -301,6 +301,19 @@ namespace ServerCore
             await context.SaveChangesAsync();
         }
 
+        /// <summary>
+        /// Get the solved status of a single puzzle. 
+        /// Do not use if you want to get status of many puzzles as it will be very inefficient.
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<bool> IsPuzzleSolved(PuzzleServerContext context, int puzzleID, int teamID)
+        {
+            DateTime? solved = await (from PuzzleStatePerTeam pspt in context.PuzzleStatePerTeam
+                                      where pspt.PuzzleID == puzzleID && pspt.TeamID == teamID
+                                      select pspt.SolvedTime).FirstOrDefaultAsync();
+            return solved != null;
+        }
+
         private static DateTime LastGlobalExpiry;
         private static Dictionary<int, DateTime> TimedUnlockExpiryCache = new Dictionary<int, DateTime>();
         private static TimeSpan ClosestExpirySpacing = TimeSpan.FromSeconds(2);


### PR DESCRIPTION
I don't have time to finish testing this now but I have a question so I figure I'd go ahead and upload it and ask. It looks like there is no concept of beta in the app right now. I thought I could check the event name and if it has 'beta' in it, it's a beta. But Hints has no access to the event object. (I think it doesn't actually need it because all the puzzle ids and team ids are unique across all events. Is that right?)

So what I did instead was hardcode `IsBeta = true` and then we would need to redeploy later with that flag set false. Any better ideas?