### PR TITLE
Email Scenarios

### DIFF
--- a/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml.cs
@@ -38,6 +38,15 @@ namespace ServerCore.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnPostAsync(string returnUrl = null)
         {
+            if (string.IsNullOrEmpty(PuzzleUser.Email))
+            {
+                ModelState.AddModelError("PuzzleUser.Email", "An email is required.");
+            }
+            else if (!MailHelper.IsValidEmail(PuzzleUser.Email))
+            {
+                ModelState.AddModelError("PuzzleUser.Email", "This email address is not valid.");
+            }
+
             if (!ModelState.IsValid)
             {
                 return Page();

--- a/ServerCore/Helpers/MailHelper.cs
+++ b/ServerCore/Helpers/MailHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Mail;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 
 /// <summary>
@@ -204,5 +205,33 @@ your email as the contact address for a team, then you also need to remove it on
         Debug.WriteLine("Subject: " + subject);
         Debug.WriteLine("Body: " + body);
         Debug.WriteLine("----------------------------------------");
+    }
+
+    /// <summary>
+    /// Is the string a valid email or list of comma/semicolon-separated emails?
+    /// Errs on the side of allowing false positives rather than having false negatives.
+    /// </summary>
+    public static bool IsValidEmail(string s)
+    {
+        if (string.IsNullOrEmpty(s))
+        {
+            return false;
+        }
+
+        string[] addresses = s.Split(',', ';');
+
+        try
+        {
+            foreach (string address in addresses)
+            {
+                MailAddress mailAddress = new MailAddress(address.Trim());
+            }
+
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
     }
 }

--- a/ServerCore/Helpers/TeamHelper.cs
+++ b/ServerCore/Helpers/TeamHelper.cs
@@ -117,7 +117,7 @@ namespace ServerCore.Helpers
             await context.SaveChangesAsync();
 
             MailHelper.Singleton.SendPlaintextWithoutBcc(new string[] { team.PrimaryContactEmail, user.Email },
-                $"{user.Name} has now joined {team.Name}!",
+                $"{Event.Name}: {user.Name} has now joined {team.Name}!",
                 $"Have a great time!");
 
             return new Tuple<bool, string>(true, "");

--- a/ServerCore/Helpers/TeamHelper.cs
+++ b/ServerCore/Helpers/TeamHelper.cs
@@ -115,6 +115,11 @@ namespace ServerCore.Helpers
 
             context.TeamMembers.Add(Member);
             await context.SaveChangesAsync();
+
+            MailHelper.Singleton.SendPlaintextWithoutBcc(new string[] { team.PrimaryContactEmail, user.Email },
+                $"{user.Name} has now joined {team.Name}!",
+                $"Have a great time!");
+
             return new Tuple<bool, string>(true, "");
         }
     }

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -355,19 +355,19 @@ namespace ServerCore.Pages.Events
                 //
                 // Create teams. Can we add players to these?
                 //
-                Team team1 = new Team { Name = "Team Bugs", Event = Event };
+                Team team1 = new Team { Name = "Team Bugs", Event = Event, IsLookingForTeammates = true };
                 _context.Teams.Add(team1);
 
-                Team team2 = new Team { Name = "Team Babs", Event = Event };
+                Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true };
                 _context.Teams.Add(team2);
 
-                Team team3 = new Team { Name = "Team Buster", Event = Event };
+                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = true };
                 _context.Teams.Add(team3);
 
                 Team teamLoneWolf = null;
                 if (AddCreatorToLoneWolfTeam)
                 {
-                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event };
+                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event, IsLookingForTeammates = true };
                     _context.Teams.Add(teamLoneWolf);
                 }
 

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -361,7 +361,7 @@ namespace ServerCore.Pages.Events
                 Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true };
                 _context.Teams.Add(team2);
 
-                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = true };
+                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = false };
                 _context.Teams.Add(team3);
 
                 Team teamLoneWolf = null;

--- a/ServerCore/Pages/Hints/Edit.cshtml.cs
+++ b/ServerCore/Pages/Hints/Edit.cshtml.cs
@@ -58,11 +58,11 @@ namespace ServerCore.Pages.Hints
 
                 var teamMembers = await (from TeamMembers tm in _context.TeamMembers
                                          join HintStatePerTeam hspt in _context.HintStatePerTeam on tm.Team equals hspt.Team
-                                         where hspt.Hint.Id == Hint.Id
+                                         where hspt.Hint.Id == Hint.Id && hspt.UnlockTime != null
                                          select tm.Member.Email).ToListAsync();
                 MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                    $"Hint updated for '{Hint.Description}' on {puzzleName}",
-                    $"The new content for this hint is: '{Hint.Content}'.");
+                    $"{Event.Name}: Hint updated for {puzzleName}",
+                    $"The new content for '{Hint.Description}' is: '{Hint.Content}'.");
             }
             catch (DbUpdateConcurrencyException)
             {

--- a/ServerCore/Pages/Hints/Edit.cshtml.cs
+++ b/ServerCore/Pages/Hints/Edit.cshtml.cs
@@ -53,6 +53,16 @@ namespace ServerCore.Pages.Hints
             try
             {
                 await _context.SaveChangesAsync();
+
+                var puzzleName = await _context.Hints.Where(m => m.Id == Hint.Id).Select(m => m.Puzzle.Name).FirstOrDefaultAsync();
+
+                var teamMembers = await (from TeamMembers tm in _context.TeamMembers
+                                         join HintStatePerTeam hspt in _context.HintStatePerTeam on tm.Team equals hspt.Team
+                                         where hspt.Hint.Id == Hint.Id
+                                         select tm.Member.Email).ToListAsync();
+                MailHelper.Singleton.SendPlaintextBcc(teamMembers,
+                    $"Hint updated for '{Hint.Description}' on {puzzleName}",
+                    $"The new content for this hint is: '{Hint.Content}'.");
             }
             catch (DbUpdateConcurrencyException)
             {

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -99,7 +99,7 @@ namespace ServerCore.Pages.Submissions
                     var authors = await _context.PuzzleAuthors.Where((pa) => pa.Puzzle == submission.Puzzle).Select((pa) => pa.Author.Email).ToListAsync();
 
                     MailHelper.Singleton.SendPlaintextBcc(authors,
-                        $"Team {submission.Team.Name} is in email mode for {submission.Puzzle.Name}",
+                        $"{Event.Name}: Team {submission.Team.Name} is in email mode for {submission.Puzzle.Name}",
                         "");
                 }
                 else

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -95,6 +95,12 @@ namespace ServerCore.Pages.Submissions
                         submission.Puzzle,
                         submission.Team,
                         true);
+
+                    var authors = await _context.PuzzleAuthors.Where((pa) => pa.Puzzle == submission.Puzzle).Select((pa) => pa.Author.Email).ToListAsync();
+
+                    MailHelper.Singleton.SendPlaintextBcc(authors,
+                        $"Team {submission.Team.Name} is in email mode for {submission.Puzzle.Name}",
+                        "");
                 }
                 else
                 {

--- a/ServerCore/Pages/Teams/Apply.cshtml.cs
+++ b/ServerCore/Pages/Teams/Apply.cshtml.cs
@@ -77,7 +77,7 @@ namespace ServerCore.Pages.Teams
             // TODO I am well aware that it would be far better to include a direct link to the details page,
             // but I cannot for the life of me figure out how to generate a URL for a Razor page.
             MailHelper.Singleton.SendPlaintextWithoutBcc(new string[] { Team.PrimaryContactEmail, LoggedInUser.Email },
-                $"{LoggedInUser.Name} is applying to join {Team.Name}",
+                $"{Event.Name}: {LoggedInUser.Name} is applying to join {Team.Name}",
                 $"To accept or reject this request, visit your team page.");
 
             return Page();

--- a/ServerCore/Pages/Teams/Apply.cshtml.cs
+++ b/ServerCore/Pages/Teams/Apply.cshtml.cs
@@ -74,11 +74,9 @@ namespace ServerCore.Pages.Teams
 
             await _context.SaveChangesAsync();
 
-            // TODO I am well aware that it would be far better to include a direct link to the details page,
-            // but I cannot for the life of me figure out how to generate a URL for a Razor page.
-            MailHelper.Singleton.SendPlaintextWithoutBcc(new string[] { Team.PrimaryContactEmail, LoggedInUser.Email },
+            MailHelper.Singleton.SendPlaintextOneAddress(Team.PrimaryContactEmail,
                 $"{Event.Name}: {LoggedInUser.Name} is applying to join {Team.Name}",
-                $"To accept or reject this request, visit your team page.");
+                $"You can contact {LoggedInUser.Name} at {LoggedInUser.Email}. To accept or reject this request, visit your team page at http://puzzlehunt.azurewebsites.net/{Event.ID}/play/Teams/{Team.ID}/Details.");
 
             return Page();
         }

--- a/ServerCore/Pages/Teams/Apply.cshtml.cs
+++ b/ServerCore/Pages/Teams/Apply.cshtml.cs
@@ -74,6 +74,12 @@ namespace ServerCore.Pages.Teams
 
             await _context.SaveChangesAsync();
 
+            // TODO I am well aware that it would be far better to include a direct link to the details page,
+            // but I cannot for the life of me figure out how to generate a URL for a Razor page.
+            MailHelper.Singleton.SendPlaintextWithoutBcc(new string[] { Team.PrimaryContactEmail, LoggedInUser.Email },
+                $"{LoggedInUser.Name} is applying to join {Team.Name}",
+                $"To accept or reject this request, visit your team page.");
+
             return Page();
         }
     }

--- a/ServerCore/Pages/Teams/Create.cshtml
+++ b/ServerCore/Pages/Teams/Create.cshtml
@@ -35,16 +35,21 @@ else
                 <span asp-validation-for="Team.Name" class="text-danger"></span>
             </div>
             <!-- TODO: Conditionally show/hide based on event property (not needed for PuzzleHunt)
-            <div class="form-group">
-                <label asp-for="Team.RoomID" class="control-label"></label>
-                <input asp-for="Team.RoomID" class="form-control" />
-                <span asp-validation-for="Team.RoomID" class="text-danger"></span>
-            </div>
-            -->
+    <div class="form-group">
+        <label asp-for="Team.RoomID" class="control-label"></label>
+        <input asp-for="Team.RoomID" class="form-control" />
+        <span asp-validation-for="Team.RoomID" class="text-danger"></span>
+    </div>
+    -->
             <div class="form-group">
                 <label asp-for="Team.CustomRoom" class="control-label">Team room</label>
                 <input asp-for="Team.CustomRoom" class="form-control" />
                 <span asp-validation-for="Team.CustomRoom" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Team.PrimaryContactEmail" class="control-label">Primary contact e-mail(s), separated by , or ;</label>
+                <input asp-for="Team.PrimaryContactEmail" class="form-control" />
+                <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Team.PrimaryPhoneNumber" class="control-label">Primary phone number</label>
@@ -55,11 +60,6 @@ else
                 <label asp-for="Team.SecondaryPhoneNumber" class="control-label">Secondary phone number (optional)</label>
                 <input asp-for="Team.SecondaryPhoneNumber" class="form-control" />
                 <span asp-validation-for="Team.SecondaryPhoneNumber" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Team.PrimaryContactEmail" class="control-label">Primary contact e-mail (optional)</label>
-                <input asp-for="Team.PrimaryContactEmail" class="form-control" />
-                <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow unsolicited applications</label>

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -74,6 +74,15 @@ namespace ServerCore.Pages.Teams
                 return NotFound();
             }
 
+            if (string.IsNullOrEmpty(Team.PrimaryContactEmail))
+            {
+                ModelState.AddModelError("Team.PrimaryContactEmail", "An email is required.");
+            }
+            else if (!MailHelper.IsValidEmail(Team.PrimaryContactEmail))
+            {
+                ModelState.AddModelError("Team.PrimaryContactEmail", "This email address is not valid.");
+            }
+
             ModelState.Remove("Team.Event");
             if (!ModelState.IsValid)
             {

--- a/ServerCore/Pages/Teams/Edit.cshtml
+++ b/ServerCore/Pages/Teams/Edit.cshtml
@@ -26,16 +26,21 @@
                 <span asp-validation-for="Team.Name" class="text-danger"></span>
             </div>
             <!-- TODO: Conditionally show/hide based on event property (not needed for PuzzleHunt)
-            <div class="form-group">
-                <label asp-for="Team.RoomID" class="control-label"></label>
-                <input asp-for="Team.RoomID" class="form-control" />
-                <span asp-validation-for="Team.RoomID" class="text-danger"></span>
-            </div>
-            -->
+    <div class="form-group">
+        <label asp-for="Team.RoomID" class="control-label"></label>
+        <input asp-for="Team.RoomID" class="form-control" />
+        <span asp-validation-for="Team.RoomID" class="text-danger"></span>
+    </div>
+    -->
             <div class="form-group">
                 <label asp-for="Team.CustomRoom" class="control-label">Team room</label>
                 <input asp-for="Team.CustomRoom" class="form-control" />
                 <span asp-validation-for="Team.CustomRoom" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Team.PrimaryContactEmail" class="control-label">Primary contact e-mail(s) separated by , or ;</label>
+                <input asp-for="Team.PrimaryContactEmail" class="form-control" />
+                <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Team.PrimaryPhoneNumber" class="control-label">Primary phone number</label>
@@ -48,16 +53,11 @@
                 <span asp-validation-for="Team.SecondaryPhoneNumber" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Team.PrimaryContactEmail" class="control-label">Primary contact e-mail (optional)</label>
-                <input asp-for="Team.PrimaryContactEmail" class="form-control" />
-                <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
-            </div>
-            <div class="form-group">
                 <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow unsolicited applications</label>
                 <table>
                     <tr>
                         <td style="width:50px;vertical-align:top;">
-                            <input asp-for="Team.IsLookingForTeammates" class="form-control"/>
+                            <input asp-for="Team.IsLookingForTeammates" class="form-control" />
                         </td>
                         <td>
                             <p>Checking this box will cause your team to show up in the list of teams that players who are looking for a team can request to join. If you want to manually invite your teammates instead, do not check this box. You will have the opportunity to approve all requests on the website.</p>

--- a/ServerCore/Pages/Teams/Edit.cshtml.cs
+++ b/ServerCore/Pages/Teams/Edit.cshtml.cs
@@ -32,6 +32,15 @@ namespace ServerCore.Pages.Teams
 
         public async Task<IActionResult> OnPostAsync()
         {
+            if (string.IsNullOrEmpty(Team.PrimaryContactEmail))
+            {
+                ModelState.AddModelError("Team.PrimaryContactEmail", "An email is required.");
+            }
+            else if (!MailHelper.IsValidEmail(Team.PrimaryContactEmail))
+            {
+                ModelState.AddModelError("Team.PrimaryContactEmail", "This email address is not valid.");
+            }
+
             ModelState.Remove("Team.Event");
             if (!ModelState.IsValid)
             {

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -572,10 +572,10 @@ namespace ServerCore
 
                     var teamMembers = await (from TeamMembers tm in context.TeamMembers
                                              join Submission sub in context.Submissions on tm.Team equals sub.Team
-                                             where sub.Puzzle == response.Puzzle && sub.SubmissionText == response.SubmittedText
+                                             where sub.PuzzleID == response.PuzzleID && sub.SubmissionText == response.SubmittedText
                                              select tm.Member.Email).ToListAsync();
                     MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                        $"Response updated for '{response.SubmittedText}' on {response.Puzzle.Name}",
+                        $"{puzzle.Event.Name}: {response.Puzzle.Name} Response updated for '{response.SubmittedText}'",
                         $"The new response for this submission is: '{response.ResponseText}'.");
                 }
             }


### PR DESCRIPTION
Using the new emailer class (Thanks, Bruce! Thanks, Roy!), I've implemented mailer support for a few scenarios:

- Applying to join a team (mails the primary contact and the applicant on To, so they can have a discussion)
- Accepting an application (mails the applicant on To)
- Revising/creating a response (mails all team members of teams who submitted that response, on Bcc)
- Revising a hint (mails all team members of teams who asked for that hint, on Bcc)
- Entering email mode (mails all authors of that puzzle, on Bcc)