### PR TITLE
Event Cache

### DIFF
--- a/ServerCore/Helpers/EventHelper.cs
+++ b/ServerCore/Helpers/EventHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +13,11 @@ namespace ServerCore.Helpers
     /// </summary>
     public static class EventHelper
     {
+        private static ConcurrentDictionary<int, Event> eventCacheByInt = new ConcurrentDictionary<int, Event>();
+        private static ConcurrentDictionary<string, Event> eventCacheByString = new ConcurrentDictionary<string, Event>();
+        private static DateTime expiryTime = DateTime.MinValue;
+        private static TimeSpan expiryWindow = TimeSpan.FromMinutes(1);
+
         /// <summary>
         /// Returns the event that matches a given eventId
         /// </summary>
@@ -19,14 +26,36 @@ namespace ServerCore.Helpers
         {
             Event result = null;
 
+            DateTime now = DateTime.UtcNow;
+            if (now > expiryTime)
+            {
+                eventCacheByInt.Clear();
+                eventCacheByString.Clear();
+                expiryTime = now + expiryWindow;
+            }
+            else
+            {
+                if (eventCacheByString.TryGetValue(eventId, out result) || (Int32.TryParse(eventId, out int eventIdInt) && eventCacheByInt.TryGetValue(eventIdInt, out result)))
+                {
+                    return result;
+                }
+            }
+
             // first, lookup by UrlString - this is the friendly name
             result = await puzzleServerContext.Events.Where(e => e.UrlString == eventId).FirstOrDefaultAsync();
 
-            // otherwise, look up by int for legacy event support
-            // TODO: Delete when people have cleaned up their DBs
-            if (result == null && Int32.TryParse(eventId, out int eventIdAsInt))
+            if (result != null)
+            {
+                eventCacheByString[eventId] = result;
+            }
+            else if (Int32.TryParse(eventId, out int eventIdAsInt))
             {
                 result = await puzzleServerContext.Events.Where(e => e.ID == eventIdAsInt).FirstOrDefaultAsync();
+
+                if (result != null)
+                {
+                    eventCacheByInt[eventIdAsInt] = result;
+                }
             }
 
             return result;


### PR DESCRIPTION
Caches lookups from the Events table, since we make a lot of calls to this. This eliminates 5 server roundtrips per page load. The cache expires after 1 minute and is shared among all users and threads.