### PR TITLE
Reduce unnecessary queries

### DIFF
--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -77,11 +77,16 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsEventAdminCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
+            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
+            if (role != EventRole.admin)
+            {
+                return;
+            }
+
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
-            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
 
-            if (thisEvent != null && role == EventRole.admin && await puzzleUser.IsAdminForEvent(dbContext, thisEvent))
+            if (thisEvent != null && await puzzleUser.IsAdminForEvent(dbContext, thisEvent))
             {
                 authContext.Succeed(requirement);
             }
@@ -89,12 +94,17 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsPuzzleAuthorCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
+            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
+            if (role != EventRole.author)
+            {
+                return;
+            }
+
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             Puzzle puzzle = await AuthorizationHelper.GetPuzzleFromContext(authContext);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
-            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
 
-            if (thisEvent != null && role == EventRole.author && await UserEventHelper.IsAuthorOfPuzzle(dbContext, puzzle, puzzleUser))
+            if (thisEvent != null && await UserEventHelper.IsAuthorOfPuzzle(dbContext, puzzle, puzzleUser))
             {
                 authContext.Succeed(requirement);
             }
@@ -107,14 +117,19 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsEventAuthorCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
-            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
+            if (role != EventRole.author)
+            {
+                return;
+            }
+
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
 
             if (authContext.Resource is AuthorizationFilterContext filterContext)
             {
                 Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
 
-                if (thisEvent != null && role == EventRole.author && await puzzleUser.IsAuthorForEvent(dbContext, thisEvent))
+                if (thisEvent != null && await puzzleUser.IsAuthorForEvent(dbContext, thisEvent))
                 {
                     authContext.Succeed(requirement);
                 }
@@ -123,11 +138,16 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsEventPlayerCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
+            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
+            if (role != EventRole.play)
+            {
+                return;
+            }
+
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
-            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
 
-            if (thisEvent != null && role == EventRole.play && await puzzleUser.IsPlayerInEvent(dbContext, thisEvent))
+            if (thisEvent != null && await puzzleUser.IsPlayerInEvent(dbContext, thisEvent))
             {
                 authContext.Succeed(requirement);
             }
@@ -135,12 +155,18 @@ namespace ServerCore.Areas.Identity
 
         public static async Task IsPlayerOnTeamCheck(AuthorizationHandlerContext authContext, PuzzleServerContext dbContext, UserManager<IdentityUser> userManager, IAuthorizationRequirement requirement)
         {
+            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
+
+            if (role != EventRole.play)
+            {
+                return;
+            }
+
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             Team team = await AuthorizationHelper.GetTeamFromContext(authContext);
             Event thisEvent = await AuthorizationHelper.GetEventFromContext(authContext);
-            EventRole role = AuthorizationHelper.GetEventRoleFromContext(authContext);
 
-            if (thisEvent != null && role == EventRole.play)
+            if (thisEvent != null)
             {
                 Team userTeam = await UserEventHelper.GetTeamForPlayer(dbContext, thisEvent, puzzleUser);
                 if (userTeam != null && userTeam.ID == team.ID)

--- a/ServerCore/Helpers/EventHelper.cs
+++ b/ServerCore/Helpers/EventHelper.cs
@@ -19,14 +19,15 @@ namespace ServerCore.Helpers
         {
             Event result = null;
 
-            // first, lookup by UrlString - this is the friendly name
-            result = await puzzleServerContext.Events.Where(e => e.UrlString == eventId).FirstOrDefaultAsync();
-
-            // otherwise, look up by int for legacy event support
-            // TODO: Delete when people have cleaned up their DBs
-            if (result == null && Int32.TryParse(eventId, out int eventIdAsInt))
+            // Decide whether to look up by friendly string or ID
+            if (int.TryParse(eventId, out int eventIdAsInt))
             {
                 result = await puzzleServerContext.Events.Where(e => e.ID == eventIdAsInt).FirstOrDefaultAsync();
+            }
+            else
+            {
+                // first, lookup by UrlString - this is the friendly name
+                result = await puzzleServerContext.Events.Where(e => e.UrlString == eventId).FirstOrDefaultAsync();
             }
 
             return result;

--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -13,7 +13,6 @@ using ServerCore.Helpers;
 
 namespace ServerCore.ModelBases
 {
-    [Authorize(Policy = "IsRegisteredForEvent")]
     public abstract class EventSpecificPageModel : PageModel
     {
         [FromRoute]
@@ -47,31 +46,53 @@ namespace ServerCore.ModelBases
             userManager = manager;
         }
 
+        private bool? isRegisteredUser;
         public async Task<bool> IsRegisteredUser()
         {
             if (LoggedInUser == null)
             {
                 return false;
             }
-            return await LoggedInUser.IsPlayerInEvent(_context, Event);
+
+            if (isRegisteredUser == null)
+            {
+                isRegisteredUser = await LoggedInUser.IsPlayerInEvent(_context, Event);
+            }
+
+            return isRegisteredUser.Value;
         }
 
+
+        private bool? isEventAuthor;
         public async Task<bool> IsEventAuthor()
         {
             if (LoggedInUser == null)
             {
                 return false;
             }
-            return await LoggedInUser.IsAuthorForEvent(_context, Event);
+
+            if (isEventAuthor == null)
+            {
+                isEventAuthor = await LoggedInUser.IsAuthorForEvent(_context, Event);
+            }
+
+            return isEventAuthor.Value;
         }
 
+        private bool? isEventAdmin;
         public async Task<bool> IsEventAdmin()
         {
             if (LoggedInUser == null)
             {
                 return false;
             }
-            return await LoggedInUser.IsAdminForEvent(_context, Event);
+
+            if (isEventAdmin == null)
+            {
+                isEventAdmin = await LoggedInUser.IsAdminForEvent(_context, Event);
+            }
+
+            return isEventAdmin.Value;
         }
 
         public async Task<int> GetTeamId()

--- a/ServerCore/Pages/Events/FastestSolves.cshtml.cs
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
@@ -9,6 +10,7 @@ using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Events
 {
+    [Authorize(Policy = "IsRegisteredForEvent")]
     public class FastestSolvesModel : EventSpecificPageModel
     {
         public List<PuzzleStats> Puzzles { get; private set; }

--- a/ServerCore/Pages/Events/Standings.cshtml.cs
+++ b/ServerCore/Pages/Events/Standings.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
@@ -9,6 +10,7 @@ using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Events
 {
+    [Authorize(Policy = "IsRegisteredForEvent")]
     public class StandingsModel : EventSpecificPageModel
     {
         public List<TeamStats> Teams { get; private set; }


### PR DESCRIPTION
Reduce the number of queries in most page loads by exiting early from non-applicable auth calls, removing the redundant auth from EventSpecificPageModel and caching the results of the role checks used in page layout for the rest of the request. Reduces simple page load time by about 2/3.