### PR TITLE
Errata Visibility

### DIFF
--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -18,7 +18,7 @@
 @if (!string.IsNullOrEmpty(Model.Puzzle.Errata))
 {
     <div style="font-size:16px;">
-        <span style="color: red; font-weight:600;">Errata: </span>@Model.Puzzle.Errata
+        <span style="color: red; font-weight:600;">&#x26A0; Errata: </span>@Model.Puzzle.Errata
     </div>
     <br />
 }

--- a/ServerCore/Pages/Teams/Play.cshtml
+++ b/ServerCore/Pages/Teams/Play.cshtml
@@ -54,7 +54,7 @@
                 @Html.DisplayFor(modelItem => item.Group)
             </td>
             <td>
-                @if (item.Errata != null)
+                @if (!string.IsNullOrWhiteSpace(item.Errata))
                 {
                 <text>&#x26A0; </text>
                 }

--- a/ServerCore/Pages/Teams/Play.cshtml
+++ b/ServerCore/Pages/Teams/Play.cshtml
@@ -54,15 +54,19 @@
             <td>
                 @if (item.Puzzle.CustomURL != null)
                 {
-                    <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.Puzzle, Model.Event.ID)" target="_blank">@item.Puzzle.Name</a>
+                <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.Puzzle, Model.Event.ID)" target="_blank">@item.Puzzle.Name</a>
                 }
                 else if (item.Content != null)
                 {
-                    @Html.ActionLink(item.Puzzle.Name, "Index", "Files", new { eventId = Model.Event.ID, filename = item.Content.ShortName }, new { target = "_blank" })
+                @Html.ActionLink(item.Puzzle.Name, "Index", "Files", new { eventId = Model.Event.ID, filename = item.Content.ShortName }, new { target = "_blank" })
                 }
                 else
                 {
-                    @Html.DisplayFor(modelItem => item.Puzzle.Name)
+                @if (item.Puzzle.Errata != null)
+                {
+                <text>&#x26A0; </text>
+                }
+                @Html.DisplayFor(modelItem => item.Puzzle.Name)
                 }
             </td>
             @if (showAnswers)
@@ -100,3 +104,5 @@
     }
     </tbody>
 </table>
+
+<p>Note: Puzzles with a &#x26A0; before the name have errata, which will be provided on that puzzle's answer submission page.</p>

--- a/ServerCore/Pages/Teams/Play.cshtml.cs
+++ b/ServerCore/Pages/Teams/Play.cshtml.cs
@@ -71,7 +71,7 @@ namespace ServerCore.Pages.Teams
             // Note: EF gotcha is that you have to join into anonymous types in order to not lose valuable stuff
             var visiblePuzzlesQ = from Puzzle puzzle in puzzlesInEventQ
                                   join PuzzleStatePerTeam pspt in stateForTeamQ on puzzle.ID equals pspt.PuzzleID
-                                  select new PuzzleView { ID = puzzle.ID, Group = puzzle.Group, OrderInGroup = puzzle.OrderInGroup, Name = puzzle.Name, CustomUrl = puzzle.CustomURL, SolvedTime = pspt.SolvedTime };
+                                  select new PuzzleView { ID = puzzle.ID, Group = puzzle.Group, OrderInGroup = puzzle.OrderInGroup, Name = puzzle.Name, CustomUrl = puzzle.CustomURL, Errata = puzzle.Errata, SolvedTime = pspt.SolvedTime };
 
             switch (sort ?? DefaultSort)
             {
@@ -146,6 +146,7 @@ namespace ServerCore.Pages.Teams
             public string Group { get; set; }
             public int OrderInGroup { get; set; }
             public string Name { get; set; }
+            public string Errata { get; set; }
             public string CustomUrl { get; set; }
             public DateTime? SolvedTime { get; set; }
             public ContentFile Content { get; set; }


### PR DESCRIPTION
One thing that came out of the last PH20 meeting was that we needed a way for players to know that errata for a puzzle existed. This is that way: a simple caution icon plus an explanation at the bottom for what it means.