### PR TITLE
Fix #424: Don't send emails for Response/Hint Updated when there are …

### DIFF
--- a/ServerCore/Pages/Hints/Edit.cshtml.cs
+++ b/ServerCore/Pages/Hints/Edit.cshtml.cs
@@ -60,9 +60,12 @@ namespace ServerCore.Pages.Hints
                                          join HintStatePerTeam hspt in _context.HintStatePerTeam on tm.Team equals hspt.Team
                                          where hspt.Hint.Id == Hint.Id && hspt.UnlockTime != null
                                          select tm.Member.Email).ToListAsync();
-                MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                    $"{Event.Name}: Hint updated for {puzzleName}",
-                    $"The new content for '{Hint.Description}' is: '{Hint.Content}'.");
+                if (teamMembers.Count > 0)
+                {
+                    MailHelper.Singleton.SendPlaintextBcc(teamMembers,
+                        $"{Event.Name}: Hint updated for {puzzleName}",
+                        $"The new content for '{Hint.Description}' is: '{Hint.Content}'.");
+                }
             }
             catch (DbUpdateConcurrencyException)
             {

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -582,9 +582,12 @@ namespace ServerCore
                                              join Submission sub in context.Submissions on tm.Team equals sub.Team
                                              where sub.PuzzleID == response.PuzzleID && sub.SubmissionText == response.SubmittedText
                                              select tm.Member.Email).ToListAsync();
-                    MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                        $"{puzzle.Event.Name}: {response.Puzzle.Name} Response updated for '{response.SubmittedText}'",
-                        $"The new response for this submission is: '{response.ResponseText}'.");
+                    if (teamMembers.Count > 0)
+                    {
+                        MailHelper.Singleton.SendPlaintextBcc(teamMembers,
+                            $"{puzzle.Event.Name}: {response.Puzzle.Name} Response updated for '{response.SubmittedText}'",
+                            $"The new response for this submission is: '{response.ResponseText}'.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #424: Don't send emails for Response/Hint Updated when there are no actual recipients