### PR TITLE
Hint Visibility and Perf

### DIFF
--- a/ServerCore/Pages/Hints/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Hints/AuthorIndex.cshtml
@@ -44,37 +44,37 @@
                 </th>
                 <th>
                     <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.DescriptionAscending, AuthorIndexModel.SortOrder.DescriptionDescending))">
-                        @Html.DisplayNameFor(model => model.HintStatePerTeam[0].Hint.Description)
+                        @Html.DisplayNameFor(model => model.HintViews[0].Description)
                     </a>
                 </th>
                 <th>
                     <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.CostAscending, AuthorIndexModel.SortOrder.CostDescending))">
-                        @Html.DisplayNameFor(model => model.HintStatePerTeam[0].Hint.Cost)
+                        @Html.DisplayNameFor(model => model.HintViews[0].Cost)
                     </a>
                 </th>
                 <th>
                     <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TimeAscending, AuthorIndexModel.SortOrder.TimeDescending))">
-                        @Html.DisplayNameFor(model => model.HintStatePerTeam[0].UnlockTime)
+                        @Html.DisplayNameFor(model => model.HintViews[0].UnlockTime)
                     </a>
                 </th>
                 <th></th>
             </tr>
         </thead>
         <tbody>
-            @foreach (var item in Model.HintStatePerTeam)
+            @foreach (var item in Model.HintViews)
             {
             <tr>
                 <td>
-                    <a asp-page="AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@item.Team.ID">@Html.DisplayFor(modelItem => item.Team.Name)</a>
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@item.TeamId">@Html.DisplayFor(modelItem => item.TeamName)</a>
                 </td>
                 <td>
-                    <a asp-page="AuthorIndex" asp-route-puzzleId="@item.Hint.Puzzle.ID" asp-route-teamId="@Model.Team?.ID">@Html.DisplayFor(modelItem => item.Hint.Puzzle.Name)</a>
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@item.PuzzleId" asp-route-teamId="@Model.Team?.ID">@Html.DisplayFor(modelItem => item.PuzzleName)</a>
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Hint.Description)
+                    @Html.DisplayFor(modelItem => item.Description)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Hint.Cost)
+                    @Html.DisplayFor(modelItem => item.Cost)
                 </td>
                 <td>
                     @Html.Raw(Model.LocalTime(item.UnlockTime))

--- a/ServerCore/Pages/Teams/Hints.cshtml.cs
+++ b/ServerCore/Pages/Teams/Hints.cshtml.cs
@@ -77,7 +77,7 @@ namespace ServerCore.Pages.Teams
                 }
 
                 // if the event is over, show all hints
-                if (Event.AreAnswersAvailableNow)
+                if (Event.AreAnswersAvailableNow && Team.Name.Contains("Archive"))
                 {
                     foreach (HintWithState hint in Hints)
                     {

--- a/ServerCore/Pages/Teams/Hints.cshtml.cs
+++ b/ServerCore/Pages/Teams/Hints.cshtml.cs
@@ -75,6 +75,15 @@ namespace ServerCore.Pages.Teams
                 {
                     hint.Discount = discount;
                 }
+
+                // if the event is over, show all hints
+                if (Event.AreAnswersAvailableNow)
+                {
+                    foreach (HintWithState hint in Hints)
+                    {
+                        hint.IsUnlocked = true;
+                    }
+                }
             }
             return Hints;
         }


### PR DESCRIPTION
Make all hints visible after the event is over. This helps with archiving.
Improve the perf of the existing hints-taken page.