### PR TITLE
Clean up duplicate submissions

### DIFF
--- a/ServerCore/Pages/Events/MigrateData.cshtml
+++ b/ServerCore/Pages/Events/MigrateData.cshtml
@@ -10,5 +10,5 @@
 
 <form method="post">
     <button type="submit" asp-page-handler="MigrateAdmins">Migrate Admins</button>
-    <button type="submit" asp-page-handler="DeleteDumplicateSubmissions">Delete duplicate submissions</button>
+    <button type="submit" asp-page-handler="DeleteDuplicateSubmissions">Delete duplicate submissions</button>
 </form>

--- a/ServerCore/Pages/Events/MigrateData.cshtml
+++ b/ServerCore/Pages/Events/MigrateData.cshtml
@@ -10,4 +10,5 @@
 
 <form method="post">
     <button type="submit" asp-page-handler="MigrateAdmins">Migrate Admins</button>
+    <button type="submit" asp-page-handler="DeleteDumplicateSubmissions">Delete duplicate submissions</button>
 </form>


### PR DESCRIPTION
Adds a button to clean duplicate submissions out of the system. This will be followed by enforcement to prevent future ones.