### PR TITLE
Sort puzzles by name as a third sort key of other sorts fail

### DIFF
--- a/ServerCore/Pages/Teams/Play.cshtml.cs
+++ b/ServerCore/Pages/Teams/Play.cshtml.cs
@@ -85,10 +85,10 @@ namespace ServerCore.Pages.Teams
                     visiblePuzzlesQ = visiblePuzzlesQ.OrderByDescending(pv => pv.Name);
                     break;
                 case SortOrder.GroupAscending:
-                    visiblePuzzlesQ = visiblePuzzlesQ.OrderBy(pv => pv.Group).ThenBy(pv => pv.OrderInGroup);
+                    visiblePuzzlesQ = visiblePuzzlesQ.OrderBy(pv => pv.Group).ThenBy(pv => pv.OrderInGroup).ThenBy(pv => pv.Name);
                     break;
                 case SortOrder.GroupDescending:
-                    visiblePuzzlesQ = visiblePuzzlesQ.OrderByDescending(pv => pv.Group).ThenByDescending(pv => pv.OrderInGroup);
+                    visiblePuzzlesQ = visiblePuzzlesQ.OrderByDescending(pv => pv.Group).ThenByDescending(pv => pv.OrderInGroup).ThenByDescending(pv => pv.Name);
                     break;
                 case SortOrder.SolveAscending:
                     visiblePuzzlesQ = visiblePuzzlesQ.OrderBy(pv => pv.SolvedTime ?? DateTime.MaxValue);


### PR DESCRIPTION
This keeps puzzles from appearing in essentially random order when everything has the same OrderInGroup (e.g. PuzzleDay)