### PR TITLE
State Map on New Edge

### DIFF
--- a/ServerCore/wwwroot/css/site.css
+++ b/ServerCore/wwwroot/css/site.css
@@ -45,7 +45,7 @@ table.ph-statemap > tbody > tr > td {
     vertical-align: middle;
 }
 
-table.ph-statemap > thead > tr > th:nth-child(1n+5) {
+table.ph-statemap > thead > tr > th:nth-child(1n+5) > a {
     font-weight: normal;
     writing-mode: vertical-rl;
 }


### PR DESCRIPTION
The State Map looks wonky on the new Edge because the text does not rotate. This tweak to the selector works on both the old and the new Edge.