### PR TITLE
Optimize submission

### DIFF
--- a/Data/DataModel/Puzzle.cs
+++ b/Data/DataModel/Puzzle.cs
@@ -60,6 +60,11 @@ namespace ServerCore.DataModel
         /// <summary>
         /// The event the puzzle is a part of
         /// </summary>
+        public int EventID { get; set; }
+
+        /// <summary>
+        /// The event the puzzle is a part of
+        /// </summary>
         [Required]
         public virtual Event Event { get; set; }
 

--- a/Data/DataModel/Team.cs
+++ b/Data/DataModel/Team.cs
@@ -9,6 +9,15 @@ namespace ServerCore.DataModel
     {
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
+
+        /// <summary>
+        /// The event the team is a part of
+        /// </summary>
+        public int EventID { get; set; }
+
+        /// <summary>
+        /// The event the team is a part of
+        /// </summary>
         [Required]
         public virtual Event Event { get; set; }
 

--- a/ServerCore/Pages/Events/MigrateData.cshtml
+++ b/ServerCore/Pages/Events/MigrateData.cshtml
@@ -8,7 +8,13 @@
 
 <p class="text-danger">Do not press any of these buttons unless you know what you're doing!</p>
 
+@if(Model.Status != null)
+{
+    <p class="text-danger">@Model.Status</p>
+}
+
 <form method="post">
-    <button type="submit" asp-page-handler="MigrateAdmins">Migrate Admins</button>
-    <button type="submit" asp-page-handler="DeleteDuplicateSubmissions">Delete duplicate submissions</button>
+    <button type="submit" asp-page-handler="MigrateAdmins">Migrate Admins</button><br />
+    <button type="submit" asp-page-handler="DeleteDuplicateSubmissions">Delete duplicate submissions</button><br />
+    <button type="submit" asp-page-handler="CreateMissingPSPT">Create missing PuzzleStatePerTeam rows</button><br />
 </form>

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -73,10 +73,12 @@
             <form method="post">
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <div class="form-group">
-                    <label asp-for="SubmissionText" class="control-label">Answer</label>
-                    <input asp-for="SubmissionText" class="form-control" />
-                    <span style="font-size:12px">Submitted answers will automatically be capitalized and stripped of non-alphanumeric characters</span>
-                    <span asp-validation-for="SubmissionText" class="text-danger"></span>
+                    <label class="control-label">Answer</label>
+                    <input name="submissionText" class="form-control" data-val="true" data-val-required="Your answer cannot be empty" />
+                    <span style="font-size:12px">Submitted answers will automatically be capitalized and stripped of non-alphanumeric characters</span><br />
+                    @Html.ValidationSummary(true)
+                    <span class="text-danger"><span class="field-validation-valid" data-valmsg-for="submissionText" data-valmsg-replace="true"></span></span>
+                    @*<span asp-validation-for="SubmissionText" class="text-danger"></span>*@
                 </div>
                 <div class="form-group">
                     <input type="submit" value="Submit" class="btn btn-default" />
@@ -91,13 +93,13 @@
         <thead>
             <tr>
                 <th>
-                    @Html.DisplayNameFor(model => model.Submissions[0].TimeSubmitted)
+                    Time Submitted
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Submissions[0].Submitter.Name)
+                    Name
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Submissions[0].SubmissionText)
+                    Submission Text
                 </th>
                 <th>
                     Response
@@ -106,20 +108,20 @@
             </tr>
         </thead>
         <tbody>
-            @for (int i = Model.Submissions.Count-1; i >= 0; --i)
+            @for (int i = Model.SubmissionViews.Count-1; i >= 0; --i)
             {
                 <tr>
                     <td>
-                        @Html.Raw(Model.LocalTime(Model.Submissions[i].TimeSubmitted))
+                        @Html.Raw(Model.LocalTime(Model.SubmissionViews[i].Submission.TimeSubmitted))
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => Model.Submissions[i].Submitter.Name)
+                        @Html.DisplayFor(modelItem => Model.SubmissionViews[i].SubmitterName)
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => Model.Submissions[i].SubmissionText)
+                        @Html.DisplayFor(modelItem => Model.SubmissionViews[i].Submission.SubmissionText)
                     </td>
                     <td>
-                        @(Model.Submissions[i].Response != null ? Model.Submissions[i].Response.ResponseText : "Incorrect")
+                        @(Model.SubmissionViews[i].Response != null ? Model.SubmissionViews[i].Response.ResponseText : "Incorrect")
                     </td>
                 </tr>
             }

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -78,7 +78,6 @@
                     <span style="font-size:12px">Submitted answers will automatically be capitalized and stripped of non-alphanumeric characters</span><br />
                     @Html.ValidationSummary(true)
                     <span class="text-danger"><span class="field-validation-valid" data-valmsg-for="submissionText" data-valmsg-replace="true"></span></span>
-                    @*<span asp-validation-for="SubmissionText" class="text-danger"></span>*@
                 </div>
                 <div class="form-group">
                     <input type="submit" value="Submit" class="btn btn-default" />

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -166,9 +166,6 @@ namespace ServerCore.Pages.Submissions
                 SubmitterName = LoggedInUser.Name
             });
 
-            // Clear the textbox for the next submission
-            ModelState.Clear();
-
             return Page();
         }
 

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -22,8 +22,6 @@ namespace ServerCore.Pages.Submissions
 
         public PuzzleStatePerTeam PuzzleState { get; set; }
 
-        //[BindProperty]
-        //[Required]
         public string SubmissionText { get; set; }
 
         private IList<Submission> Submissions { get; set; }

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -38,8 +38,6 @@ namespace ServerCore
                     .Where(state => state.Puzzle == puzzle && state.Team == team);
             }
 
-#pragma warning disable IDE0031 // despite the compiler message, "teamstate?.UnlockedTime", etc does not compile here
-
             if (puzzle != null)
             {
                 return context.PuzzleStatePerTeam.Where(state => state.Puzzle == puzzle);
@@ -51,7 +49,8 @@ namespace ServerCore
                 {
                     return from state in context.PuzzleStatePerTeam
                            join auth in context.PuzzleAuthors on state.PuzzleID equals auth.PuzzleID
-                           where state.Team == team
+                           where state.Team == team &&
+                           auth.Author == author
                            select state;
                 }
                 else
@@ -59,7 +58,6 @@ namespace ServerCore
                     return context.PuzzleStatePerTeam.Where(state => state.Team == team);
                 }
             }
-#pragma warning restore IDE0031
 
             throw new NotImplementedException("Full event query is NYI and may never be needed; use the sparse one");
         }
@@ -96,7 +94,18 @@ namespace ServerCore
 
             if (team != null)
             {
-                return context.PuzzleStatePerTeam.Where(state => state.Team == team);
+                if (author != null)
+                {
+                    return from state in context.PuzzleStatePerTeam
+                           join auth in context.PuzzleAuthors on state.PuzzleID equals auth.PuzzleID
+                           where state.Team == team &&
+                           auth.Author == author
+                           select state;
+                }
+                else
+                {
+                    return context.PuzzleStatePerTeam.Where(state => state.Team == team);
+                }
             }
 
             return context.PuzzleStatePerTeam.Where(state => state.Puzzle.Event == eventObj);

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -18,6 +18,7 @@ namespace ServerCore
         /// <param name="eventObj">The event we are querying from</param>
         /// <param name="puzzle">The puzzle; if null, get all puzzles in the event.</param>
         /// <param name="team">The team; if null, get all the teams in the event.</param>
+        /// <param name="author">The author; if null get puzzles matching other criteria by all authors</param>
         /// <returns>A query of PuzzleStatePerTeam objects that can be sorted and instantiated, but you can't edit the results.</returns>
         public static IQueryable<PuzzleStatePerTeam> GetFullReadOnlyQuery(PuzzleServerContext context, Event eventObj, Puzzle puzzle, Team team, PuzzleUser author = null)
         {
@@ -34,60 +35,29 @@ namespace ServerCore
             if (puzzle != null && team != null)
             {
                 return context.PuzzleStatePerTeam
-                    .Where(state => state.Puzzle == puzzle && state.Team == team)
-                    .DefaultIfEmpty(new DataModel.PuzzleStatePerTeam()
-                    {
-                        Puzzle = puzzle,
-                        PuzzleID = puzzle.ID,
-                        Team = team,
-                        TeamID = team.ID
-                    });
+                    .Where(state => state.Puzzle == puzzle && state.Team == team);
             }
 
 #pragma warning disable IDE0031 // despite the compiler message, "teamstate?.UnlockedTime", etc does not compile here
 
             if (puzzle != null)
             {
-                IQueryable<Team> teams = context.Teams.Where(t => t.Event == eventObj);
-                IQueryable<PuzzleStatePerTeam> states = context.PuzzleStatePerTeam.Where(state => state.Puzzle == puzzle);
-
-                return from t in teams
-                       join state in states on t.ID equals state.TeamID into tmp
-                       from teamstate in tmp.DefaultIfEmpty()
-                       select new PuzzleStatePerTeam
-                       {
-                           Puzzle = puzzle,
-                           PuzzleID = puzzle.ID,
-                           Team = t,
-                           TeamID = t.ID,
-                           UnlockedTime = teamstate == null ? null : teamstate.UnlockedTime,
-                           SolvedTime = teamstate == null ? null : teamstate.SolvedTime,
-                           Printed = teamstate == null ? false : teamstate.Printed,
-                           Notes = teamstate == null ? null : teamstate.Notes,
-                           IsEmailOnlyMode = teamstate == null ? false : teamstate.IsEmailOnlyMode
-                       };
+                return context.PuzzleStatePerTeam.Where(state => state.Puzzle == puzzle);
             }
 
             if (team != null)
             {
-                IQueryable<Puzzle> puzzles = author == null ? context.Puzzles.Where(p => p.Event == eventObj) : UserEventHelper.GetPuzzlesForAuthorAndEvent(context, eventObj, author);
-                IQueryable<PuzzleStatePerTeam> states = context.PuzzleStatePerTeam.Where(state => state.Team == team);
-
-                return from p in puzzles
-                       join state in states on p.ID equals state.PuzzleID into tmp
-                       from teamstate in tmp.DefaultIfEmpty()
-                       select new PuzzleStatePerTeam
-                       {
-                           Puzzle = p,
-                           PuzzleID = p.ID,
-                           Team = team,
-                           TeamID = team.ID,
-                           UnlockedTime = teamstate == null ? null : teamstate.UnlockedTime,
-                           SolvedTime = teamstate == null ? null : teamstate.SolvedTime,
-                           Printed = teamstate == null ? false : teamstate.Printed,
-                           Notes = teamstate == null ? null : teamstate.Notes,
-                           IsEmailOnlyMode = teamstate == null ? false : teamstate.IsEmailOnlyMode
-                       };
+                if (author != null)
+                {
+                    return from state in context.PuzzleStatePerTeam
+                           join auth in context.PuzzleAuthors on state.PuzzleID equals auth.PuzzleID
+                           where state.Team == team
+                           select state;
+                }
+                else
+                {
+                    return context.PuzzleStatePerTeam.Where(state => state.Team == team);
+                }
             }
 #pragma warning restore IDE0031
 
@@ -143,7 +113,7 @@ namespace ServerCore
         /// <returns>A task that can be awaited for the unlock/lock operation</returns>
         public static async Task SetUnlockStateAsync(PuzzleServerContext context, Event eventObj, Puzzle puzzle, Team team, DateTime? value, PuzzleUser author = null)
         {
-            IQueryable<PuzzleStatePerTeam> statesQ = await PuzzleStateHelper.GetFullReadWriteQueryAsync(context, eventObj, puzzle, team, author);
+            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper.GetFullReadWriteQuery(context, eventObj, puzzle, team, author);
             List<PuzzleStatePerTeam> states = await statesQ.ToListAsync();
 
             for (int i = 0; i < states.Count; i++)
@@ -181,8 +151,8 @@ namespace ServerCore
             DateTime? value,
             PuzzleUser author = null)
         {
-            IQueryable<PuzzleStatePerTeam> statesQ = await PuzzleStateHelper
-                .GetFullReadWriteQueryAsync(context, eventObj, puzzle, team, author);
+            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper
+                .GetFullReadWriteQuery(context, eventObj, puzzle, team, author);
 
             List<PuzzleStatePerTeam> states = await statesQ.ToListAsync();
 
@@ -253,8 +223,8 @@ namespace ServerCore
             bool value,
             PuzzleUser author = null)
         {
-            IQueryable<PuzzleStatePerTeam> statesQ = await PuzzleStateHelper
-                .GetFullReadWriteQueryAsync(context, eventObj, puzzle, team, author);
+            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper
+                .GetFullReadWriteQuery(context, eventObj, puzzle, team, author);
 
             List<PuzzleStatePerTeam> states = await statesQ.ToListAsync();
 
@@ -296,8 +266,8 @@ namespace ServerCore
             DateTime? value,
             PuzzleUser author = null)
         {
-            IQueryable<PuzzleStatePerTeam> statesQ = await PuzzleStateHelper
-                .GetFullReadWriteQueryAsync(context, eventObj, puzzle, team, author);
+            IQueryable<PuzzleStatePerTeam> statesQ = PuzzleStateHelper
+                .GetFullReadWriteQuery(context, eventObj, puzzle, team, author);
 
             List<PuzzleStatePerTeam> states = await statesQ.ToListAsync();
 
@@ -400,62 +370,8 @@ namespace ServerCore
         /// <param name="puzzle">The puzzle; if null, get all puzzles in the event.</param>
         /// <param name="team">The team; if null, get all the teams in the event.</param>
         /// <returns>A query of PuzzleStatePerTeam objects that can be sorted and instantiated, but you can't edit the results.</returns>
-        private static async Task<IQueryable<PuzzleStatePerTeam>> GetFullReadWriteQueryAsync(PuzzleServerContext context, Event eventObj, Puzzle puzzle, Team team, PuzzleUser author)
+        private static IQueryable<PuzzleStatePerTeam> GetFullReadWriteQuery(PuzzleServerContext context, Event eventObj, Puzzle puzzle, Team team, PuzzleUser author)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException("Context required.");
-            }
-
-            if (eventObj == null)
-            {
-                throw new ArgumentNullException("Event required.");
-            }
-
-            if (puzzle != null && team != null)
-            {
-                PuzzleStatePerTeam state = await context.PuzzleStatePerTeam.Where(s => s.Puzzle == puzzle && s.Team == team).FirstOrDefaultAsync();
-                if (state == null)
-                {
-                    context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Puzzle = puzzle, Team = team });
-                }
-            }
-            else if (puzzle != null)
-            {
-                IQueryable<int> teamIdsQ = context.Teams.Where(p => p.Event == eventObj).Select(p => p.ID);
-                IQueryable<int> puzzleStateTeamIdsQ = context.PuzzleStatePerTeam.Where(s => s.Puzzle == puzzle).Select(s => s.TeamID);
-                List<int> teamIdsWithoutState = await teamIdsQ.Except(puzzleStateTeamIdsQ).ToListAsync();
-
-                if (teamIdsWithoutState.Count > 0)
-                {
-                    for (int i = 0; i < teamIdsWithoutState.Count; i++)
-                    {
-                        context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Puzzle = puzzle, TeamID = teamIdsWithoutState[i] });
-                    }
-                }
-            }
-            else if (team != null)
-            {
-                IQueryable<int> puzzleIdsQ = author == null ? context.Puzzles.Where(p => p.Event == eventObj).Select(p => p.ID) : UserEventHelper.GetPuzzlesForAuthorAndEvent(context, eventObj, author).Select(p => p.ID);
-                IQueryable<int> puzzleStatePuzzleIdsQ = context.PuzzleStatePerTeam.Where(s => s.Team == team).Select(s => s.PuzzleID);
-                List<int> puzzleIdsWithoutState = await puzzleIdsQ.Except(puzzleStatePuzzleIdsQ).ToListAsync();
-
-                if (puzzleIdsWithoutState.Count > 0)
-                {
-                    for (int i = 0; i < puzzleIdsWithoutState.Count; i++)
-                    {
-                        context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { Team = team, PuzzleID = puzzleIdsWithoutState[i] });
-                    }
-                }
-            }
-            else if (puzzle == null && team == null)
-            {
-                throw new NotImplementedException("Full event query is NYI and may never be needed");
-            }
-
-            await context.SaveChangesAsync(); // query below will not return these unless we save
-
-            // now this query is no longer sparse because we just filled it all out!
             return GetSparseQuery(context, eventObj, puzzle, team, author);
         }
 
@@ -533,15 +449,8 @@ namespace ServerCore
                     // Enough puzzles unlocked by count? Let's unlock it
                     if (puzzleToUpdate.PrerequisiteIDs.Where(id => solvedPuzzleIDsForTeamT.Contains(id)).Count() >= puzzleToUpdate.MinPrerequisiteCount)
                     {
-                        PuzzleStatePerTeam state = await context.PuzzleStatePerTeam.Where(s => s.PuzzleID == puzzleToUpdate.PuzzleID && s.Team == t).FirstOrDefaultAsync();
-                        if (state == null)
-                        {
-                            context.PuzzleStatePerTeam.Add(new DataModel.PuzzleStatePerTeam() { PuzzleID = puzzleToUpdate.PuzzleID, Team = t, UnlockedTime = unlockTime });
-                        }
-                        else
-                        {
-                            state.UnlockedTime = unlockTime;
-                        }
+                        PuzzleStatePerTeam state = await context.PuzzleStatePerTeam.Where(s => s.PuzzleID == puzzleToUpdate.PuzzleID && s.Team == t).FirstAsync();
+                        state.UnlockedTime = unlockTime;
                     }
                 }
             }


### PR DESCRIPTION
Optimizations for answer submission:
* Remove lazy creation of PuzzleStatePerTeam. We were already creating them eagerly, so this is just removing a backup. Includes a button to generate any that may be missing.
* Don't refresh the submissions page after processing a post request -- this avoids redoing most of the database queries
* Fix the submission page making a separate DB call for every submission that has a response