### PR TITLE
Sort the map columns the other way, and add support for refresh.

### DIFF
--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -24,6 +24,8 @@ namespace ServerCore.ModelBases
         [ModelBinder(typeof(RoleBinder))]
         public EventRole EventRole { get; set; }
 
+        public int? Refresh { get; set; }
+
         /// <summary>
         /// Runs before page actions
         /// </summary>

--- a/ServerCore/Pages/Events/Map.cshtml
+++ b/ServerCore/Pages/Events/Map.cshtml
@@ -9,6 +9,9 @@
 }
 
 <h2>Puzzle State Map</h2>
+<div>
+    Refresh every: <a asp-page="/Events/Map" asp-route-refresh="60">1 min</a> | <a asp-page="/Events/Map" asp-route-refresh="120">2 min</a> | <a asp-page="/Events/Map" asp-route-refresh="300">5 min</a> | <a asp-page="/Events/Map">off</a>
+</div>
 
 <table class="table table-condensed ph-statemap">
             <thead>

--- a/ServerCore/Pages/Events/Map.cshtml.cs
+++ b/ServerCore/Pages/Events/Map.cshtml.cs
@@ -25,8 +25,13 @@ namespace ServerCore.Pages.Events
                         UserManager<IdentityUser> userManager)
             : base(serverContext, userManager) { }
 
-        public async Task<IActionResult> OnGetAsync()
+        public async Task<IActionResult> OnGetAsync(int? refresh)
         {
+            if (refresh != null)
+            {
+                Refresh = refresh;
+            }
+
             // get the puzzles and teams
             List<PuzzleStats> puzzles;
 
@@ -100,7 +105,7 @@ namespace ServerCore.Pages.Events
             }
 
             // sort puzzles by solve count, add the sort index to the lookup
-            puzzles = puzzles.OrderByDescending(p => p.SolveCount)
+            puzzles = puzzles.OrderBy(p => p.SolveCount)
                 .ThenBy(p => p.Puzzle.Name)
                 .ToList();
 

--- a/ServerCore/Pages/Shared/_Layout.cshtml
+++ b/ServerCore/Pages/Shared/_Layout.cshtml
@@ -28,6 +28,14 @@
     }
     <link href="https://fonts.googleapis.com/css?family=Montserrat|Staatliches" rel="stylesheet">
 
+    @{
+        var refresh = (Model as ServerCore.ModelBases.EventSpecificPageModel)?.Refresh;
+        if (refresh.HasValue)
+        {
+            <meta http-equiv="refresh" content="@refresh.Value"/>
+        }
+    }
+
 </head>
 <body>
 @{


### PR DESCRIPTION
Refresh capability is global but only exposed for the map.