### PR TITLE
Make location info less specific for Safari.

### DIFF
--- a/ServerCore/Pages/Resources/ps19/FAQPartial.cshtml
+++ b/ServerCore/Pages/Resources/ps19/FAQPartial.cshtml
@@ -48,8 +48,8 @@
     Your team will have to decide if it's worth the effort to gather Round 1 stamps or if you want to go for
     the full 10 points for the Round 2 stamps. For some hints about strategy, see our Strategy Guide below.</p>
 <h4>What parts of campus does Puzzle Safari cover?</h4>
-<p>Safari takes place on the Microsoft East Campus (also known as Main Campus) east of 156th Avenue, north of
-    28th Street and south of 40th Street. The outdoors of campus is all part of the game, but most stamps are
+<p>Safari traditionally takes place on the Microsoft East Campus (also known as Main Campus) east of 156th Avenue, north of
+    28th Street and south of 40th Street. The outdoors of campus is all part of the game, but many stamps are
     in the Microsoft buildings, so only employees with a badge can effectively collect stamps. A number of
     buildings are restricted by Microsoft Security for safety and for Microsoft business reasons, however!
     Players are not allowed to enter these buildings, even though they are not explicitly marked--it is the
@@ -172,8 +172,8 @@ tear things apart to find them.</b></p>
 <h3>Strategy</h3>
     <p>Here are a few hints to get you started in Puzzle Safari.</p>
     <h4>Getting Ready</h4>
-    <p>Book your conference room as soon as you register, if not sooner. Our central events take place in Building 37, so rooms near
-        there are a good choice. Conference rooms in 37 fill up fast, so book early!</p>
+    <p>Book your conference room as soon as you register, if not sooner. Conference rooms in central locations
+        tend to fill up fast.</p>
     <p>Decide a strategy for playing the game. Do you want to solve a lot of puzzles for two hours and then spend an hour looking for
         stamps, or do you want to send people scouting for stamps early while a few people stay behind and solve puzzles? You'll have
         to decide the winning strategy, but take it from us: the more time you spend on campus looking for stamps the better. One hour

--- a/ServerCore/Pages/Resources/ps19/FAQPartial.cshtml
+++ b/ServerCore/Pages/Resources/ps19/FAQPartial.cshtml
@@ -48,13 +48,13 @@
     Your team will have to decide if it's worth the effort to gather Round 1 stamps or if you want to go for
     the full 10 points for the Round 2 stamps. For some hints about strategy, see our Strategy Guide below.</p>
 <h4>What parts of campus does Puzzle Safari cover?</h4>
-<p>Safari traditionally takes place on the Microsoft East Campus (also known as Main Campus) east of 156th Avenue, north of
-    28th Street and south of 40th Street. The outdoors of campus is all part of the game, but many stamps are
-    in the Microsoft buildings, so only employees with a badge can effectively collect stamps. A number of
-    buildings are restricted by Microsoft Security for safety and for Microsoft business reasons, however!
-    Players are not allowed to enter these buildings, even though they are not explicitly marked--it is the
-    players' responsibility to avoid these buildings. See the <a asp-page="/EventSpecific/Rules">Rules</a> for 
-    the current list of restricted buildings.</p>
+<p>Safari usually takes place on the Microsoft East Campus (also known as Main Campus) east of 156th Avenue
+    and south of 40th Street. The outdoors of campus is all part of the game, but many stamps are hidden 
+    inside the Microsoft buildings, so only employees with a badge can effectively collect stamps.
+    A number of buildings, and all construction areas, are restricted by Microsoft Security for safety and for
+    Microsoft business reasons. Players are not allowed to enter construction areas or the restricted buildings,
+    even though they may not be explicitly marked--it is the players' responsibility to avoid them.
+    See your logbook and listen at the opening ceremony for the current list of restricted buildings.</p>
 <h4>How is Puzzle Safari different from other puzzle events?</h4>
 <p>Puzzle Safari differs in a number of ways:</P>
 <ol>

--- a/ServerCore/Pages/Resources/ps19/RulesPartial.cshtml
+++ b/ServerCore/Pages/Resources/ps19/RulesPartial.cshtml
@@ -48,12 +48,17 @@
     <p>Teams must put each stamp in the appropriate location in their logbooks. Incorrectly stamping a
         logbook forfeits the points earned by that stamp.</p>
     <h3>Avoiding Restricted Areas</h3>
-    <p>The valid building numbers are 16, 17, 18, 19, 25, 30, 31, 32, 36, and 37.
-        This means that you should not look for indoor stamps except in these buildings. Your team's
-        headquarters must also be in one of these buildings. You should not run through other buildings in an
-        effort to find a shortest path between two points. If you think a location clue leads to the inside of
-        a building not on this list you have interpreted it incorrectly. Stamps may be located on the outside
-        of other East Campus buildings not on this list.</p>
+    <p><strong>Do not enter any areas fenced off or barricaded for construction!</strong> Don't take any 
+        shortcuts through these areas, either. Unfortunately, we may not know very far in advance which 
+        areas are off limits on the day of the event, but we will not place any stamps in these areas.
+        Any location clues that appear to send you there are either misunderstood (likely) or incorrect
+        (unlikely, but possible). Email psafari if you are sure a location clue is incorrect.</p>
+    <p>The valid building numbers are given in your logbook. Any updates to the list will be announced in
+        the opening ceremony. This means that you should not look for indoor stamps except in the valid 
+        buildings. Your team's headquarters must also be in one of these buildings. You should not run
+        through other buildings in an effort to find a shortest path between two points. If you think a
+        location clue leads to the inside of a building not on this list, you have interpreted it 
+        incorrectly. Stamps may be located on the outside of other East Campus buildings not on this list.</p>
     <p>The buildings west of 156th (22, 40, 41, 42, 43, and 44), and any
         building with a number greater than 49 are also out of bounds. They're not forbidden, we just didn't
         put any stamps there.</p>

--- a/ServerCore/Pages/Resources/ps19/RulesPartial.cshtml
+++ b/ServerCore/Pages/Resources/ps19/RulesPartial.cshtml
@@ -49,8 +49,8 @@
         logbook forfeits the points earned by that stamp.</p>
     <h3>Avoiding Restricted Areas</h3>
     <p><strong>Do not enter any areas fenced off or barricaded for construction!</strong> Don't take any 
-        shortcuts through these areas, either. Unfortunately, we may not know very far in advance which 
-        areas are off limits on the day of the event, but we will not place any stamps in these areas.
+        shortcuts through these areas, either. Unfortunately, we may not know very far in advance of the
+        event which areas are off limits, but we will not place any stamps in these areas.
         Any location clues that appear to send you there are either misunderstood (likely) or incorrect
         (unlikely, but possible). Email psafari if you are sure a location clue is incorrect.</p>
     <p>The valid building numbers are given in your logbook. Any updates to the list will be announced in
@@ -59,8 +59,7 @@
         through other buildings in an effort to find a shortest path between two points. If you think a
         location clue leads to the inside of a building not on this list, you have interpreted it 
         incorrectly. Stamps may be located on the outside of other East Campus buildings not on this list.</p>
-    <p>The buildings west of 156th (22, 40, 41, 42, 43, and 44), and any
-        building with a number greater than 49 are also out of bounds. They're not forbidden, we just didn't
+    <p>Any buildings not mentioned in your logbook are also out of bounds. They're not forbidden, we just didn't
         put any stamps there.</p>
     <p>Team members must not enter private offices to collect a stamp. Any stamps associated with a private
         office will be velcroed to the relight or door.</p>


### PR DESCRIPTION
Changes Puzzle Safari 19 partial pages to remove specific location info. We have to hold off on identifying event locations for now. 

Include specific verbiage about construction areas being off-limits.