### PR TITLE
Allow downloading a CSV file of all of the teams.

### DIFF
--- a/ServerCore/Helpers/CsvCreationHelper.cs
+++ b/ServerCore/Helpers/CsvCreationHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CsvHelper;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ServerCore.Helpers
+{
+    /// <summary>
+    /// Helpers for creating CSV files.
+    /// </summary>
+    public class CsvCreationHelper
+    {
+        /// <summary>
+        /// Create a CSV file for download from the list of records.
+        /// </summary>
+        /// <param name="records">Records with public properties that are the columns of the CSV.</param>
+        /// <param name="fileName">Base file name for the downloaded file.</param>
+        /// <returns>A FileContentResult with the CSV file.</returns>
+        public static FileContentResult CreateCsvFileResult<T>(List<T> records, string fileName)
+        {
+            MemoryStream stream = new MemoryStream();
+
+            using (TextWriter textWriter = new StreamWriter(stream))
+            {
+                CsvWriter csvWriter = new CsvWriter(textWriter);
+                csvWriter.WriteRecords(records);
+            }
+
+            return new FileContentResult(stream.ToArray(), "text/csv") { FileDownloadName = fileName };
+        }
+    }
+}

--- a/ServerCore/Pages/Teams/Csv.cshtml
+++ b/ServerCore/Pages/Teams/Csv.cshtml
@@ -1,0 +1,3 @@
+﻿@page "/{eventId}/{eventRole}/Teams/Csv"
+@model ServerCore.Pages.Teams.CsvModel
+@* No HTML - Get downloads a CSV file *@

--- a/ServerCore/Pages/Teams/Csv.cshtml.cs
+++ b/ServerCore/Pages/Teams/Csv.cshtml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Teams
+{
+    [Authorize(Policy = "IsEventAdminOrEventAuthor")]
+    public class CsvModel : TeamListBase
+    {
+        public CsvModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) 
+            : base(serverContext, userManager)
+        {
+
+        }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            await LoadTeamDataAsync();
+            var teamCsvRecords = (from team in Teams
+                                  select new
+                                  {
+                                      Name = team.Name,
+                                      Size = PlayerCountByTeamID[team.ID],
+                                      Room = team.CustomRoom,
+                                      Email = team.PrimaryContactEmail,
+                                      PrimaryPhoneNumber = team.PrimaryPhoneNumber,
+                                      SecondaryPhoneNumber = team.SecondaryPhoneNumber,
+
+                                  }).ToList();
+
+            return CsvCreationHelper.CreateCsvFileResult(teamCsvRecords, "Teams.csv");
+        }
+    }
+}

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -58,10 +58,10 @@
     <div>
         Summaries:
         <a asp-page="/Teams/TeamCompositionSummary">Team Composition</a> @("|")
-        @if (Model.Event.IsInternEvent)
-        {
+        @if (Model.Event.IsInternEvent) {
             <a asp-page="/Swag/Report">Intern T-shirts and Lunch</a> @("|")
         }
+        <a asp-page="Csv">Download CSV File</a> @("|")
     </div>
     <br />
     <a asp-page="/Events/Mailer" asp-route-group="PrimaryContacts">Email all team primary contacts from the bulk mailer</a>

--- a/ServerCore/ServerCore.csproj
+++ b/ServerCore/ServerCore.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.9.406" />
+    <PackageReference Include="CsvHelper" Version="12.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="2.0.2" />


### PR DESCRIPTION
This PR adds a link to the admin teams display that allows downloading a CSV file with a summary of all of the teams. This is useful for Puzzle Safari to move team information into the Puzzle Safari day-of-event management system.