### PR TITLE
Answer submission page magic

### DIFF
--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -14,9 +14,11 @@
     
     // to: Add the proper support agent as recipient
     mailtoUrl += Model.PuzzleState?.Puzzle.SupportEmailAlias ?? (Model.Event?.ContactEmail ?? "puzzhunt@microsoft.com");
+    // cc: Cc the team's email address because what if this email account is a random personal one?
+    mailtoUrl += "?cc=" + Uri.EscapeDataString(Model.Team.PrimaryContactEmail);
 
     // subject: Make this be about this puzzle
-    mailtoUrl += "?subject=" + Uri.EscapeDataString("[" + Model.Puzzle.Name + "]");
+    mailtoUrl += "&subject=" + Uri.EscapeDataString("[" + Model.Puzzle.Name + "]");
     // subject: Make this be from this team
     mailtoUrl += Uri.EscapeDataString(" [" + Model.Team.Name + "]");
 
@@ -70,7 +72,7 @@
         else if (!@Model.Event.IsAnswerSubmissionActive)
         {
             <div class="col-md-12" style="padding-bottom: 15px;">
-                <h4>Answer Submissions Closed</h4>
+                <h4>Answer Submission Closed</h4>
                 <span>No submissions will be accepted at this time.</span>
             </div>
         }
@@ -78,21 +80,21 @@
         {
             <div class="alert alert-danger" role="alert">
                 <h4>Answer Submission Locked Indefinitely</h4>
-                <span>You have submitted too many wrong responses. Please <a href="@mailtoUrl">use this link to submit your answer for @Model.Puzzle.Name or ask for help</a>.</span>
+                <span>You've submitted too many wrong responses. Please <a href="@mailtoUrl">use this link to email us your answer for @Model.Puzzle.Name or ask for help</a>.</span>
             </div>
         }
         else if (Model.PuzzleState.IsTeamLockedOut)
         {
             <div class="alert alert-danger" role="alert">
                 <h4>Answer Submission Locked</h4>
-                <span>You are locked out. Please wait <span id="LockoutTimer">@Model.PuzzleState.LockoutTimeRemaining.ToString(@"mm\:ss")</span> before attempting another submission.</span>
+                <span>You're locked out. Please wait <span id="LockoutTimer">@Model.PuzzleState.LockoutTimeRemaining.ToString(@"mm\:ss")</span> before attempting another submission.</span>
             </div>
         }
         else if (Model.PuzzlesCausingGlobalLockout.Count != 0 && !Model.PuzzlesCausingGlobalLockout.Contains(Model.Puzzle))
         {
             <div class="alert alert-danger" role="alert">
                 <h4>Answer Submission Locked</h4>
-                <span>You are in global lockout until time expires on '@Model.PuzzlesCausingGlobalLockout[0].Name', or it is solved. Go help your teammates with that puzzle!</span>
+                <span>You're in global lockout until time expires on <a href="./@Model.PuzzlesCausingGlobalLockout[0].ID" target="_blank">@Model.PuzzlesCausingGlobalLockout[0].Name</a>, or it is solved. Go help your teammates with that puzzle!</span>
             </div>
         }
         else
@@ -101,7 +103,7 @@
             {
             <div class="alert alert-danger" role="alert">
                 <h4>Oops</h4>
-                <span>You already submitted @Model.SubmissionText!</span>
+                <span>You've already submitted @Model.SubmissionText!</span>
             </div>
             }
 
@@ -194,7 +196,7 @@
                 }
                 var timeDeltaSeconds = Math.floor((unlockTime - Date.now()) / 1000);
                 if (timeDeltaSeconds <= 0) {
-                    window.location.reload(false);
+                    window.location.href = window.location.href;
                 }
                 // Prevent negative time, also pad with zero
                 var minutesLeft = "0" + Math.max(0, Math.floor(timeDeltaSeconds / 60));

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -10,26 +10,30 @@
 }
 
 @{
-    var mailtoUrlBase = "mailto:";
-    var mailtoUrlForEmailMode = "";
-    var mailtoUrlForHelp = "";
-
+    var mailtoUrl = "mailto:";
+    
     // to: Add the proper support agent as recipient
-    mailtoUrlBase += Model.PuzzleState?.Puzzle.SupportEmailAlias ?? (Model.Event?.ContactEmail ?? "puzzhunt@microsoft.com");
+    mailtoUrl += Model.PuzzleState?.Puzzle.SupportEmailAlias ?? (Model.Event?.ContactEmail ?? "puzzhunt@microsoft.com");
 
     // subject: Make this be about this puzzle
-    mailtoUrlBase += "?subject=[" + Uri.EscapeDataString(Model.Puzzle.Name) + "]";
+    mailtoUrl += "?subject=" + Uri.EscapeDataString("[" + Model.Puzzle.Name + "]");
     // subject: Make this be from this team
-    mailtoUrlBase += " [" + Uri.EscapeDataString(Model.Team.Name) + "]";
+    mailtoUrl += Uri.EscapeDataString(" [" + Model.Team.Name + "]");
 
-    // request out of email mode
-    // subject: Add the Email Mode signifier
-    mailtoUrlForEmailMode = mailtoUrlBase + Uri.EscapeDataString(" [⚠EmailMode✉]");
-    mailtoUrlForEmailMode += "&body=" + Uri.EscapeDataString("Use this email to fully explain your thought process so we know you're not randomly spamming attempts! 😇" + Environment.NewLine + Environment.NewLine);
-
-    // request for help
-    // body: Invite solver to give details
-    mailtoUrlForHelp = mailtoUrlBase + "&body=" + Uri.EscapeDataString("The more details you add here, the more helpful the responses you'll get will be! 😇" + Environment.NewLine + Environment.NewLine);
+    if (Model.PuzzleState.IsEmailOnlyMode)
+    {
+        // request out of email mode
+        // subject: Add the Email Mode signifier
+        mailtoUrl += Uri.EscapeDataString(" [⚠EmailMode✉]");
+        // body: Invite solver to give details
+        mailtoUrl += "&body=" + Uri.EscapeDataString("Use this email to fully explain your thought process so we know you're not randomly spamming attempts! 😇" + Environment.NewLine + Environment.NewLine);
+    }
+    else
+    {
+        // request for help
+        // body: Invite solver to give details
+        mailtoUrl += "&body=" + Uri.EscapeDataString("The more details you add here, the more helpful the responses you'll get will be! 😇" + Environment.NewLine + Environment.NewLine);
+    }
 }
 
 
@@ -59,40 +63,46 @@
         @if (!string.IsNullOrEmpty(Model.AnswerToken))
         {
             <div class="alert alert-success" role="alert">
-                You got it! Correct answer: @Model.AnswerToken
+                <h4>Correct</h4>
+                <span>Answer: @Model.AnswerToken</span>
             </div>
         }
         else if (!@Model.Event.IsAnswerSubmissionActive)
         {
             <div class="col-md-12" style="padding-bottom: 15px;">
-                <h3>This event is not in session. No submissions will be accepted at this time.</h3>
+                <h4>Answer Submissions Closed</h4>
+                <span>No submissions will be accepted at this time.</span>
             </div>
         }
         else if (Model.PuzzleState.IsEmailOnlyMode)
         {
             <div class="alert alert-danger" role="alert">
-                You have submitted too many wrong responses. Please <a href="@mailtoUrlForEmailMode">use this link to submit your answer for @Model.Puzzle.Name or ask for help</a>.
+                <h4>Answer Submission Locked Indefinitely</h4>
+                <span>You have submitted too many wrong responses. Please <a href="@mailtoUrl">use this link to submit your answer for @Model.Puzzle.Name or ask for help</a>.</span>
             </div>
         }
         else if (Model.PuzzleState.IsTeamLockedOut)
         {
             <div class="alert alert-danger" role="alert">
-                You are locked out. Please wait <span id="LockoutTimer">@Model.PuzzleState.LockoutTimeRemaining.ToString(@"mm\:ss")</span> before attempting another submission.
+                <h4>Answer Submission Locked</h4>
+                <span>You are locked out. Please wait <span id="LockoutTimer">@Model.PuzzleState.LockoutTimeRemaining.ToString(@"mm\:ss")</span> before attempting another submission.</span>
             </div>
         }
         else if (Model.PuzzlesCausingGlobalLockout.Count != 0 && !Model.PuzzlesCausingGlobalLockout.Contains(Model.Puzzle))
         {
             <div class="alert alert-danger" role="alert">
-                You are in global lockout until time expires on '@Model.PuzzlesCausingGlobalLockout[0].Name', or it is solved. Go help your teammates with that puzzle!
+                <h4>Answer Submission Locked</h4>
+                <span>You are in global lockout until time expires on '@Model.PuzzlesCausingGlobalLockout[0].Name', or it is solved. Go help your teammates with that puzzle!</span>
             </div>
         }
         else
         {
             if (Model.DuplicateSubmission)
             {
-                <div class="alert alert-danger" role="alert">
-                    You already submitted @Model.SubmissionText!
-                </div>
+            <div class="alert alert-danger" role="alert">
+                <h4>Oops</h4>
+                <span>You already submitted @Model.SubmissionText!</span>
+            </div>
             }
 
             <form method="post">
@@ -112,54 +122,55 @@
     </div>
 </div>
 
-<h3>Submission history</h3>
-<div>
-    <table class="table">
-        <thead>
-            <tr>
-                <th>
-                    Time Submitted
-                </th>
-                <th>
-                    Name
-                </th>
-                <th>
-                    Submission Text
-                </th>
-                <th>
-                    Response
-                </th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @for (int i = Model.SubmissionViews.Count - 1; i >= 0; --i)
-            {
+@if (Model.SubmissionViews.Count > 0)
+{
+    <h3>Submission history</h3>
+    <div>
+        <table class="table">
+            <thead>
                 <tr>
-                    <td>
-                        @Html.Raw(Model.LocalTime(Model.SubmissionViews[i].Submission.TimeSubmitted))
-                    </td>
-                    <td>
-                        @Html.DisplayFor(modelItem => Model.SubmissionViews[i].SubmitterName)
-                    </td>
-                    <td>
-                        @Html.DisplayFor(modelItem => Model.SubmissionViews[i].Submission.SubmissionText)
-                    </td>
-                    <td>
-                        @(Model.SubmissionViews[i].Response != null ? Model.SubmissionViews[i].Response.ResponseText : "Incorrect")
-                    </td>
+                    <th>
+                        Time Submitted
+                    </th>
+                    <th>
+                        Name
+                    </th>
+                    <th>
+                        Submission Text
+                    </th>
+                    <th>
+                        Response
+                    </th>
+                    <th></th>
                 </tr>
-            }
-        </tbody>
-    </table>
-</div>
+            </thead>
+            <tbody>
+                @for (int i = Model.SubmissionViews.Count - 1; i >= 0; --i)
+                {
+                    <tr>
+                        <td>
+                            @Html.Raw(Model.LocalTime(Model.SubmissionViews[i].Submission.TimeSubmitted))
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => Model.SubmissionViews[i].SubmitterName)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => Model.SubmissionViews[i].Submission.SubmissionText)
+                        </td>
+                        <td>
+                            @(Model.SubmissionViews[i].Response != null ? Model.SubmissionViews[i].Response.ResponseText : "Incorrect")
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
 
 @if (!Model.PuzzleState.IsEmailOnlyMode)
-{
-    // if we are in EmailMode, we shouldn't show this section because there's that other
-    // call-to-action with a mailto link that solvers should use instead
+{ 
     <h3>Need some help?</h3>
-    <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a href="@mailtoUrlForHelp">use this link to contact the author for @Model.Puzzle.Name</a>!</p>
+    <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a href="@mailtoUrl">use this link to contact the author for @Model.Puzzle.Name</a>!</p>
     <p>A pre-populated email form will appear and you should add details to the message body. Remember: the author may only know specifics about this puzzle and not others in the event.</p>
 }
 
@@ -185,9 +196,10 @@
                 if (timeDeltaSeconds <= 0) {
                     window.location.reload(false);
                 }
-                var minutesLeft = Math.floor(timeDeltaSeconds / 60);
-                var secondsLeft = timeDeltaSeconds % 60;
-                timer.innerText = minutesLeft + ":" + (secondsLeft < 10 ? "0" + secondsLeft : secondsLeft);
+                // Prevent negative time, also pad with zero
+                var minutesLeft = "0" + Math.max(0, Math.floor(timeDeltaSeconds / 60));
+                var secondsLeft = "0" + Math.max(0, timeDeltaSeconds % 60);
+                timer.innerText = minutesLeft.substr(-2) + ":" + secondsLeft.substr(-2);
             }, 1000);
         </script>
     }

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -9,6 +9,31 @@
     ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
 }
 
+@{
+    var mailtoUrlBase = "mailto:";
+    var mailtoUrlForEmailMode = "";
+    var mailtoUrlForHelp = "";
+
+    // to: Add the proper support agent as recipient
+    mailtoUrlBase += Model.PuzzleState?.Puzzle.SupportEmailAlias ?? (Model.Event?.ContactEmail ?? "puzzhunt@microsoft.com");
+
+    // subject: Make this be about this puzzle
+    mailtoUrlBase += "?subject=[" + Uri.EscapeDataString(Model.Puzzle.Name) + "]";
+    // subject: Make this be from this team
+    mailtoUrlBase += " [" + Uri.EscapeDataString(Model.Team.Name) + "]";
+
+    // request out of email mode
+    // subject: Add the Email Mode signifier
+    mailtoUrlForEmailMode = mailtoUrlBase + Uri.EscapeDataString(" [⚠EmailMode✉]");
+    mailtoUrlForEmailMode += "&body=" + Uri.EscapeDataString("Use this email to fully explain your thought process so we know you're not randomly spamming attempts! 😇" + Environment.NewLine + Environment.NewLine);
+
+    // request for help
+    // body: Invite solver to give details
+    mailtoUrlForHelp = mailtoUrlBase + "&body=" + Uri.EscapeDataString("The more details you add here, the more helpful the responses you'll get will be! 😇" + Environment.NewLine + Environment.NewLine);
+}
+
+
+
 <h2>Submissions for @Model.Puzzle.Name</h2>
 <hr />
 <div>
@@ -26,9 +51,9 @@
     <div class="col-md-4">
         @if (Model.Puzzle.HasDataConfirmation)
         {
-        <div style="font-style:italic;">
-            <img src="~/images/DataConfirmationIcon.png" width="20" height="20" style="margin-bottom:3px" /> Reminder: This puzzle supports data confirmation
-        </div>
+            <div style="font-style:italic;">
+                <img src="~/images/DataConfirmationIcon.png" width="20" height="20" style="margin-bottom:3px" /> Reminder: This puzzle supports data confirmation
+            </div>
             <br />
         }
         @if (!string.IsNullOrEmpty(Model.AnswerToken))
@@ -46,7 +71,7 @@
         else if (Model.PuzzleState.IsEmailOnlyMode)
         {
             <div class="alert alert-danger" role="alert">
-                You have submitted too many wrong responses. Please email your solutions to <a href="mailto:@(Model.PuzzleState?.Puzzle.SupportEmailAlias ?? (Model.Event?.ContactEmail ?? "puzzhunt@microsoft.com"))">@(Model.PuzzleState?.Puzzle.SupportEmailAlias ?? (Model.Event?.ContactEmail ?? "puzzhunt@microsoft.com"))</a>.
+                You have submitted too many wrong responses. Please <a href="@mailtoUrlForEmailMode">use this link to submit your answer for @Model.Puzzle.Name or ask for help</a>.
             </div>
         }
         else if (Model.PuzzleState.IsTeamLockedOut)
@@ -63,7 +88,7 @@
         }
         else
         {
-             if (Model.DuplicateSubmission)
+            if (Model.DuplicateSubmission)
             {
                 <div class="alert alert-danger" role="alert">
                     You already submitted @Model.SubmissionText!
@@ -74,7 +99,7 @@
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <div class="form-group">
                     <label class="control-label">Answer</label>
-                    <input name="submissionText" class="form-control" data-val="true" data-val-required="Your answer cannot be empty" />
+                    <input autofocus name="submissionText" class="form-control" data-val="true" data-val-required="Your answer cannot be empty" />
                     <span style="font-size:12px">Submitted answers will automatically be capitalized and stripped of non-alphanumeric characters</span><br />
                     @Html.ValidationSummary(true)
                     <span class="text-danger"><span class="field-validation-valid" data-valmsg-for="submissionText" data-valmsg-replace="true"></span></span>
@@ -87,6 +112,7 @@
     </div>
 </div>
 
+<h3>Submission history</h3>
 <div>
     <table class="table">
         <thead>
@@ -107,7 +133,7 @@
             </tr>
         </thead>
         <tbody>
-            @for (int i = Model.SubmissionViews.Count-1; i >= 0; --i)
+            @for (int i = Model.SubmissionViews.Count - 1; i >= 0; --i)
             {
                 <tr>
                     <td>
@@ -127,6 +153,15 @@
         </tbody>
     </table>
 </div>
+
+@if (!Model.PuzzleState.IsEmailOnlyMode)
+{
+    // if we are in EmailMode, we shouldn't show this section because there's that other
+    // call-to-action with a mailto link that solvers should use instead
+    <h3>Need some help?</h3>
+    <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a href="@mailtoUrlForHelp">use this link to contact the author for @Model.Puzzle.Name</a>!</p>
+    <p>A pre-populated email form will appear and you should add details to the message body. Remember: the author may only know specifics about this puzzle and not others in the event.</p>
+}
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -55,32 +55,32 @@ namespace ServerCore.Pages.Submissions
             SubmissionText = submissionText;
             if (!this.Event.IsAnswerSubmissionActive)
             {
-                return Page();
+                return RedirectToPage();
             }
 
             await SetupContext(puzzleId);
 
             if (!ModelState.IsValid)
             {
-                return Page();
+                return RedirectToPage();
             }
             
             // Don't allow submissions if the team is locked out.
             if (PuzzleState.IsTeamLockedOut)
             {
-                return Page();
+                return RedirectToPage();
             }
 
             // Don't allow submissions after the answer has been found.
             if (PuzzleState.SolvedTime != null)
             {
-                return Page();
+                return RedirectToPage();
             }
 
             // Don't accept posted submissions when a puzzle is causing lockout
             if (PuzzlesCausingGlobalLockout.Count != 0 && !PuzzlesCausingGlobalLockout.Contains(Puzzle))
             {
-                return Page();
+                return RedirectToPage();
             }
 
             // Soft enforcement of duplicates to give a friendly message in most cases
@@ -90,7 +90,7 @@ namespace ServerCore.Pages.Submissions
 
             if (DuplicateSubmission)
             {
-                return Page();
+                return RedirectToPage();
             }
 
             // Create submission and add it to list
@@ -170,7 +170,7 @@ namespace ServerCore.Pages.Submissions
                 SubmitterName = LoggedInUser.Name
             });
 
-            return Page();
+            return RedirectToPage();
         }
 
         public async Task<IActionResult> OnGetAsync(int puzzleId)

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -55,32 +55,32 @@ namespace ServerCore.Pages.Submissions
             SubmissionText = submissionText;
             if (!this.Event.IsAnswerSubmissionActive)
             {
-                return RedirectToPage();
+                return Page();
             }
 
             await SetupContext(puzzleId);
 
             if (!ModelState.IsValid)
             {
-                return RedirectToPage();
+                return Page();
             }
             
             // Don't allow submissions if the team is locked out.
             if (PuzzleState.IsTeamLockedOut)
             {
-                return RedirectToPage();
+                return Page();
             }
 
             // Don't allow submissions after the answer has been found.
             if (PuzzleState.SolvedTime != null)
             {
-                return RedirectToPage();
+                return Page();
             }
 
             // Don't accept posted submissions when a puzzle is causing lockout
             if (PuzzlesCausingGlobalLockout.Count != 0 && !PuzzlesCausingGlobalLockout.Contains(Puzzle))
             {
-                return RedirectToPage();
+                return Page();
             }
 
             // Soft enforcement of duplicates to give a friendly message in most cases
@@ -90,7 +90,7 @@ namespace ServerCore.Pages.Submissions
 
             if (DuplicateSubmission)
             {
-                return RedirectToPage();
+                return Page();
             }
 
             // Create submission and add it to list
@@ -170,7 +170,7 @@ namespace ServerCore.Pages.Submissions
                 SubmitterName = LoggedInUser.Name
             });
 
-            return RedirectToPage();
+            return Page();
         }
 
         public async Task<IActionResult> OnGetAsync(int puzzleId)


### PR DESCRIPTION
##Bunch'a fixes

#528 
- submission history not shown if submitted nothing
- a ton of error messages friendlified
- answer submission box autofocused
- lockout timer can no longer go negative

#531 
Fixed (Edit: NOT) by using the POST -> REDIRECT -> GET trick so that when the POST happens, we redirect to a GET call, thereby avoiding the "did you want to resend the submission" scenario.

Edit: THIS HAS BEEN REVERTED because it would cause a 2x increase in page load.

#526 
Fixed by changing 
```
                if (timeDeltaSeconds <= 0) {
                    window.location.reload(false)
                }
```
to
```
                if (timeDeltaSeconds <= 0) {
                    window.location.href = window.location.href;
                }
```

#517 
- mailto link will now exist
- and have the right data in it 
- and BONUS: CC the team in case some random email account was used 
- and BONUS: be different for if you're in Email Mode

#530
![image](https://user-images.githubusercontent.com/836760/60376689-7d38eb00-99c5-11e9-871e-c83ab4e2c17d.png)
