### PR TITLE
Team Merge Capability

### DIFF
--- a/ServerCore/Helpers/TeamHelper.cs
+++ b/ServerCore/Helpers/TeamHelper.cs
@@ -16,7 +16,7 @@ namespace ServerCore.Helpers
         /// Helper for deleting teams that correctly deletes dependent objects
         /// </summary>
         /// <param name="team">Team to delete</param>
-        public static async Task DeleteTeamAsync(PuzzleServerContext context, Team team)
+        public static async Task DeleteTeamAsync(PuzzleServerContext context, Team team, bool sendEmail = true)
         {
             var memberEmails = await (from teamMember in context.TeamMembers
                                       where teamMember.Team == team
@@ -49,9 +49,12 @@ namespace ServerCore.Helpers
 
             await context.SaveChangesAsync();
 
-            MailHelper.Singleton.SendPlaintextBcc(memberEmails.Union(applicationEmails),
-                $"{team.Event.Name}: Team '{team.Name}' has been deleted",
-                $"Sorry! You can apply to another team if you wish, or create your own.");
+            if (sendEmail)
+            {
+                MailHelper.Singleton.SendPlaintextBcc(memberEmails.Union(applicationEmails),
+                    $"{team.Event.Name}: Team '{team.Name}' has been deleted",
+                    $"Sorry! You can apply to another team if you wish, or create your own.");
+            }
         }
 
         /// <summary>

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -355,19 +355,19 @@ namespace ServerCore.Pages.Events
                 //
                 // Create teams. Can we add players to these?
                 //
-                Team team1 = new Team { Name = "Team Bugs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "bugs@bugs.bugs" };
+                Team team1 = new Team { Name = "Team Bugs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "bugs@example.com" };
                 _context.Teams.Add(team1);
 
-                Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "babs@babs.babs" };
+                Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "babs@example.com" };
                 _context.Teams.Add(team2);
 
-                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = false, PrimaryContactEmail = "buster@buster.buster" };
+                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = false, PrimaryContactEmail = "buster@example.com" };
                 _context.Teams.Add(team3);
 
                 Team teamLoneWolf = null;
                 if (AddCreatorToLoneWolfTeam)
                 {
-                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "wolf@wolf.wolf" };
+                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "wolf@example.com" };
                     _context.Teams.Add(teamLoneWolf);
                 }
 

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -355,19 +355,19 @@ namespace ServerCore.Pages.Events
                 //
                 // Create teams. Can we add players to these?
                 //
-                Team team1 = new Team { Name = "Team Bugs", Event = Event, IsLookingForTeammates = true };
+                Team team1 = new Team { Name = "Team Bugs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "bugs@bugs.bugs" };
                 _context.Teams.Add(team1);
 
-                Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true };
+                Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "babs@babs.babs" };
                 _context.Teams.Add(team2);
 
-                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = false };
+                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = false, PrimaryContactEmail = "buster@buster.buster" };
                 _context.Teams.Add(team3);
 
                 Team teamLoneWolf = null;
                 if (AddCreatorToLoneWolfTeam)
                 {
-                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event, IsLookingForTeammates = true };
+                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "wolf@wolf.wolf" };
                     _context.Teams.Add(teamLoneWolf);
                 }
 

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -11,11 +11,15 @@
 
 @{
     var mailtoUrl = "mailto:";
-    
+
     // to: Add the proper support agent as recipient
     mailtoUrl += Model.PuzzleState?.Puzzle.SupportEmailAlias ?? (Model.Event?.ContactEmail ?? "puzzhunt@microsoft.com");
-    // cc: Cc the team's email address because what if this email account is a random personal one?
-    mailtoUrl += "?cc=" + Uri.EscapeDataString(Model.Team.PrimaryContactEmail);
+
+    if (Model.Team.PrimaryContactEmail != null)
+    {
+        // cc: Cc the team's email address because what if this email account is a random personal one?
+        mailtoUrl += "?cc=" + Uri.EscapeDataString(Model.Team.PrimaryContactEmail);
+    }
 
     // subject: Make this be about this puzzle
     mailtoUrl += "&subject=" + Uri.EscapeDataString("[" + Model.Puzzle.Name + "]");

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -94,7 +94,7 @@ namespace ServerCore.Pages.Teams
 
             using (IDbContextTransaction transaction = _context.Database.BeginTransaction(System.Data.IsolationLevel.Serializable))
             {
-                if (await _context.Teams.Where((t) => t.Event == Event).CountAsync() >= Event.MaxNumberOfTeams)
+                if (EventRole != EventRole.admin && await _context.Teams.Where((t) => t.Event == Event).CountAsync() >= Event.MaxNumberOfTeams)
                 {
                     return NotFound("Registration is full. No further teams may be created at the present time.");
                 }

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -137,6 +137,7 @@
                                     <a asp-page="/Hints/AuthorIndex" asp-route-teamId="@item.ID">Hints Taken</a><br />
                                 }
                                 ------<br />
+                                <a asp-page="./MergeInto" asp-route-teamId="@item.ID">Merge Into...</a><br/>
                                 <a asp-page="./Delete" asp-route-teamId="@item.ID">Delete</a>
                             </div>
                         </div>

--- a/ServerCore/Pages/Teams/MergeInto.cshtml
+++ b/ServerCore/Pages/Teams/MergeInto.cshtml
@@ -1,0 +1,53 @@
+﻿@page "/{eventId}/{eventRole}/Teams/{teamId}/MergeInto"
+@model ServerCore.Pages.Teams.MergeIntoModel
+
+@{
+    ViewData["Title"] = "Merge Team Into Another";
+    //Needs route data - ViewData["AdminRoute"] = "/Teams/Delete";
+    //Needs route data - ViewData["AuthorRoute"] = "/Teams/Status";
+    //Needs route data - ViewData["PlayRoute"] = "/Teams/Delete";
+    Layout = "_teamLayout.cshtml";
+}
+
+<h2>@Html.DisplayFor(model => model.Team.Name): Merge Into Another Team</h2>
+<div>
+    <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Cancel</a>
+</div>
+
+<h3>Are you sure you want to merge this team into another team?</h3>
+<div>
+    <hr />
+    <form method="post">
+        <dl>
+            <!-- class="dl-horizontal"> -->
+            <dt>
+                Team name
+            </dt>
+            <dd>
+                @Html.DisplayFor(model => model.Team.Name)
+            </dd>
+            <dt>
+                Primary contact e-mail
+            </dt>
+            <dd>
+                @if (Model.Team.PrimaryContactEmail == null)
+            {
+                <div>(none)</div>
+            }
+            else
+            {
+                @Html.DisplayFor(model => model.Team.PrimaryContactEmail)
+            }
+            </dd>
+            <dt>
+                Merge Into
+            </dt>
+            <dd>
+                <select class="form-control" asp-for="MergeIntoID" asp-items="@(new SelectList(Model.OtherTeams, "ID", "Name"))"></select>
+            </dd>
+        </dl>
+
+        <input type="hidden" asp-for="Team.ID" />
+        <input type="submit" value="Merge" class="btn btn-default" onclick="return confirm('Are you sure you want to merge these teams? This operation cannot be undone.')" />
+    </form>
+</div>

--- a/ServerCore/Pages/Teams/MergeInto.cshtml
+++ b/ServerCore/Pages/Teams/MergeInto.cshtml
@@ -15,11 +15,11 @@
 </div>
 
 <h3>Are you sure you want to merge this team into another team?</h3>
+<h3>Note: this will not merge 100% of team progress and is best used before the event, not during.</h3>
 <div>
     <hr />
     <form method="post">
         <dl>
-            <!-- class="dl-horizontal"> -->
             <dt>
                 Team name
             </dt>
@@ -31,13 +31,13 @@
             </dt>
             <dd>
                 @if (Model.Team.PrimaryContactEmail == null)
-            {
-                <div>(none)</div>
-            }
-            else
-            {
-                @Html.DisplayFor(model => model.Team.PrimaryContactEmail)
-            }
+                {
+                    <div>(none)</div>
+                }
+                else
+                {
+                    @Html.DisplayFor(model => model.Team.PrimaryContactEmail)
+                }
             </dd>
             <dt>
                 Merge Into
@@ -49,5 +49,6 @@
 
         <input type="hidden" asp-for="Team.ID" />
         <input type="submit" value="Merge" class="btn btn-default" onclick="return confirm('Are you sure you want to merge these teams? This operation cannot be undone.')" />
+        <p>Note: the merged players will get bulk email announcing the merge.</p>
     </form>
 </div>

--- a/ServerCore/Pages/Teams/MergeInto.cshtml.cs
+++ b/ServerCore/Pages/Teams/MergeInto.cshtml.cs
@@ -52,15 +52,15 @@ namespace ServerCore.Pages.Teams
                 return NotFound();
             }
 
-            var members = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).ToListAsync();
-            var memberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).Select(tm => tm.Member.Email).ToListAsync();
-            var mergeIntoMemberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == MergeIntoID).Select(m => m.Member.Email).ToListAsync();
-
-            var states = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, Team).ToListAsync();
-            var mergeIntoStates = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, mergeIntoTeam).ToDictionaryAsync(s => s.PuzzleID);
-
             using (var transaction = await _context.Database.BeginTransactionAsync(IsolationLevel.Serializable))
             {
+                var members = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).ToListAsync();
+                var memberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).Select(tm => tm.Member.Email).ToListAsync();
+                var mergeIntoMemberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == MergeIntoID).Select(m => m.Member.Email).ToListAsync();
+
+                var states = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, Team).ToListAsync();
+                var mergeIntoStates = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, mergeIntoTeam).ToDictionaryAsync(s => s.PuzzleID);
+
                 // copy all the team members over
                 foreach (var member in members)
                 {

--- a/ServerCore/Pages/Teams/MergeInto.cshtml.cs
+++ b/ServerCore/Pages/Teams/MergeInto.cshtml.cs
@@ -52,11 +52,14 @@ namespace ServerCore.Pages.Teams
                 return NotFound();
             }
 
+            List<string> memberEmails = null;
+            List<string> mergeIntoMemberEmails = null;
+
             using (var transaction = await _context.Database.BeginTransactionAsync(IsolationLevel.Serializable))
             {
                 var members = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).ToListAsync();
-                var memberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).Select(tm => tm.Member.Email).ToListAsync();
-                var mergeIntoMemberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == MergeIntoID).Select(m => m.Member.Email).ToListAsync();
+                memberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).Select(tm => tm.Member.Email).ToListAsync();
+                mergeIntoMemberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == MergeIntoID).Select(m => m.Member.Email).ToListAsync();
 
                 var states = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, Team).ToListAsync();
                 var mergeIntoStates = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, mergeIntoTeam).ToDictionaryAsync(s => s.PuzzleID);

--- a/ServerCore/Pages/Teams/MergeInto.cshtml.cs
+++ b/ServerCore/Pages/Teams/MergeInto.cshtml.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Teams
+{
+    [Authorize("IsEventAdmin")]
+    public class MergeIntoModel : EventSpecificPageModel
+    {
+        public MergeIntoModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
+        {
+        }
+
+        [BindProperty]
+        public Team Team { get; set; }
+
+        [BindProperty]
+        public int MergeIntoID { get; set; }
+
+        public List<Team> OtherTeams { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int teamId)
+        {
+            Team = await _context.Teams.FirstOrDefaultAsync(m => m.ID == teamId);
+
+            if (Team == null)
+            {
+                return NotFound();
+            }
+
+            OtherTeams = await _context.Teams.Where(m => m.EventID == Team.EventID && m.ID != teamId).OrderBy(m => m.Name).ToListAsync();
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(int teamId)
+        {
+            Team = await _context.Teams.FindAsync(teamId);
+            var mergeIntoTeam = await _context.Teams.FindAsync(MergeIntoID);
+
+            if (Team == null || mergeIntoTeam == null)
+            {
+                return NotFound();
+            }
+
+            var members = await _context.TeamMembers.Where(tm => tm.Team.ID == teamId).ToListAsync();
+            var memberEmails = members.Select(m => m.Member.Email).ToList();
+            var mergeIntoMemberEmails = await _context.TeamMembers.Where(tm => tm.Team.ID == MergeIntoID).Select(m => m.Member.Email).ToListAsync();
+
+            var states = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, Team).ToListAsync();
+            var mergeIntoStates = await PuzzleStateHelper.GetSparseQuery(_context, Team.Event, null, mergeIntoTeam).ToDictionaryAsync(s => s.PuzzleID);
+
+            // copy all the team members over
+            foreach (var member in members)
+            {
+                member.Team = mergeIntoTeam;
+            }
+
+            await _context.SaveChangesAsync();
+
+            // also copy puzzle solves over
+            foreach (var state in states)
+            {
+                if (state.SolvedTime != null && mergeIntoStates.TryGetValue(state.PuzzleID, out var mergeIntoState) && mergeIntoState.SolvedTime == null)
+                {
+                    await PuzzleStateHelper.SetSolveStateAsync(_context, Team.Event, mergeIntoState.Puzzle, mergeIntoTeam, state.UnlockedTime);
+                }
+            }
+
+            await _context.SaveChangesAsync();
+
+            await TeamHelper.DeleteTeamAsync(_context, Team);
+
+            MailHelper.Singleton.SendPlaintextBcc(memberEmails.Union(mergeIntoMemberEmails),
+                $"{Event.Name}: Team '{Team.Name}' has been merged into '{mergeIntoTeam.Name}'",
+                $"These two teams have been merged into one superteam. Please welcome your new teammates!");
+
+            return RedirectToPage("./Index");
+        }
+    }
+}

--- a/ServerCore/Pages/Teams/_teamLayout.cshtml
+++ b/ServerCore/Pages/Teams/_teamLayout.cshtml
@@ -17,7 +17,8 @@
     {
         <a asp-page="/Hints/AuthorIndex" asp-route-teamId="@Model.Team.ID">Hints Taken</a>@(" |")
     }
-    <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a>
+    <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a> |
+    <a asp-page="/Teams/MergeInto" asp-route-teamId="@Model.Team.ID">Merge Into...</a>
 </div>
 }
 @if (Model.EventRole == ModelBases.EventRole.author)


### PR DESCRIPTION
Allows admins to merge players and progress from one team into another. This should streamline the process of consolidating teams, which we will have to do a lot of!

Also fixed a bug where demo teams didn't have primary contacts.