### PR TITLE
Permit Raw HTML in a Simple Meta

### DIFF
--- a/ServerCore/Pages/Pieces/SimpleMeta.cshtml
+++ b/ServerCore/Pages/Pieces/SimpleMeta.cshtml
@@ -12,7 +12,7 @@
 @foreach (var item in Model.EarnedPieces) {
         <tr>
             <td>
-                @Html.DisplayFor(modelItem => item.Contents)
+                @Html.Raw(item.Contents)
             </td>
         </tr>
 }


### PR DESCRIPTION
Simple metas now interpret pieces as raw HTML - this allows for hyperlinks, etc.