### PR TITLE
Update Puzzle Safari 20 registration link to avoid confusion.

### DIFF
--- a/ServerCore/Pages/Resources/ps20/HomePartial.cshtml
+++ b/ServerCore/Pages/Resources/ps20/HomePartial.cshtml
@@ -22,7 +22,7 @@
     </p>
 
 
-    <p>Registration opened on Tuesday, June 23. To register, select the yellow <strong>Register</strong> link at the top of the page.</p>
+    <p>Registration opened on Tuesday, June 23, and runs through July 16th. <a href="https://puzzlehunt.azurewebsites.net/ps20/play/Teams/List">Register your team here!</a></p>
     <p><a href="https://safarilabs.solutions/Home/EventInfo">Detailed event information (Rules, FAQ, etc.) can be found here.</a></p>
 </div>
 

--- a/ServerCore/Pages/Resources/ps20/HomePartial.cshtml
+++ b/ServerCore/Pages/Resources/ps20/HomePartial.cshtml
@@ -22,7 +22,7 @@
     </p>
 
 
-    <p>Registration is planned to open on Tuesday, June 23. <a href="https://puzzlehunt.azurewebsites.net/ps20/play">Register here!</a></p>
+    <p>Registration opened on Tuesday, June 23. To register, select the yellow <strong>Register</strong> link at the top of the page.</p>
     <p><a href="https://safarilabs.solutions/Home/EventInfo">Detailed event information (Rules, FAQ, etc.) can be found here.</a></p>
 </div>
 


### PR DESCRIPTION
Replace a "Register here!" link that just points at its own page with one that points at the registration page.