### PR TITLE
Permit raw HTML in Responses

### DIFF
--- a/ServerCore/Pages/Responses/Index.cshtml
+++ b/ServerCore/Pages/Responses/Index.cshtml
@@ -17,6 +17,7 @@
     <a asp-page="CreateBulk" asp-route-puzzleId="@Model.PuzzleId">Bulk Create</a>
 </p>
 
+<h4>Note: ResponseText can either be plain text or Raw HTML.<br/>If you are using plain text, do not use the &quot;&lt;&quot; or &quot;&gt;&quot; characters.<br/>If you are using HTML, <b>CHECK IT VERY CAREFULLY!</b><br/>Failure to follow these rules may make responses uneditable, and you may have to delete your puzzle and start over.</h4>
 <table class="table">
     <thead>
         <tr>
@@ -51,7 +52,7 @@
                 @Html.DisplayFor(modelItem => item.SubmittedText)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.ResponseText)
+                @Html.Raw(item.ResponseText)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Note)

--- a/ServerCore/Pages/Responses/Index.cshtml
+++ b/ServerCore/Pages/Responses/Index.cshtml
@@ -17,7 +17,7 @@
     <a asp-page="CreateBulk" asp-route-puzzleId="@Model.PuzzleId">Bulk Create</a>
 </p>
 
-<h4>Note: ResponseText can either be plain text or Raw HTML.<br/>If you are using plain text, do not use the &quot;&lt;&quot; or &quot;&gt;&quot; characters.<br/>If you are using HTML, <b>CHECK IT VERY CAREFULLY!</b><br/>Failure to follow these rules may make responses uneditable, and you may have to delete your puzzle and start over.</h4>
+<h4>Note: ResponseText can either be plain text or Raw HTML.<br/>If you are using HTML, write it as Html.Raw(<i>&lt;your html&gt;</i>) and <b>CHECK IT VERY CAREFULLY!</b><br/>Failure to be careful may make responses uneditable, and you may have to delete your puzzle and start over.</h4>
 <table class="table">
     <thead>
         <tr>
@@ -52,7 +52,14 @@
                 @Html.DisplayFor(modelItem => item.SubmittedText)
             </td>
             <td>
-                @Html.Raw(item.ResponseText)
+                @if (item.ResponseText.StartsWith("Html.Raw(") && item.ResponseText.EndsWith(")"))
+                {
+                    @Html.Raw(item.ResponseText.Substring(9, item.ResponseText.Length - 10))
+                }
+                else
+                {
+                    @Html.DisplayFor(modelItem => item.ResponseText)
+                }
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Note)

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -182,7 +182,22 @@
                             @Html.DisplayFor(modelItem => Model.SubmissionViews[i].Submission.SubmissionText)
                         </td>
                         <td>
-                            @Html.Raw(Model.SubmissionViews[i].Response != null ? Model.SubmissionViews[i].Response.ResponseText : "Incorrect")
+                            @{
+                                var response = Model.SubmissionViews[i].Response;
+
+                                if (response == null)
+                                {
+                                    <text>Incorrect</text>
+                                }
+                                else if (response.ResponseText.StartsWith("Html.Raw(") && response.ResponseText.EndsWith(")"))
+                                {
+                                    @Html.Raw(response.ResponseText.Substring(9, response.ResponseText.Length - 10))
+                                }
+                                else
+                                {
+                                    @Html.DisplayFor(modelItem => response.ResponseText)
+                                }
+                            }
                         </td>
                     </tr>
                 }

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -182,7 +182,7 @@
                             @Html.DisplayFor(modelItem => Model.SubmissionViews[i].Submission.SubmissionText)
                         </td>
                         <td>
-                            @(Model.SubmissionViews[i].Response != null ? Model.SubmissionViews[i].Response.ResponseText : "Incorrect")
+                            @Html.Raw(Model.SubmissionViews[i].Response != null ? Model.SubmissionViews[i].Response.ResponseText : "Incorrect")
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
This lets authors put hyperlinks, emphasis, pictures, etc. in responses. There's a little bit of danger here but since this is only editable by authors and authors can only mangle their own puzzles, I think the expressivity is worth the danger. We plan to use this capability for the correct responses to the PD2020 metas.