### PR TITLE
File import improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 /.vs
+/ServerCore/.config/dotnet-tools.json

--- a/Data/DataModel/ContentFile.cs
+++ b/Data/DataModel/ContentFile.cs
@@ -18,10 +18,10 @@ namespace ServerCore.DataModel
         public ContentFile(ContentFile source)
         {
             FileType = source.FileType;
-            Event = source.Event;
+            EventID = source.EventID;
             ShortName = source.ShortName;
             UrlString = source.UrlString;
-            Puzzle = source.Puzzle;
+            PuzzleID = source.PuzzleID;
         }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/ServerCore/FileManager.cs
+++ b/ServerCore/FileManager.cs
@@ -27,7 +27,7 @@ namespace ServerCore
         /// <returns>Url of the file in blob storage</returns>
         public static async Task<Uri> UploadBlobAsync(string fileName, int eventId, Stream contents)
         {
-            CloudBlockBlob blob = await CreateNewBlob(fileName, eventId);
+            CloudBlockBlob blob = await CreateNewBlob(fileName, eventId, true);
 
             await blob.UploadFromStreamAsync(contents);
             return blob.Uri;
@@ -43,16 +43,18 @@ namespace ServerCore
         public static async Task<Uri> CloneBlobAsync(string fileName, int eventId, Uri sourceUri)
         {
             CloudBlockBlob blobSource = new CloudBlockBlob(sourceUri, StorageAccount.Credentials);
-            
-            CloudBlockBlob blob = await CreateNewBlob(fileName, eventId);
+            Uri sourceContainerUri = new Uri(blobSource.Container.Uri.ToString() + "/");
+            Uri relativeUri = sourceContainerUri.MakeRelativeUri(sourceUri);
+            string newFileName = relativeUri.ToString();
+            CloudBlockBlob blob = await CreateNewBlob(newFileName, eventId, false);
             await blob.StartCopyAsync(blobSource);
 
             return blob.Uri;
         }
 
-        private static async Task<CloudBlockBlob> CreateNewBlob(string fileName, int eventId)
+        private static async Task<CloudBlockBlob> CreateNewBlob(string fileName, int eventId, bool randomize)
         {
-            CloudBlobDirectory puzzleDirectory = await GetRandomDirectoryAsync(eventId);
+            CloudBlobDirectory puzzleDirectory = await GetRandomDirectoryAsync(eventId, randomize);
 
             CloudBlockBlob blob = puzzleDirectory.GetBlockBlobReference(fileName);
             if (fileExtensionProvider.TryGetContentType(fileName, out string contentType))
@@ -72,7 +74,7 @@ namespace ServerCore
         /// <returns>A dictionary with key of the file names and value of the urls of the files in blob storage</returns>
         public static async Task<Dictionary<string, Uri>> UploadBlobsAsync(Dictionary<string, Stream> files, int eventId)
         {
-            CloudBlobDirectory puzzleDirectory = await GetRandomDirectoryAsync(eventId);
+            CloudBlobDirectory puzzleDirectory = await GetRandomDirectoryAsync(eventId, true);
             Dictionary<string, Uri> fileUrls = new Dictionary<string, Uri>(files.Count);
 
             foreach (KeyValuePair<string, Stream> file in files)
@@ -105,16 +107,24 @@ namespace ServerCore
         /// Gets a reference to a random directory
         /// </summary>
         /// <param name="eventId">Event the directory should be associated with</param>
-        private static async Task<CloudBlobDirectory> GetRandomDirectoryAsync(int eventId)
+        private static async Task<CloudBlobDirectory> GetRandomDirectoryAsync(int eventId, bool randomize)
         {
             CloudBlobContainer eventContainer = await GetOrCreateEventContainerAsync(eventId);
+            CloudBlobDirectory puzzleDirectory;
+            if (randomize)
+            {
+                // Obfuscate the file by putting it in a random directory
+                byte[] manglingBytes = new byte[16];
+                RandomNumberGenerator.Fill(manglingBytes);
+                // Turn the random bytes into legal URL characters
+                string mangledString = Convert.ToBase64String(manglingBytes).Replace('/', '_');
+                puzzleDirectory = eventContainer.GetDirectoryReference(mangledString);
+            }
+            else
+            {
+                puzzleDirectory = eventContainer.GetDirectoryReference("");
+            }
 
-            // Obfuscate the file by putting it in a random directory
-            byte[] manglingBytes = new byte[16];
-            RandomNumberGenerator.Fill(manglingBytes);
-            // Turn the random bytes into legal URL characters
-            string mangledString = Convert.ToBase64String(manglingBytes).Replace('/', '_');
-            CloudBlobDirectory puzzleDirectory = eventContainer.GetDirectoryReference(mangledString);
             return puzzleDirectory;
         }
 

--- a/ServerCore/Startup.cs
+++ b/ServerCore/Startup.cs
@@ -99,7 +99,7 @@ namespace ServerCore
             services.AddScoped<IAuthorizationHandler, IsRegisteredForEventHandler_Admin>();
             services.AddScoped<IAuthorizationHandler, IsRegisteredForEventHandler_Author>();
             services.AddScoped<IAuthorizationHandler, IsRegisteredForEventHandler_Player>();
-
+            services.AddScoped<BackgroundFileUploader>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Fixes issues in importing files across events:
1. Moves the file copying to background threads and updates the database as each file copies. This was previously taking long enough that it would cause request timeouts and the entire import would fail. 
2. Doesn't re-randomize urls when copying blobs to the new event. This maintains the relationship between files that were uploaded in the same directory