### PR TITLE
Fix homepage to promote PH21

### DIFF
--- a/ServerCore/Pages/Index.cshtml
+++ b/ServerCore/Pages/Index.cshtml
@@ -4,31 +4,24 @@
     ViewData["Title"] = "Microsoft Puzzle Event Homepage";
 }
 
-<h3>Our next events</h3>
+<h3>Our next event</h3>
 
-<h4>Microsoft Non-Intern Puzzleday 2020</h4>
-<br />
-<h2 style="font-family: 'Segoe UI'; text-transform: uppercase; font-size: 8rem; color: black;">
-    <span>Non-Intern Puzzleday </span><span style="white-space:nowrap;"><span style="display: inline-block; font-weight: bold; color: #01A4EF; text-shadow: 0em -0.9em #F44E24; transform: translate(0, 0.45em)">2</span><span style="display: inline-block; font-weight: bold; color: #FFB902; text-shadow: 0em -0.9em #81B900; transform: translate(0, 0.45em)">0</span></span>
-</h2>
-<br />
-<br />
-<p>A one-weekend event for FTEs and friends that happens every summer. Puzzle solvers of all levels of experience are welcome!</p>
-<a href="https://puzzlehunt.azurewebsites.net/nipd2020/play">Go to Puzzleday 2020</a>
-
-<hr />
 <h4>Microsoft Puzzlehunt 21</h4>
-<!--
 <a href="https://puzzlehunt.azurewebsites.net/ph21/play">
-    <img class="pd2019-logo" src="~/images/msph2020.png" />
+    <img class="pd2019-logo" src="~/images/msph2021.png" width="600" />
 </a>
--->
 <p>A weekend-long event in spring <b style="color:red">2021</b> (postponed from 2020, sorry) for full-time employees and friends. Puzzles of all levels are included!</p>
 <a href="https://puzzlehunt.azurewebsites.net/ph21/play">Go to Puzzlehunt 21</a>
 
 <hr />
 
 <h3>Past events</h3>
+
+<h4>Microsoft Non-Intern Puzzleday 2020</h4>
+<p>A one-weekend event for FTEs and friends that happens every summer. Puzzle solvers of all levels of experience are welcome!</p>
+<a href="https://puzzlehunt.azurewebsites.net/nipd2020/play">Go to the Non-Intern Puzzleday event</a>
+
+<hr />
 
 <h4>Puzzle Safari 2020</h4>
 <p>A one-day event for employees and friends that combines solving, running, and searching. Puzzle solvers at all levels are welcome!</p>

--- a/ServerCore/Pages/Teams/Details.cshtml
+++ b/ServerCore/Pages/Teams/Details.cshtml
@@ -114,6 +114,7 @@
         @Html.DisplayFor(model => model.Team.RoomID)
     </dd>
     -->
+                <!--
                 <dt>
                     Team room
                 </dt>
@@ -134,6 +135,7 @@
                     @Html.DisplayFor(model => model.Team.CustomRoom)
                     }
                 </dd>
+                -->
                 <dt>
                     Primary phone number
                 </dt>


### PR DESCRIPTION
Forgot to do this for the previous refresh.

As a bonus, removing the team room from the team details page since we've already removed it from the create and edit pages.