### PR TITLE
Upgrade to .NET 5

### DIFF
--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -1,8 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>ServerCore</RootNamespace>
+    <ApplicationIcon />
+    <OutputType>Library</OutputType>
+    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,8 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>ServerCore</RootNamespace>
     <ApplicationIcon />
     <OutputType>Library</OutputType>

--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>ServerCore</RootNamespace>
     <ApplicationIcon />
     <OutputType>Library</OutputType>

--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Data/DataModel/EventAdmins.cs
+++ b/Data/DataModel/EventAdmins.cs
@@ -8,11 +8,15 @@ namespace ServerCore.DataModel
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
 
+        public int EventID { get; set; }
+
         /// <summary>
         /// Foreign key - event table
         /// </summary
         [Required]
         public virtual Event Event { get; set; }
+
+        public int AdminID { get; set; }
 
         /// <summary>
         /// Foreign key - user table

--- a/Data/DataModel/EventAuthors.cs
+++ b/Data/DataModel/EventAuthors.cs
@@ -23,11 +23,15 @@ namespace ServerCore.DataModel
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
 
+        public int EventID { get; set; }
+
         /// <summary>
         /// Foreign Key - event table
         /// </summary>
         [Required]
         public virtual Event Event { get; set; }
+
+        public int AuthorID { get; set; }
 
         /// <summary>
         /// Foreign Key - user table (author)

--- a/Data/DataModel/Feedback.cs
+++ b/Data/DataModel/Feedback.cs
@@ -22,8 +22,12 @@ namespace ServerCore.DataModel
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
 
+        public int PuzzleID { get; set; }
+
         [Required]
         public virtual Puzzle Puzzle { get; set; }
+
+        public int SubmitterID { get; set; }
 
         /// <summary>
         /// The user who submitted the feedback>

--- a/Data/DataModel/Hint.cs
+++ b/Data/DataModel/Hint.cs
@@ -30,6 +30,9 @@ namespace ServerCore.DataModel
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
         
+        [Required]
+        public int PuzzleID { get; set; }
+
         /// <summary>
         /// The puzzle this is a hint for
         /// </summary>

--- a/Data/DataModel/Submission.cs
+++ b/Data/DataModel/Submission.cs
@@ -35,6 +35,8 @@ namespace ServerCore.DataModel
         [ForeignKey("Team")]
         public int TeamID { get; set; }
 
+        public int SubmitterID { get; set; }
+
         /// <summary>
         /// The exact user giving the submission
         /// </summary>

--- a/Data/DataModel/TeamApplication.cs
+++ b/Data/DataModel/TeamApplication.cs
@@ -14,11 +14,15 @@ namespace ServerCore.DataModel
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
 
+        public int TeamID { get; set; }
+
         /// <summary>
         /// The team the player wants to join
         /// </summary>
         [Required]
         public virtual Team Team { get; set; }
+
+        public int PlayerID { get; set; }
 
         /// <summary>
         /// The user who wants to join the team

--- a/PuzzleServer.sln
+++ b/PuzzleServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerCore", "ServerCore\ServerCore.csproj", "{67B91CCE-4E3D-4F0F-8A76-EAFD37C5F949}"
 EndProject

--- a/ServerCore/Areas/Deployment/DeploymentConfiguration.cs
+++ b/ServerCore/Areas/Deployment/DeploymentConfiguration.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using ServerCore.DataModel;
 
@@ -9,7 +10,7 @@ namespace ServerCore.Areas.Deployment
 {
     public class DeploymentConfiguration
     {
-        internal static void ConfigureDatabase(IConfiguration configuration, IServiceCollection services, IHostingEnvironment env)
+        internal static void ConfigureDatabase(IConfiguration configuration, IServiceCollection services, IWebHostEnvironment env)
         {
             // Use SQL Database if in Azure, otherwise, use localdb
             if (env.IsStaging() && Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") == "PuzzleServerTestDeploy")

--- a/ServerCore/Areas/Identity/IdentityHostingStartup.cs
+++ b/ServerCore/Areas/Identity/IdentityHostingStartup.cs
@@ -15,7 +15,7 @@ namespace ServerCore.Areas.Identity
             builder.ConfigureServices((context, services) =>
             {
                 // Set up to use Azure settings
-                IHostingEnvironment env = context.HostingEnvironment;
+                IWebHostEnvironment env = context.HostingEnvironment;
                 IConfigurationBuilder configBuilder = new ConfigurationBuilder()
                     .SetBasePath(env.ContentRootPath)
                     .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)

--- a/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ServerCore.DataModel;
 
@@ -123,7 +124,7 @@ namespace ServerCore.Areas.Identity.Pages.Account
                         if (ModelState.IsValid)
                         {
                             // If there are no GlobalAdmins make them the GlobalAdmin
-                            if ((Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == EnvironmentName.Development) && !_context.PuzzleUsers.Where(u => u.IsGlobalAdmin).Any())
+                            if ((Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == Environments.Development) && !_context.PuzzleUsers.Where(u => u.IsGlobalAdmin).Any())
                             {
                                 Input.IsGlobalAdmin = true;
                             }

--- a/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -2,7 +2,6 @@
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
@@ -14,18 +13,15 @@ namespace ServerCore.Areas.Identity.Pages.Account.Manage
     {
         private readonly UserManager<IdentityUser> _userManager;
         private readonly SignInManager<IdentityUser> _signInManager;
-        private readonly IEmailSender _emailSender;
         private readonly PuzzleServerContext _context;
 
         public IndexModel(
             UserManager<IdentityUser> userManager,
             SignInManager<IdentityUser> signInManager,
-            IEmailSender emailSender,
             PuzzleServerContext context)
         {
             _userManager = userManager;
             _signInManager = signInManager;
-            _emailSender = emailSender;
             _context = context;
         }
 
@@ -110,10 +106,6 @@ namespace ServerCore.Areas.Identity.Pages.Account.Manage
                 pageHandler: null,
                 values: new { userId = userId, code = code },
                 protocol: Request.Scheme);
-            await _emailSender.SendEmailAsync(
-                email,
-                "Confirm your email",
-                $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
 
             StatusMessage = "Verification email sent. Please check your email.";
             return RedirectToPage();

--- a/ServerCore/Areas/Identity/Pages/Error.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Error.cshtml.cs
@@ -11,13 +11,13 @@ using Microsoft.AspNetCore.Identity;
 namespace ServerCore.Areas.Identity.Pages
 {
     [AllowAnonymous]
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel
     {
         public string RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
-        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public void OnGet()
         {
             RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;

--- a/ServerCore/Areas/Identity/Pages/_ViewImports.cshtml
+++ b/ServerCore/Areas/Identity/Pages/_ViewImports.cshtml
@@ -1,5 +1,4 @@
 ﻿@using Microsoft.AspNetCore.Identity
 @using ServerCore.Areas.Identity
-@using Microsoft.AspNetCore.Identity
 @namespace ServerCore.Areas.Identity.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -86,7 +86,7 @@ namespace ServerCore.Areas.Identity
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             Event thisEvent = await GetEventFromRoute();
 
-            if (thisEvent != null && await puzzleUser.IsAdminForEvent(dbContext, thisEvent))
+            if (thisEvent != null && puzzleUser != null && await puzzleUser.IsAdminForEvent(dbContext, thisEvent))
             {
                 authContext.Succeed(requirement);
             }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsAuthorOfPuzzle.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsAuthorOfPuzzle.cs
@@ -17,19 +17,17 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsAuthorOfPuzzleHandler : AuthorizationHandler<IsAuthorOfPuzzleRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsAuthorOfPuzzleHandler(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsAuthorOfPuzzleHandler(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsAuthorOfPuzzleRequirement requirement)
         {
-            await AuthorizationHelper.IsPuzzleAuthorCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsPuzzleAuthorCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdmin.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdmin.cs
@@ -17,19 +17,17 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsAdminInEventHandler : AuthorizationHandler<IsAdminInEventRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsAdminInEventHandler(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsAdminInEventHandler(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsAdminInEventRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAdminCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAdminCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrAuthorOfPuzzle.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrAuthorOfPuzzle.cs
@@ -17,37 +17,33 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsEventAdminOrAuthorOfPuzzleHandler_Admin : AuthorizationHandler<IsEventAdminOrAuthorOfPuzzleRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsEventAdminOrAuthorOfPuzzleHandler_Admin(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsEventAdminOrAuthorOfPuzzleHandler_Admin(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsEventAdminOrAuthorOfPuzzleRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAdminCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAdminCheck(authContext, requirement);
         }
     }
 
     public class IsEventAdminOrAuthorOfPuzzleHandler_Author : AuthorizationHandler<IsEventAdminOrAuthorOfPuzzleRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsEventAdminOrAuthorOfPuzzleHandler_Author(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsEventAdminOrAuthorOfPuzzleHandler_Author(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsEventAdminOrAuthorOfPuzzleRequirement requirement)
         {
-            await AuthorizationHelper.IsPuzzleAuthorCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsPuzzleAuthorCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrEventAuthor.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrEventAuthor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using ServerCore.DataModel;
 
@@ -14,35 +15,31 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsEventAdminOrEventAuthorHandler_Admin : AuthorizationHandler<IsEventAdminOrEventAuthorRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsEventAdminOrEventAuthorHandler_Admin(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsEventAdminOrEventAuthorHandler_Admin(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext, IsEventAdminOrEventAuthorRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAdminCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAdminCheck(authContext, requirement);
         }
     }
 
     public class IsEventAdminOrEventAuthorHandler_Author : AuthorizationHandler<IsEventAdminOrEventAuthorRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsEventAdminOrEventAuthorHandler_Author(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsEventAdminOrEventAuthorHandler_Author(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext, IsEventAdminOrEventAuthorRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAuthorCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAuthorCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrPlayerOnTeam.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrPlayerOnTeam.cs
@@ -14,35 +14,31 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsEventAdminOrPlayerOnTeamHandler_Admin : AuthorizationHandler<IsEventAdminOrPlayerOnTeamRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsEventAdminOrPlayerOnTeamHandler_Admin(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsEventAdminOrPlayerOnTeamHandler_Admin(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext, IsEventAdminOrPlayerOnTeamRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAdminCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAdminCheck(authContext, requirement);
         }
     }
 
     public class IsEventAdminOrPlayerOnTeamHandler_Play : AuthorizationHandler<IsEventAdminOrPlayerOnTeamRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsEventAdminOrPlayerOnTeamHandler_Play(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsEventAdminOrPlayerOnTeamHandler_Play(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext, IsEventAdminOrPlayerOnTeamRequirement requirement)
         {
-            await AuthorizationHelper.IsPlayerOnTeamCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsPlayerOnTeamCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAuthor.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAuthor.cs
@@ -18,19 +18,17 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsAuthorInEventHandler : AuthorizationHandler<IsAuthorInEventRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsAuthorInEventHandler(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsAuthorInEventHandler(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsAuthorInEventRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAuthorCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAuthorCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsGlobalAdmin.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsGlobalAdmin.cs
@@ -31,7 +31,7 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
         {
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
 
-            if (puzzleUser.IsGlobalAdmin)
+            if (puzzleUser != null && puzzleUser.IsGlobalAdmin)
             {
                 authContext.Succeed(requirement);
             }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsPlayerInEvent.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsPlayerInEvent.cs
@@ -17,19 +17,17 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsPlayerInEventHandler : AuthorizationHandler<IsPlayerInEventRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsPlayerInEventHandler(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsPlayerInEventHandler(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsPlayerInEventRequirement requirement)
         {
-            await AuthorizationHelper.IsEventPlayerCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventPlayerCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsRegisteredForEvent.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsRegisteredForEvent.cs
@@ -14,55 +14,49 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class IsRegisteredForEventHandler_Admin : AuthorizationHandler<IsRegisteredForEventRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsRegisteredForEventHandler_Admin(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsRegisteredForEventHandler_Admin(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsRegisteredForEventRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAdminCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAdminCheck(authContext, requirement);
         }
     }
 
     public class IsRegisteredForEventHandler_Author : AuthorizationHandler<IsRegisteredForEventRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsRegisteredForEventHandler_Author(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsRegisteredForEventHandler_Author(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsRegisteredForEventRequirement requirement)
         {
-            await AuthorizationHelper.IsEventAuthorCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventAuthorCheck(authContext, requirement);
         }
     }
 
     public class IsRegisteredForEventHandler_Player : AuthorizationHandler<IsRegisteredForEventRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public IsRegisteredForEventHandler_Player(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public IsRegisteredForEventHandler_Player(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsRegisteredForEventRequirement requirement)
         {
-            await AuthorizationHelper.IsEventPlayerCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsEventPlayerCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/PlayerIsOnTeam.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/PlayerIsOnTeam.cs
@@ -16,19 +16,17 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
 
     public class PlayerIsOnTeamHandler : AuthorizationHandler<PlayerIsOnTeamRequirement>
     {
-        private readonly PuzzleServerContext dbContext;
-        private readonly UserManager<IdentityUser> userManager;
+        private readonly AuthorizationHelper authHelper;
 
-        public PlayerIsOnTeamHandler(PuzzleServerContext pContext, UserManager<IdentityUser> manager)
+        public PlayerIsOnTeamHandler(AuthorizationHelper authHelper)
         {
-            dbContext = pContext;
-            userManager = manager;
+            this.authHelper = authHelper;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        PlayerIsOnTeamRequirement requirement)
         {
-            await AuthorizationHelper.IsPlayerOnTeamCheck(authContext, dbContext, userManager, requirement);
+            await authHelper.IsPlayerOnTeamCheck(authContext, requirement);
         }
     }
 }

--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -149,6 +149,7 @@ namespace ServerCore.ModelBases
 
         public class RoleBinder : IModelBinder
         {
+#pragma warning disable 1998 // Async method that doesn't await anything forced by the IModelBinder interface
             // This doesn't actually run async but the compiler complains if I try to use BindModel :(
             public async Task BindModelAsync(ModelBindingContext bindingContext)
             {
@@ -169,6 +170,7 @@ namespace ServerCore.ModelBases
                     throw new Exception("Invalid route parameter '" + eventRoleAsString + "'. Please check your URL to make sure you are using the correct path. (code: InvalidRoleId)");
                 }
             }
+#pragma warning restore
         }
     }
 }

--- a/ServerCore/Pages/Events/Delete.cshtml.cs
+++ b/ServerCore/Pages/Events/Delete.cshtml.cs
@@ -27,7 +27,7 @@ namespace ServerCore.Pages.Events
             {
                 using (var transaction = _context.Database.BeginTransaction())
                 {
-                    var eventTeams = from Team team in _context.Teams
+                    var eventTeams = from team in _context.Teams
                                      where team.Event == Event
                                      select team;
 
@@ -36,7 +36,7 @@ namespace ServerCore.Pages.Events
                         await TeamHelper.DeleteTeamAsync(_context, team);
                     }
 
-                    var eventPuzzles = from Puzzle puzzle in _context.Puzzles
+                    var eventPuzzles = from puzzle in _context.Puzzles
                                        where puzzle.Event == Event
                                        select puzzle;
                     foreach (Puzzle puzzle in eventPuzzles)

--- a/ServerCore/Pages/Events/FastestSolves.cshtml
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml
@@ -39,7 +39,7 @@
                                                                       FastestSolvesModel.SortOrder.PuzzleDescending))"
                             asp-route-stateFilter="@Model.StateFilter">
 
-                            @Html.DisplayNameFor(model => model.Puzzles[0].Puzzle.Name)
+                            @Html.DisplayNameFor(model => model.Puzzles[0].PuzzleName)
                         </a>
                     </th>
                     <th>
@@ -75,7 +75,7 @@
 
                 <tr>
                     <td>
-                        @(puzzle.Puzzle.Name)
+                        @(puzzle.PuzzleName)
                     </td>
                     <td>
                         @(puzzle.SolveCount)

--- a/ServerCore/Pages/Events/FastestSolves.cshtml.cs
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml.cs
@@ -54,10 +54,12 @@ namespace ServerCore.Pages.Events
                                      pspt.SolvedTime <= submissionEnd &&
                                      !pspt.Team.IsDisqualified &&
                                      pspt.Puzzle.Event == Event
-                                     let puzzleToGroup = new { PuzzleID = pspt.Puzzle.ID, PuzzleName = pspt.Puzzle.Name }
+                                     let puzzleToGroup = new { PuzzleID = pspt.Puzzle.ID, PuzzleName = pspt.Puzzle.Name } // Using 'let' to work around EF grouping limitations (https://www.codeproject.com/Questions/5266406/Invalidoperationexception-the-LINQ-expression-for)
                                      group puzzleToGroup by puzzleToGroup.PuzzleID into puzzleGroup
                                      orderby puzzleGroup.Count() descending, puzzleGroup.Max(puzzleGroup => puzzleGroup.PuzzleName) // Using Max(PuzzleName) because only aggregate operators are allowed
                                      select new { PuzzleID = puzzleGroup.Key, PuzzleName = puzzleGroup.Max(puzzleGroup => puzzleGroup.PuzzleName), SolveCount = puzzleGroup.Count() }).ToListAsync();
+
+            // Getting the top 3 requires working around EF limitations translating sorting results within a group to SQL. Workaround from https://github.com/dotnet/efcore/issues/13805
 
             // Filter to solved puzzles
             var psptToQuery = _context.PuzzleStatePerTeam.Where(pspt => pspt.Puzzle.EventID == Event.ID &&

--- a/ServerCore/Pages/Hints/Create.cshtml.cs
+++ b/ServerCore/Pages/Hints/Create.cshtml.cs
@@ -50,7 +50,7 @@ namespace ServerCore.Pages.Hints
 
             using (IDbContextTransaction transaction = _context.Database.BeginTransaction(System.Data.IsolationLevel.Serializable))
             {
-                var teams = from Team team in _context.Teams
+                var teams = from team in _context.Teams
                             where team.Event == Event
                             select team;
                 _context.Hints.Add(Hint);

--- a/ServerCore/Pages/Hints/Edit.cshtml.cs
+++ b/ServerCore/Pages/Hints/Edit.cshtml.cs
@@ -56,8 +56,8 @@ namespace ServerCore.Pages.Hints
 
                 var puzzleName = await _context.Hints.Where(m => m.Id == Hint.Id).Select(m => m.Puzzle.Name).FirstOrDefaultAsync();
 
-                var teamMembers = await (from TeamMembers tm in _context.TeamMembers
-                                         join HintStatePerTeam hspt in _context.HintStatePerTeam on tm.Team equals hspt.Team
+                var teamMembers = await (from tm in _context.TeamMembers
+                                         join hspt in _context.HintStatePerTeam on tm.Team equals hspt.Team
                                          where hspt.Hint.Id == Hint.Id && hspt.UnlockTime != null
                                          select tm.Member.Email).ToListAsync();
                 MailHelper.Singleton.SendPlaintextBcc(teamMembers,

--- a/ServerCore/Pages/Pieces/SyncTest.cshtml.cs
+++ b/ServerCore/Pages/Pieces/SyncTest.cshtml.cs
@@ -14,7 +14,7 @@ using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Pieces
 {
-    [AllowAnonymous]
+    [Authorize(Policy = "IsEventAdmin")]
     public class SyncTestModel : EventSpecificPageModel
     {
         public int EventId { get; set; }
@@ -28,7 +28,6 @@ namespace ServerCore.Pages.Pieces
         {
         }
 
-        [Authorize(Policy = "IsEventAdmin")]
         public async Task<IActionResult> OnGetAsync(string eventId, int puzzleId)
         {
             Event currentEvent = await EventHelper.GetEventFromEventId(_context, eventId);

--- a/ServerCore/Pages/Puzzles/Checklist.cshtml
+++ b/ServerCore/Pages/Puzzles/Checklist.cshtml
@@ -83,7 +83,7 @@
                 }
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Puzzle.MinPrerequisiteCount) of:
+                @Html.DisplayFor(modelItem => item.Puzzle.MinPrerequisiteCount) of @Html.DisplayFor(modelItem => item.PrerequisitesCount)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Prerequisites)

--- a/ServerCore/Pages/Puzzles/Checklist.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Checklist.cshtml.cs
@@ -48,6 +48,7 @@ namespace ServerCore.Pages.Puzzles
         {
             List<Puzzle> puzzles = await PuzzleHelper.GetPuzzles(_context, Event, LoggedInUser, EventRole);
 
+            // todo: this query doesn't work because it's trying to get the contents of the group back, which involves client evaluation
             Dictionary<int, List<string>> puzzleAuthors = await (from author in _context.PuzzleAuthors
                                                                         where author.Puzzle.Event == Event
                                                                         group author by author.PuzzleID into authorList

--- a/ServerCore/Pages/Puzzles/Create.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Create.cshtml.cs
@@ -81,7 +81,7 @@ namespace ServerCore.Pages.Puzzles
                 _context.Puzzles.Add(p);
                 _context.PuzzleAuthors.Add(new PuzzleAuthors() { Puzzle = p, Author = LoggedInUser });
 
-                var teamIDs = await (from Team team in _context.Teams
+                var teamIDs = await (from team in _context.Teams
                                        where team.Event == Event
                                        select team.ID).ToListAsync();
                 foreach (int teamID in teamIDs)

--- a/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml.cs
+++ b/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml.cs
@@ -77,7 +77,7 @@ namespace ServerCore.Pages.Submissions
                 })
                 .OrderByDescending(incorrectCountView => incorrectCountView.NumberOfTimesSubmitted);
 
-            SubmissionCounts = incorrectCounts.ToAsyncEnumerable().ToEnumerable();
+            SubmissionCounts = await incorrectCounts.ToListAsync();
             return Page();
         }
 

--- a/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml.cs
+++ b/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml.cs
@@ -61,23 +61,18 @@ namespace ServerCore.Pages.Submissions
                 submissionsQ = _context.Submissions.Where((s) => s.Puzzle != null && s.Puzzle.ID == puzzleId);
             }
 
-            IQueryable<SubmissionCountsView> incorrectCounts = submissionsQ
-                .Where(submission => submission.Response == null)
-                .GroupBy(submission => Tuple.Create<string,int>
-                (
-                    submission.SubmissionText,
-                    submission.PuzzleID
-                ))
-                .Select((submissions) => new SubmissionCountsView()
-                {
-                    PuzzleID = submissions.First().PuzzleID,
-                    PuzzleName = submissions.First().Puzzle.Name,
-                    SubmissionText = submissions.Key.Item1,
-                    NumberOfTimesSubmitted = submissions.Count()
-                })
-                .OrderByDescending(incorrectCountView => incorrectCountView.NumberOfTimesSubmitted);
-
-            SubmissionCounts = await incorrectCounts.ToListAsync();
+            SubmissionCounts = await (from submission in submissionsQ
+                                         where submission.Response == null
+                                         group submission by new { submission.PuzzleID, submission.SubmissionText, submission.Puzzle.Name } into submissionCounts
+                                         orderby submissionCounts.Count() descending
+                                         select new SubmissionCountsView
+                                         {
+                                             PuzzleID = submissionCounts.Key.PuzzleID,
+                                             PuzzleName = submissionCounts.Key.Name,
+                                             SubmissionText = submissionCounts.Key.SubmissionText,
+                                             NumberOfTimesSubmitted = submissionCounts.Count()
+                                         }                                         
+                                         ).ToListAsync();
             return Page();
         }
 

--- a/ServerCore/Pages/Teams/AddMember.cshtml.cs
+++ b/ServerCore/Pages/Teams/AddMember.cshtml.cs
@@ -46,7 +46,7 @@ namespace ServerCore.Pages.Teams
 
         public async Task<IActionResult> OnGetAddMemberAsync(int teamId, int userId, int applicationId)
         {
-            Tuple<bool, string> result = TeamHelper.AddMemberAsync(_context, Event, EventRole, teamId, userId).Result;
+            Tuple<bool, string> result = await TeamHelper.AddMemberAsync(_context, Event, EventRole, teamId, userId);
             if (result.Item1)
             {
                 return RedirectToPage("./Details", new { teamId = teamId });

--- a/ServerCore/Pages/Teams/Answers.cshtml.cs
+++ b/ServerCore/Pages/Teams/Answers.cshtml.cs
@@ -78,7 +78,7 @@ namespace ServerCore.Pages.Teams
                     throw new Exception("Sort order is not mapped");
             }
 
-            CorrectSubmissions = finalSubmissions.ToList();
+            CorrectSubmissions = await finalSubmissions.ToListAsync();
         }
 
         public SortOrder? SortForColumnLink(SortOrder ascending, SortOrder descending)

--- a/ServerCore/Pages/Teams/Apply.cshtml.cs
+++ b/ServerCore/Pages/Teams/Apply.cshtml.cs
@@ -51,7 +51,7 @@ namespace ServerCore.Pages.Teams
                 return RedirectToPage("./Details", new { teamId = playerTeam.Team.ID });
             }
 
-            Team = await (from Team t in _context.Teams
+            Team = await (from t in _context.Teams
                                where t.ID == teamID && t.Event == Event
                                select t).FirstOrDefaultAsync();
 
@@ -71,7 +71,7 @@ namespace ServerCore.Pages.Teams
             }
 
             // Only handle one application at a time for a player to avoid spamming all teams
-            IEnumerable<TeamApplication> oldApplications = from TeamApplication oldApplication in _context.TeamApplications
+            IEnumerable<TeamApplication> oldApplications = from oldApplication in _context.TeamApplications
                                                            where oldApplication.Player == LoggedInUser && oldApplication.Team.Event == Event
                                                            select oldApplication;
             _context.TeamApplications.RemoveRange(oldApplications);

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -63,7 +63,7 @@ namespace ServerCore.Pages.Teams
             }
 
             if ((EventRole == EventRole.admin && !await LoggedInUser.IsAdminForEvent(_context, Event))
-                || IsNotAllowedInInternEvent())
+                || (EventRole != EventRole.admin && IsNotAllowedInInternEvent()))
             {
                 return Forbid();
             }
@@ -119,7 +119,7 @@ namespace ServerCore.Pages.Teams
                     _context.TeamMembers.Add(teamMember);
                 }
 
-                var hints = await (from Hint hint in _context.Hints
+                var hints = await (from hint in _context.Hints
                             where hint.Puzzle.Event == Event
                             select hint).ToListAsync();
 
@@ -128,7 +128,7 @@ namespace ServerCore.Pages.Teams
                     _context.HintStatePerTeam.Add(new HintStatePerTeam() { Hint = hint, Team = Team });
                 }
 
-                var puzzleIDs = await (from Puzzle puzzle in _context.Puzzles
+                var puzzleIDs = await (from puzzle in _context.Puzzles
                                 where puzzle.Event == Event
                                 select puzzle.ID).ToListAsync();
                 foreach (int puzzleID in puzzleIDs)

--- a/ServerCore/Pages/Teams/Hints.cshtml
+++ b/ServerCore/Pages/Teams/Hints.cshtml
@@ -116,7 +116,7 @@ You have <b>
                             {
                                 var clickString = hint.AdjustedCost == 0
                                     ? "return confirm('Are you sure you want to unlock this free hint?')"
-                                    : "return confirm('Are you sure you want to spend @hint.AdjustedCost tickets to find out &quot;@hint.Hint.Description&quot;?')";
+                                    : "return confirm('Are you sure you want to spend " + @hint.AdjustedCost + " tickets to find out \\'" + @hint.Hint.Description + "\\'?')";
 
                                 <button type="submit" asp-route-hintId="@hint.Hint.Id" 
                                     asp-route-teamId="@Model.Team.ID" 

--- a/ServerCore/Pages/Teams/List.cshtml.cs
+++ b/ServerCore/Pages/Teams/List.cshtml.cs
@@ -41,7 +41,7 @@ namespace ServerCore.Pages.Teams
                 return RedirectToPage("./Details", new { teamId = playerTeam.Team.ID });
             }
 
-            var applications = from TeamApplication application in _context.TeamApplications
+            var applications = from application in _context.TeamApplications
                                where application.Player == LoggedInUser && application.Team.Event == Event
                                select application.Team;
             AppliedTeam = await applications.FirstOrDefaultAsync();

--- a/ServerCore/Pages/TestConfig.cshtml.cs
+++ b/ServerCore/Pages/TestConfig.cshtml.cs
@@ -9,7 +9,7 @@ namespace ServerCore.Pages
     [Authorize(Policy = "IsGlobalAdmin")]
     public class TestConfigModel : PageModel
     {
-        public async Task<IActionResult> OnPostSendTestEmailAsync()
+        public IActionResult OnPostSendTestEmail()
         {
             // The purpose of this function is to verify that the server is configured properly.
             // That's why there are no options and we don't try different kinds of recipients and bodies.

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -474,8 +474,8 @@ namespace ServerCore
         {
             using (IDbContextTransaction transaction = context.Database.BeginTransaction(System.Data.IsolationLevel.Serializable))
             {
-                var submissionsThatMatchResponse = await (from PuzzleStatePerTeam pspt in context.PuzzleStatePerTeam
-                                                          join Submission sub in context.Submissions on pspt.Team equals sub.Team
+                var submissionsThatMatchResponse = await (from pspt in context.PuzzleStatePerTeam
+                                                          join sub in context.Submissions on pspt.Team equals sub.Team
                                                           where pspt.PuzzleID == response.PuzzleID &&
                                                           sub.PuzzleID == response.PuzzleID &&
                                                           sub.SubmissionText == response.SubmittedText
@@ -499,8 +499,8 @@ namespace ServerCore
                     await context.SaveChangesAsync();
                     transaction.Commit();
 
-                    var teamMembers = await (from TeamMembers tm in context.TeamMembers
-                                             join Submission sub in context.Submissions on tm.Team equals sub.Team
+                    var teamMembers = await (from tm in context.TeamMembers
+                                             join sub in context.Submissions on tm.Team equals sub.Team
                                              where sub.PuzzleID == response.PuzzleID && sub.SubmissionText == response.SubmittedText
                                              select tm.Member.Email).ToListAsync();
                     MailHelper.Singleton.SendPlaintextBcc(teamMembers,

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -334,7 +334,7 @@ namespace ServerCore
             while (true)
             {
                 var puzzlesToSolveByTime = await PuzzleStateHelper.GetSparseQuery(context, eventObj, null, team)
-                    .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesToAutomaticallySolve != null && state.UnlockedTime.Value + TimeSpan.FromMinutes(state.Puzzle.MinutesToAutomaticallySolve.Value) <= now)
+                    .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesToAutomaticallySolve != null && EF.Functions.DateDiffMinute(state.UnlockedTime.Value, now) < state.Puzzle.MinutesToAutomaticallySolve.Value)
                     .Select((state) => new { Puzzle = state.Puzzle, UnlockedTime = state.UnlockedTime.Value })
                     .ToListAsync();
 
@@ -373,7 +373,7 @@ namespace ServerCore
         {
             DateTime now = DateTime.UtcNow;
             return PuzzleStateHelper.GetSparseQuery(context, eventObj, null, team)
-                .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesOfEventLockout != 0 && state.UnlockedTime.Value + TimeSpan.FromMinutes(state.Puzzle.MinutesOfEventLockout) > now)
+                .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesOfEventLockout != 0 && EF.Functions.DateDiffMinute(state.UnlockedTime.Value, now) > state.Puzzle.MinutesOfEventLockout)
                 .Select((s) => s.Puzzle);
         }
 

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -334,7 +334,7 @@ namespace ServerCore
             while (true)
             {
                 var puzzlesToSolveByTime = await PuzzleStateHelper.GetSparseQuery(context, eventObj, null, team)
-                    .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesToAutomaticallySolve != null && EF.Functions.DateDiffMinute(state.UnlockedTime.Value, now) < state.Puzzle.MinutesToAutomaticallySolve.Value)
+                    .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesToAutomaticallySolve != null && EF.Functions.DateDiffMinute(state.UnlockedTime.Value, now) >= state.Puzzle.MinutesToAutomaticallySolve.Value)
                     .Select((state) => new { Puzzle = state.Puzzle, UnlockedTime = state.UnlockedTime.Value })
                     .ToListAsync();
 
@@ -373,7 +373,7 @@ namespace ServerCore
         {
             DateTime now = DateTime.UtcNow;
             return PuzzleStateHelper.GetSparseQuery(context, eventObj, null, team)
-                .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesOfEventLockout != 0 && EF.Functions.DateDiffMinute(state.UnlockedTime.Value, now) > state.Puzzle.MinutesOfEventLockout)
+                .Where(state => state.SolvedTime == null && state.UnlockedTime != null && state.Puzzle.MinutesOfEventLockout != 0 && EF.Functions.DateDiffMinute(state.UnlockedTime.Value, now) < state.Puzzle.MinutesOfEventLockout)
                 .Select((s) => s.Puzzle);
         }
 

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -202,7 +202,7 @@ namespace ServerCore
             await context.SaveChangesAsync();
 
             // if this puzzle got solved, look for others to unlock
-            if (value != null)
+            if (puzzle != null && value != null)
             {
                 await UnlockAnyPuzzlesThatThisSolveUnlockedAsync(context,
                     eventObj,
@@ -395,7 +395,7 @@ namespace ServerCore
         /// </summary>
         /// <param name="context">The puzzle DB context</param>
         /// <param name="eventObj">The event we are working in</param>
-        /// <param name="puzzleJustSolved">The puzzle just solved; if null, all the puzzles in the event (which will make more sense once we add per author filtering)</param>
+        /// <param name="puzzleJustSolved">The puzzle just solved</param>
         /// <param name="team">The team that just solved; if null, all the teams in the event.</param>
         /// <param name="unlockTime">The time that the puzzle should be marked as unlocked.</param>
         /// <returns></returns>

--- a/ServerCore/ServerCore.csproj
+++ b/ServerCore/ServerCore.csproj
@@ -31,13 +31,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.9.406" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="5.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="2.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
   <ItemGroup>

--- a/ServerCore/ServerCore.csproj
+++ b/ServerCore/ServerCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>04bdbf00-8cf2-4132-9652-595fd71fdc98</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/ServerCore/ServerCore.csproj
+++ b/ServerCore/ServerCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <UserSecretsId>04bdbf00-8cf2-4132-9652-595fd71fdc98</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -31,11 +31,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.9.406" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/ServerCore/ServerCore.csproj
+++ b/ServerCore/ServerCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>04bdbf00-8cf2-4132-9652-595fd71fdc98</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/ServerCore/ServerCore.csproj
+++ b/ServerCore/ServerCore.csproj
@@ -31,14 +31,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.9.406" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="2.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Version="2.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />

--- a/ServerCore/Startup.cs
+++ b/ServerCore/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ServerCore.Areas.Deployment;
 using ServerCore.Areas.Identity.UserAuthorizationPolicy;
 using ServerCore.DataModel;
+using ServerCore.Areas.Identity;
 
 namespace ServerCore
 {
@@ -41,21 +42,6 @@ namespace ServerCore
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            //services.AddMvc(config =>
-            //{
-            //    var policy = new AuthorizationPolicyBuilder()
-            //                     .RequireAuthenticatedUser()
-            //                     .Build();
-            //    config.Filters.Add(new AuthorizeFilter(policy));
-            //})
-            //    .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
-
-            //services.AddMvc()
-            //    .AddRazorPagesOptions(options =>
-            //    {
-            //        options.Conventions.AuthorizeFolder("/Pages");
-            //        options.Conventions.AuthorizeFolder("/ModelBases");
-            //    });
             services.AddRazorPages()
             .AddRazorPagesOptions(options =>
             {
@@ -105,6 +91,7 @@ namespace ServerCore
             services.AddScoped<IAuthorizationHandler, IsRegisteredForEventHandler_Author>();
             services.AddScoped<IAuthorizationHandler, IsRegisteredForEventHandler_Player>();
             services.AddScoped<BackgroundFileUploader>();
+            services.AddScoped<AuthorizationHelper>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/ServerCore/Startup.cs
+++ b/ServerCore/Startup.cs
@@ -42,6 +42,13 @@ namespace ServerCore
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            // Endpoint routing breaks most of our links because it doesn't include "ambient" route parameters
+            // like eventId and eventRole in links -- they'd have to be manually specified everywhere
+            services.AddMvc(options =>
+            {
+                options.EnableEndpointRouting = false;
+            });
+
             services.AddRazorPages()
             .AddRazorPagesOptions(options =>
             {
@@ -125,14 +132,9 @@ namespace ServerCore
             // According to the Identity Scaffolding readme the order of the following calls matters
             // Must be UseStaticFiles, UseAuthentication, UseMvc
             app.UseStaticFiles();
-            app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapRazorPages();
-            });
+            app.UseMvc();
         }
     }
 }

--- a/ServerCore/SyncController.cs
+++ b/ServerCore/SyncController.cs
@@ -360,7 +360,7 @@ namespace ServerCore.Pages
             if (existingAnnotation != null)
             {
                 context.Entry(existingAnnotation).State = EntityState.Detached;
-                UpdateOneAnnotation(response, puzzleId, teamId, key, contents);
+                await UpdateOneAnnotation(response, puzzleId, teamId, key, contents);
             }
             else
             {
@@ -382,7 +382,7 @@ namespace ServerCore.Pages
                     // doesn't think the annotation is in the database.
     
                     context.Entry(annotation).State = EntityState.Detached;
-                    UpdateOneAnnotation(response, puzzleId, teamId, key, contents);
+                    await UpdateOneAnnotation(response, puzzleId, teamId, key, contents);
                 }
             }
         }

--- a/ServerCore/SyncController.cs
+++ b/ServerCore/SyncController.cs
@@ -329,7 +329,7 @@ namespace ServerCore.Pages
           
           try {
               var sqlCommand = "UPDATE Annotations SET Version = Version + 1, Contents = @Contents, Timestamp = @Timestamp WHERE PuzzleID = @PuzzleID AND TeamID = @TeamID AND [Key] = @Key";
-              int result = await context.Database.ExecuteSqlCommandAsync(sqlCommand,
+              int result = await context.Database.ExecuteSqlRawAsync(sqlCommand,
                                                                          new SqlParameter("@Contents", contents),
                                                                          new SqlParameter("@Timestamp", DateTime.Now),
                                                                          new SqlParameter("@PuzzleID", puzzleId),


### PR DESCRIPTION
Upgrade to .NET 5. Reasons for doing so:
* .NET Core 2.1 goes out of support in August
* Newer versions of .NET Core include Blazor, which should allow more interactive pages without reloads (This will help for PH Hints and would also let us make select pages like answer submission faster)
* Newer versions have improved performance

Changes include:
* Project and package updates to 5.0
* Fixes for breaking changes:
  * Entity Framework no longer does automatic local evaluation, so queries that required local evaluation have been refactored. In most cases, this should have either equivalent or better performance
  * AuthorizationFilterContext is gone, replace with passing appropriate objects to the auth helpers
  * Workarounds for EF Core bugs:
    * Some queries that include the name of the type were broken in .NET Core 3.1 (the bug was supposedly fixed in .NET 5, but I haven't verified it). Removed the name of the type from the impacted queries.
    * Navigation properties with the Required attribute set up the wrong kind of foreign key. This would mess with several tables the next time somebody generates a migration. Worked around by adding a ID property to the affected classes (that doesn't have any effect on the DB).