### PR TITLE
Small quality of life improvements for freeform puzzles

### DIFF
--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml
@@ -1,7 +1,7 @@
 ﻿@page "/{eventId}/{eventRole}/Submissions/AuthorIndex/{puzzleId?}"
 @model ServerCore.Pages.Submissions.AuthorIndexModel
 @{
-    ViewData["Title"] = "AuthorIndex";
+    ViewData["Title"] = "Submissions";
     ViewData["AdminRoute"] = "../Submissions/AuthorIndex";
     ViewData["AuthorRoute"] = "../Submissions/AuthorIndex";
     // TODO: Needs to handle implicit teams - ViewData["PlayRoute"] = "../Submissions/Index";
@@ -21,10 +21,19 @@
 <h2>@if (Model.Puzzle != null) { <text>@Model.Puzzle.Name:</text> } Submissions @if (Model.Team != null) { <text>by @Model.Team.Name</text> }</h2>
 <a asp-page="/Puzzles/Index">Back to puzzle list</a> | <a asp-page="/Submissions/SubmissionsWithoutResponses" asp-route-puzzleId="@Model.Puzzle?.ID">Submissions without responses</a>
 <div>
-    @if(Model.Puzzle != null) { <a asp-page="./AuthorIndex" asp-route-puzzleId="" asp-route-teamId="@Model.Team?.ID">Clear Puzzle Filter</a> }
+    @if(Model.Puzzle != null) { <a asp-page="./AuthorIndex" asp-route-puzzleId="" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform">Clear Puzzle Filter</a> }
     @if(Model.Puzzle != null && Model.Team != null) { <text>|</text> }  
-    @if(Model.Team != null) { <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="">Clear Team Filter</a> }  
-    @if(Model.Puzzle != null && Model.Team != null) { <text>|</text> <a asp-page="./AuthorIndex" asp-route-puzzleId="" asp-route-teamId="">Clear All Filters</a> }  
+    @if(Model.Team != null) { <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="" asp-route-hideFreeform="@Model.HideFreeform">Clear Team Filter</a> }  
+    @if(Model.Puzzle != null && Model.Team != null) { <text>|</text> <a asp-page="./AuthorIndex" asp-route-puzzleId="" asp-route-teamId="" asp-route-hideFreeform="@Model.HideFreeform">Clear All Filters</a> }  
+    <text>|</text>
+    @if (Model.HideFreeform)
+    {
+        <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="false" asp-route-sort="@Model.Sort">Show Freeform</a>
+    }
+    else
+    {        
+        <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="true" asp-route-sort="@Model.Sort">Hide Freeform</a>
+    }
 </div>
 <br/>
 <div>
@@ -36,32 +45,32 @@
         <thead>
             <tr>
                 <th>
-                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.PlayerAscending, AuthorIndexModel.SortOrder.PlayerDescending))">
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.PlayerAscending, AuthorIndexModel.SortOrder.PlayerDescending))">
                         Player
                     </a>
                 </th>
                 <th>
-                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TeamAscending, AuthorIndexModel.SortOrder.TeamDescending))">
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TeamAscending, AuthorIndexModel.SortOrder.TeamDescending))">
                         Team Name
                     </a>
                 </th>
                 <th>
-                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.PuzzleAscending, AuthorIndexModel.SortOrder.PuzzleDescending))">
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.PuzzleAscending, AuthorIndexModel.SortOrder.PuzzleDescending))">
                         Puzzle
                     </a>
                 </th>
                 <th>
-                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.ResponseAscending, AuthorIndexModel.SortOrder.ResponseDescending))">
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.ResponseAscending, AuthorIndexModel.SortOrder.ResponseDescending))">
                         ResponseText
                     </a>
                 </th>
                 <th>
-                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.SubmissionAscending, AuthorIndexModel.SortOrder.SubmissionDescending))">
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.SubmissionAscending, AuthorIndexModel.SortOrder.SubmissionDescending))">
                         SubmissionText
                     </a>
                 </th>
                 <th>
-                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TimeAscending, AuthorIndexModel.SortOrder.TimeDescending))">
+                    <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TimeAscending, AuthorIndexModel.SortOrder.TimeDescending))">
                         TimeSubmitted
                     </a>
                 </th>

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
@@ -41,7 +41,9 @@ namespace ServerCore.Pages.Submissions
 
         public const SortOrder DefaultSort = SortOrder.TimeDescending;
 
-        public async Task<IActionResult> OnGetAsync(int? puzzleId, int? teamId, SortOrder? sort)
+        public bool HideFreeform { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int? puzzleId, int? teamId, SortOrder? sort, bool? hideFreeform)
         {
             Sort = sort;
 
@@ -92,7 +94,17 @@ namespace ServerCore.Pages.Submissions
                     submissionsQ = _context.Submissions.Where((s) => s.Puzzle != null && s.Puzzle.ID == puzzleId && s.Team.ID == teamId);
                 }
             }
-            
+
+            if (hideFreeform == null || hideFreeform.Value)
+            {
+                HideFreeform = true;
+                submissionsQ = submissionsQ.Where(s => !s.Puzzle.IsFreeform);
+            }
+            else
+            {
+                HideFreeform = false;
+            }
+
             IQueryable<SubmissionView> submissionViewQ = submissionsQ
                 .Select((s) => new SubmissionView
                 {

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml
@@ -17,7 +17,7 @@
         <h2>Freeform Queue</h2>
     }
 
-    <h3>Queue length: @Model.Submissions.Count</h3>
+    <h3>Queue length: @Model.FullQueueSize</h3>
 
     <table class="table">
         <thead>

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml
@@ -37,7 +37,16 @@
             <tr>
                 <td>@submission.PuzzleName</td>
                 <td>@submission.TeamName</td>
-                <td>@submission.SubmissionText</td>
+                <td>
+                    @if (submission.Linkify)
+                    {
+                        <a href="@submission.SubmissionText">@submission.SubmissionText</a>
+                    }
+                    else
+                    {
+                        @submission.SubmissionText
+                    }
+                </td>
                 <td>
                     <form method="post">
                         <input type="text" asp-for="FreeformResponse" />

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
@@ -52,6 +52,8 @@ namespace ServerCore.Pages.Submissions
 
         public List<SubmissionView> Submissions { get; set; }
 
+        public int FullQueueSize { get; set; }
+
         public async Task<IActionResult> OnGetAsync(int? puzzleId)
         {
             if (puzzleId != null)
@@ -93,6 +95,8 @@ namespace ServerCore.Pages.Submissions
             }
 
             Submissions = await submissionQuery.Take(50).ToListAsync();
+
+            FullQueueSize = await submissionQuery.CountAsync();
             
             foreach(SubmissionView submission in Submissions)
             {

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
@@ -31,6 +31,7 @@ namespace ServerCore.Pages.Submissions
             public string TeamName { get; set; }
             public string SubmissionText { get; set; }
             public int SubmissionId { get; set; }
+            public bool Linkify { get; set; }
         }
 
         [BindProperty]
@@ -91,7 +92,15 @@ namespace ServerCore.Pages.Submissions
                 submissionQuery = submissionQuery.Where(submissionView => submissionView.PuzzleId == puzzleId);
             }
 
-            Submissions = await submissionQuery.ToListAsync();
+            Submissions = await submissionQuery.Take(50).ToListAsync();
+            
+            foreach(SubmissionView submission in Submissions)
+            {
+                if(submission.SubmissionText.StartsWith("http"))
+                {
+                    submission.Linkify = Uri.IsWellFormedUriString(submission.SubmissionText, UriKind.Absolute);
+                }
+            }
         }
 
         public async Task<IActionResult> OnPostAsync(int? puzzleId)

--- a/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml.cs
+++ b/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml.cs
@@ -62,7 +62,8 @@ namespace ServerCore.Pages.Submissions
             }
 
             SubmissionCounts = await (from submission in submissionsQ
-                                         where submission.Response == null
+                                         where submission.Response == null &&
+                                         !submission.Puzzle.IsFreeform
                                          group submission by new { submission.PuzzleID, submission.SubmissionText, submission.Puzzle.Name } into submissionCounts
                                          orderby submissionCounts.Count() descending
                                          select new SubmissionCountsView


### PR DESCRIPTION
Small quality of life improvements for freeform puzzles:
* Turn submisisons that are only a URL into a link
* Limit queue length to make sure the page won't get overwhelmed
* Default to not showing freeform submissions on the submissions page and hide them entirely on SubmisisonsWithoutResponses