### PR TITLE
Improve Import speed

### DIFF
--- a/ServerCore/Pages/Events/Import.cshtml.cs
+++ b/ServerCore/Pages/Events/Import.cshtml.cs
@@ -157,7 +157,14 @@ namespace ServerCore.Pages.Events
                         ContentFile newFile = new ContentFile(contentFile);
                         newFile.EventID = Event.ID;
                         newFile.PuzzleID = puzzleCloneMap[contentFile.Puzzle.ID].ID;
-                        _backgroundUploader.CloneInBackground(newFile, contentFile.ShortName, Event.ID, contentFile.Url);
+                        
+                        // new
+                        // does not copy the files; you have to use Azure Storage Explorer for that afterwards
+                        newFile.UrlString = contentFile.UrlString.Replace("evt" + ImportEventID, "evt" + Event.ID);
+                        _context.ContentFiles.Add(newFile);
+
+                        // old
+                        //_backgroundUploader.CloneInBackground(newFile, contentFile.ShortName, Event.ID, contentFile.Url);
                     }
 
                     // Pieces


### PR DESCRIPTION
The slowest part of Import turns out to be the file copy, by far. This change removes the file copy responsibilities from the import task entirely; the storage can simply be duplicated in Azure Storage Explorer by right-clicking and using the Clone... command, then providing the folder name that the import step adds to URLs for this event.