### PR TITLE
Add team password url parameter

### DIFF
--- a/ServerCore/Helpers/PuzzleHelper.cs
+++ b/ServerCore/Helpers/PuzzleHelper.cs
@@ -33,16 +33,16 @@ namespace ServerCore.Helpers
 
         public static string GetFormattedUrl(Puzzle puzzle, int eventId)
         {
-            return GetFormattedUrl(puzzle.CustomURL, puzzle.ID, eventId);
+            return GetFormattedUrl(puzzle.CustomURL, puzzle.ID, eventId, null);
         }
 
-        public static string GetFormattedUrl(string customUrl, int puzzleId, int eventId)
+        public static string GetFormattedUrl(string customUrl, int puzzleId, int eventId, string teamPassword)
         {
             if (customUrl == null)
             {
                 return null;
             }
-            string formattedUrl = customUrl.Replace("{puzzleId}", $"{puzzleId}").Replace("{eventId}", $"{eventId}");
+            string formattedUrl = customUrl.Replace("{puzzleId}", $"{puzzleId}").Replace("{eventId}", $"{eventId}").Replace("{teamPass}", teamPassword);
             return formattedUrl;
         }
 

--- a/ServerCore/Pages/Events/CreateDemo.cshtml.cs
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml.cs
@@ -355,19 +355,19 @@ namespace ServerCore.Pages.Events
                 //
                 // Create teams. Can we add players to these?
                 //
-                Team team1 = new Team { Name = "Team Bugs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "bugs@example.com" };
+                Team team1 = new Team { Name = "Team Bugs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "bugs@example.com", Password = Guid.NewGuid().ToString() };
                 _context.Teams.Add(team1);
 
-                Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "babs@example.com" };
+                Team team2 = new Team { Name = "Team Babs", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "babs@example.com", Password = Guid.NewGuid().ToString() };
                 _context.Teams.Add(team2);
 
-                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = false, PrimaryContactEmail = "buster@example.com" };
+                Team team3 = new Team { Name = "Team Buster", Event = Event, IsLookingForTeammates = false, PrimaryContactEmail = "buster@example.com", Password = Guid.NewGuid().ToString() };
                 _context.Teams.Add(team3);
 
                 Team teamLoneWolf = null;
                 if (AddCreatorToLoneWolfTeam)
                 {
-                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "wolf@example.com" };
+                    teamLoneWolf = new Team { Name = "Lone Wolf", Event = Event, IsLookingForTeammates = true, PrimaryContactEmail = "wolf@example.com", Password = Guid.NewGuid().ToString() };
                     _context.Teams.Add(teamLoneWolf);
                 }
 

--- a/ServerCore/Pages/PuzzleApiController.cs
+++ b/ServerCore/Pages/PuzzleApiController.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+
+namespace ServerCore.Pages
+{
+    /// <summary>
+    /// API controller for puzzles on external sites
+    /// External sites don't have access to auth, so these APIs should rely on data given by this site
+    /// and validate inputs as untrusted
+    /// </summary>
+    public class PuzzleApiController : Controller
+    {
+        private readonly PuzzleServerContext context;
+
+        public PuzzleApiController(PuzzleServerContext context)
+        {
+            this.context = context;
+        }
+
+        /// <summary>
+        /// Allows external puzzles to validate a team password
+        /// </summary>
+        /// <param name="teamPassword">Potential team password</param>
+        /// <returns>True if the password belongs to a team, false otherwise</returns>
+        [HttpGet]
+        [Route("api/puzzleapi/validateteampassword")]
+        public async Task<ActionResult<bool>> GetValidateTeamPasswordAsync(string teamPassword)
+        {
+            if (string.IsNullOrWhiteSpace(teamPassword))
+            {
+                return false;
+            }
+
+            return await (from team in context.Teams
+                          where team.Password == teamPassword
+                          select team).AnyAsync();
+        }
+    }
+}

--- a/ServerCore/Pages/Teams/Play.cshtml
+++ b/ServerCore/Pages/Teams/Play.cshtml
@@ -108,7 +108,7 @@
 
                     @if (item.CustomUrl != null)
                     {
-                        <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomUrl, item.ID, Model.Event.ID)" target="_blank">@item.Name</a>
+                        <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomUrl, item.ID, Model.Event.ID, Model.TeamPassword)" target="_blank">@item.Name</a>
                     }
                     else if (item.Content != null)
                     {

--- a/ServerCore/Pages/Teams/Play.cshtml.cs
+++ b/ServerCore/Pages/Teams/Play.cshtml.cs
@@ -29,6 +29,8 @@ namespace ServerCore.Pages.Teams
 
         public int TeamID { get; set; }
 
+        public string TeamPassword { get; set; }
+
         public SortOrder? Sort { get; set; }
 
         private const SortOrder DefaultSort = SortOrder.GroupAscending;
@@ -43,7 +45,8 @@ namespace ServerCore.Pages.Teams
             Team myTeam = await UserEventHelper.GetTeamForPlayer(_context, Event, LoggedInUser);
             if (myTeam != null)
             {
-                this.TeamID = myTeam.ID;
+                TeamID = myTeam.ID;
+                TeamPassword = myTeam.Password;
                 await PuzzleStateHelper.CheckForTimedUnlocksAsync(_context, Event, myTeam);
             }
             else


### PR DESCRIPTION
Allow authors to add a team password to a puzzle url so the puzzle can verify that a link is associated with a particular team