### PR TITLE
Improve Import Perf

### DIFF
--- a/Data/DataModel/Event.cs
+++ b/Data/DataModel/Event.cs
@@ -21,6 +21,14 @@ namespace ServerCore.DataModel
         public string EventID => UrlString ?? ID.ToString();
 
         /// <summary>
+        /// I was unable to put this in a separate ImportEvent model in import.cshtml.cs;
+        /// for some reason SelectList did not like those type of items.
+        /// Kludging the info here although I really shouldn't have to...
+        /// </summary>
+        [NotMapped]
+        public string NameAndContainer => $"{Name} (evt{ID})";
+
+        /// <summary>
         /// The prefix of the partial files that provide the Home, FAQ, and Rules content.
         /// </summary>
         public string HomePartial { get; set; }

--- a/ServerCore/Pages/Events/Import.cshtml
+++ b/ServerCore/Pages/Events/Import.cshtml
@@ -15,6 +15,7 @@
 
 <form method="post" enctype="multipart/form-data">
     <input type="hidden" asp-for="Event.ID" />
-    <select class="form-control" asp-for="ImportEventID" asp-items="@(new SelectList(Model.Events, "ID", "Name"))"></select>
+    <select class="form-control" asp-for="ImportEventID" asp-items="@(new SelectList(Model.Events, "ID", "NameAndContainer"))"></select>
     <input type="submit" value="Import" asp-page-handler="Import" class="btn btn-default" />
+    <p><b>Note: The import will not copy the files themselves, just the data. After successful import, use Azure Storage Explorer to clone the directory for your event into a new evt<span>@Model.Event.ID</span> directory.</b></p>
 </form>

--- a/ServerCore/Pages/Events/Import.cshtml.cs
+++ b/ServerCore/Pages/Events/Import.cshtml.cs
@@ -157,7 +157,14 @@ namespace ServerCore.Pages.Events
                         ContentFile newFile = new ContentFile(contentFile);
                         newFile.EventID = Event.ID;
                         newFile.PuzzleID = puzzleCloneMap[contentFile.Puzzle.ID].ID;
-                        _backgroundUploader.CloneInBackground(newFile, contentFile.ShortName, Event.ID, contentFile.Url);
+
+                        // new
+                        // does not copy the files; you have to use Azure Storage Explorer for that afterwards
+                        newFile.UrlString = contentFile.UrlString.Replace("evt" + ImportEventID, "evt" + Event.ID);
+                        _context.ContentFiles.Add(newFile);
+
+                        // old
+                        //_backgroundUploader.CloneInBackground(newFile, contentFile.ShortName, Event.ID, contentFile.Url);
                     }
 
                     // Pieces


### PR DESCRIPTION
Improve the perf of import such that it succeeds by omitting file copy, and provide user instructions for how to complete the job by clining the container in Azure Storage Explorer.

The model for the container display is very kludgy; I tried to do it the "right" way by creating a separate model item within Import.cshtml.cs, but SelectList was crashing internally and not explaining why. Apologies!