### PR TITLE
More Bulk Edits

### DIFF
--- a/ServerCore/Pages/Hints/CreateBulk.cshtml
+++ b/ServerCore/Pages/Hints/CreateBulk.cshtml
@@ -1,0 +1,71 @@
+﻿@page "/{eventId}/{eventRole}/Hints/CreateBulk/{puzzleId}"
+@model ServerCore.Pages.Hints.CreateBulkModel
+
+@{
+    ViewData["Title"] = "Create bulk hints";
+    ViewData["AdminRoute"] = "../Hints/CreateBulk";
+    ViewData["AuthorRoute"] = "../Hints/CreateBulk";
+    ViewData["PlayRoute"] = "../Submissions/Index";
+    ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
+}
+
+<h2>@Model.Puzzle.Name: Create hints (bulk)</h2>
+<div>
+    <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
+</div>
+
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <div>
+            <p>Intended usage: Enter data for each hint in Excel, one line per hint. Then copy each column into the correct box below and click Bulk Create.</p>
+            <br />
+        </div>
+        <form method="post">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Description</th>
+                        <th>Content</th>
+                        <th>Cost</th>
+                        <th>DisplayOrder</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <textarea asp-for="Description"></textarea>
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <textarea asp-for="HintContent"></textarea>
+                            <span asp-validation-for="HintContent" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <textarea asp-for="Cost"></textarea>
+                            <span asp-validation-for="Cost" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <textarea asp-for="DisplayOrder"></textarea>
+                            <span asp-validation-for="DisplayOrder" class="text-danger"></span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <input asp-for="DeleteExisting" /> @Html.DisplayNameFor(model => model.DeleteExisting)
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Bulk Create" class="btn btn-default" />
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
+++ b/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
@@ -60,10 +60,10 @@ namespace ServerCore.Pages.Hints
                 _context.Hints.RemoveRange(hintsToRemove);
             }
 
-            StringReader descriptionReader = new StringReader(Description ?? string.Empty);
-            StringReader contentReader = new StringReader(HintContent ?? string.Empty);
-            StringReader costReader = new StringReader(Cost ?? string.Empty);
-            StringReader displayOrderReader = new StringReader(DisplayOrder ?? string.Empty);
+            using StringReader descriptionReader = new StringReader(Description ?? string.Empty);
+            using StringReader contentReader = new StringReader(HintContent ?? string.Empty);
+            using StringReader costReader = new StringReader(Cost ?? string.Empty);
+            using StringReader displayOrderReader = new StringReader(DisplayOrder ?? string.Empty);
 
             while (true)
             {

--- a/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
+++ b/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Hints
+{
+    [Authorize(Policy = "IsEventAdminOrAuthorOfPuzzle")]
+    public class CreateBulkModel : EventSpecificPageModel
+    {
+        public CreateBulkModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
+        {
+        }
+
+        [BindProperty]
+        public bool DeleteExisting { get; set; }
+
+        [BindProperty]
+        public string Description { get; set; }
+
+        [BindProperty]
+        public string HintContent { get; set; }
+
+        [BindProperty]
+        public string Cost { get; set; }
+
+        [BindProperty]
+        public string DisplayOrder { get; set; }
+
+        public int PuzzleId { get; set; }
+
+        public Puzzle Puzzle { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int puzzleId)
+        {
+            PuzzleId = puzzleId;
+            Puzzle = await _context.Puzzles.Where(m => m.ID == puzzleId).FirstOrDefaultAsync();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(int puzzleId)
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            if (DeleteExisting)
+            {
+                Hint[] hintsToRemove = await (from Hint h in _context.Hints
+                                                      where h.PuzzleID == puzzleId
+                                                      select h).ToArrayAsync();
+                _context.Hints.RemoveRange(hintsToRemove);
+            }
+
+            StringReader descriptionReader = new StringReader(Description ?? string.Empty);
+            StringReader contentReader = new StringReader(HintContent ?? string.Empty);
+            StringReader costReader = new StringReader(Cost ?? string.Empty);
+            StringReader displayOrderReader = new StringReader(DisplayOrder ?? string.Empty);
+
+            while (true)
+            {
+                string description = descriptionReader.ReadLine();
+                string content = contentReader.ReadLine();
+                string cost = costReader.ReadLine();
+                string displayOrder = displayOrderReader.ReadLine();
+
+                // TODO probably clearer ways to validate but I honestly do not understand how validation works
+                if (description == null)
+                {
+                    if (content != null)
+                    {
+                        ModelState.AddModelError("HintContent", "Unmatched Content without Description");
+                    }
+                    if (cost != null)
+                    {
+                        ModelState.AddModelError("Cost", "Unmatched Cost without Description");
+                    }
+                    if (displayOrder != null)
+                    {
+                        ModelState.AddModelError("DisplayOrder", "Unmatched DisplayOrder without Description");
+                    }
+
+                    // we're done
+                    break;
+                }
+
+                int costInt;
+                int displayOrderInt;
+
+                if (content == null)
+                {
+                    ModelState.AddModelError("HintContent", $"Content must be present");
+                }
+
+                // int checks also handle the null case
+                if (!int.TryParse(cost, out costInt))
+                {
+                    ModelState.AddModelError("Cost", $"Cost of '{cost}' must be an integer");
+                    break;
+                }
+
+                if (!int.TryParse(displayOrder, out displayOrderInt))
+                {
+                    ModelState.AddModelError("DisplayOrder", $"DisplayOrder of '{displayOrder}' must be an integer");
+                    break;
+                }
+
+                Hint hint = new Hint()
+                {
+                    PuzzleID = puzzleId,
+                    Description = description,
+                    Content = content,
+                    Cost = costInt,
+                    DisplayOrder = displayOrderInt
+                };
+
+                _context.Hints.Add(hint);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return await OnGetAsync(puzzleId);
+            }
+
+            await _context.SaveChangesAsync();
+
+            return RedirectToPage("./Index", new { puzzleid = puzzleId });
+        }
+    }
+}

--- a/ServerCore/Pages/Hints/CreateBulkMulti.cshtml
+++ b/ServerCore/Pages/Hints/CreateBulkMulti.cshtml
@@ -1,0 +1,75 @@
+﻿@page "/{eventId}/{eventRole}/Hints/CreateBulkMulti"
+@model ServerCore.Pages.Hints.CreateBulkMultiModel
+
+@{
+    ViewData["Title"] = "Create bulk hints - multiple";
+    ViewData["AdminRoute"] = "../Hints/CreateBulkMulti";
+    ViewData["AuthorRoute"] = "../Hints/CreateBulkMulti";
+    ViewData["PlayRoute"] = "../Submissions/Index";
+}
+
+<h2>Create hints (bulk, multiple puzzles)</h2>
+<div>
+    <a asp-page="/Puzzles/Index">Cancel</a>
+</div>
+
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <div>
+            <p>Intended usage: Enter data for each hint in Excel, one line per hint. Then copy each column into the correct box below and click Bulk Create.</p>
+            <br />
+        </div>
+        <form method="post">
+            <table>
+                <thead>
+                    <tr>
+                        <th>PuzzleName</th>
+                        <th>Description</th>
+                        <th>Content</th>
+                        <th>Cost</th>
+                        <th>DisplayOrder</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <textarea asp-for="PuzzleName"></textarea>
+                            <span asp-validation-for="PuzzleName" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <textarea asp-for="Description"></textarea>
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <textarea asp-for="HintContent"></textarea>
+                            <span asp-validation-for="HintContent" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <textarea asp-for="Cost"></textarea>
+                            <span asp-validation-for="Cost" class="text-danger"></span>
+                        </td>
+                        <td>
+                            <textarea asp-for="DisplayOrder"></textarea>
+                            <span asp-validation-for="DisplayOrder" class="text-danger"></span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <input asp-for="DeleteExisting" /> @Html.DisplayNameFor(model => model.DeleteExisting)
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Bulk Create" class="btn btn-default" />
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/ServerCore/Pages/Hints/CreateBulkMulti.cshtml.cs
+++ b/ServerCore/Pages/Hints/CreateBulkMulti.cshtml.cs
@@ -50,11 +50,11 @@ namespace ServerCore.Pages.Hints
                 return Page();
             }
 
-            StringReader puzzleNameReader = new StringReader(PuzzleName);
-            StringReader descriptionReader = new StringReader(Description ?? string.Empty);
-            StringReader contentReader = new StringReader(HintContent ?? string.Empty);
-            StringReader costReader = new StringReader(Cost ?? string.Empty);
-            StringReader displayOrderReader = new StringReader(DisplayOrder ?? string.Empty);
+            using StringReader puzzleNameReader = new StringReader(PuzzleName ?? string.Empty);
+            using StringReader descriptionReader = new StringReader(Description ?? string.Empty);
+            using StringReader contentReader = new StringReader(HintContent ?? string.Empty);
+            using StringReader costReader = new StringReader(Cost ?? string.Empty);
+            using StringReader displayOrderReader = new StringReader(DisplayOrder ?? string.Empty);
 
             Dictionary<string, int> puzzleTitleLookup = new Dictionary<string, int>();
 
@@ -147,6 +147,11 @@ namespace ServerCore.Pages.Hints
                 {
                     ModelState.AddModelError("DisplayOrder", $"DisplayOrder of '{displayOrder}' must be an integer");
                     break;
+                }
+
+                if (puzzleId == -1)
+                {
+                    throw new Exception($"Bug in puzzleId lookup for {puzzleName}");
                 }
 
                 Hint hint = new Hint()

--- a/ServerCore/Pages/Hints/CreateBulkMulti.cshtml.cs
+++ b/ServerCore/Pages/Hints/CreateBulkMulti.cshtml.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Hints
+{
+    [Authorize(Policy = "IsEventAdminOrEventAuthor")]
+    public class CreateBulkMultiModel : EventSpecificPageModel
+    {
+        public CreateBulkMultiModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
+        {
+        }
+
+        [BindProperty]
+        public bool DeleteExisting { get; set; }
+
+        [BindProperty]
+        public string PuzzleName { get; set; }
+
+        [BindProperty]
+        public string Description { get; set; }
+
+        [BindProperty]
+        public string HintContent { get; set; }
+
+        [BindProperty]
+        public string Cost { get; set; }
+
+        [BindProperty]
+        public string DisplayOrder { get; set; }
+
+        public IActionResult OnGet()
+        {
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            StringReader puzzleNameReader = new StringReader(PuzzleName);
+            StringReader descriptionReader = new StringReader(Description ?? string.Empty);
+            StringReader contentReader = new StringReader(HintContent ?? string.Empty);
+            StringReader costReader = new StringReader(Cost ?? string.Empty);
+            StringReader displayOrderReader = new StringReader(DisplayOrder ?? string.Empty);
+
+            Dictionary<string, int> puzzleTitleLookup = new Dictionary<string, int>();
+
+            while (true)
+            {
+                string puzzleName = puzzleNameReader.ReadLine();
+                string description = descriptionReader.ReadLine();
+                string content = contentReader.ReadLine();
+                string cost = costReader.ReadLine();
+                string displayOrder = displayOrderReader.ReadLine();
+
+                int puzzleId = -1;
+
+                if (puzzleName != null && !puzzleTitleLookup.TryGetValue(puzzleName, out puzzleId))
+                {
+                    Puzzle puzzle = await (from Puzzle p in _context.Puzzles
+                                           where p.Name == puzzleName && p.EventID == this.Event.ID
+                                           select p).FirstOrDefaultAsync();
+
+                    if (puzzle == null)
+                    {
+                        ModelState.AddModelError("PuzzleName", $"Puzzle '{puzzleName}' not found");
+                        break;
+                    }
+
+                    if (EventRole == EventRole.author && !await UserEventHelper.IsAuthorOfPuzzle(_context, puzzle, LoggedInUser))
+                    {
+                        ModelState.AddModelError("PuzzleName", $"Not an author of puzzle '{puzzleName}'");
+                        break;
+                    }
+
+                    puzzleId = puzzle.ID;
+
+                    puzzleTitleLookup[puzzleName] = puzzleId;
+
+                    if (DeleteExisting)
+                    {
+                        Hint[] hintsToRemove = await (from Hint h in _context.Hints
+                                                              where h.PuzzleID == puzzleId
+                                                              select h).ToArrayAsync();
+                        _context.Hints.RemoveRange(hintsToRemove);
+                    }
+                }
+
+                // TODO probably clearer ways to validate but I honestly do not understand how validation works
+                if (puzzleName == null)
+                {
+                    if (description != null)
+                    {
+                        ModelState.AddModelError("Description", "Unmatched Description without Puzzle");
+                    }
+                    if (content != null)
+                    {
+                        ModelState.AddModelError("HintContent", "Unmatched Content without Puzzle");
+                    }
+                    if (cost != null)
+                    {
+                        ModelState.AddModelError("Cost", "Unmatched Cost without Puzzle");
+                    }
+                    if (displayOrder != null)
+                    {
+                        ModelState.AddModelError("DisplayOrder", "Unmatched DisplayOrder without Puzzle");
+                    }
+
+                    // we're done
+                    break;
+                }
+
+                int costInt;
+                int displayOrderInt;
+
+                if (description == null)
+                {
+                    ModelState.AddModelError("Description", $"Description must be present");
+                }
+
+                if (content == null)
+                {
+                    ModelState.AddModelError("HintContent", $"Content must be present");
+                }
+
+                // int checks also handle the null case
+                if (!int.TryParse(cost, out costInt))
+                {
+                    ModelState.AddModelError("Cost", $"Cost of '{cost}' must be an integer");
+                    break;
+                }
+
+                if (!int.TryParse(displayOrder, out displayOrderInt))
+                {
+                    ModelState.AddModelError("DisplayOrder", $"DisplayOrder of '{displayOrder}' must be an integer");
+                    break;
+                }
+
+                Hint hint = new Hint()
+                {
+                    PuzzleID = puzzleId,
+                    Description = description,
+                    Content = content,
+                    Cost = costInt,
+                    DisplayOrder = displayOrderInt
+                };
+
+                _context.Hints.Add(hint);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return OnGet();
+            }
+
+            await _context.SaveChangesAsync();
+
+            return RedirectToPage("/Puzzles/Index");
+        }
+    }
+}

--- a/ServerCore/Pages/Hints/Index.cshtml
+++ b/ServerCore/Pages/Hints/Index.cshtml
@@ -13,7 +13,8 @@
 <h2>@Model.PuzzleName: Hints</h2>
 
 <p>
-    <a asp-page="Create" asp-route-puzzleID="@Model.PuzzleId">Create New</a>
+    <a asp-page="Create" asp-route-puzzleId="@Model.PuzzleId">Create New</a> |
+    <a asp-page="CreateBulk" asp-route-puzzleId="@Model.PuzzleId">Bulk Create</a>
 </p>
 <table class="table">
     <thead>

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -34,16 +34,25 @@
 <h2>@Model.Event.Name Puzzles (@Model.Puzzles.Count):</h2>
 
 <p>
-    <a asp-page="Create">Create new</a> |
-    <a asp-page="/Submissions/AuthorIndex">View all submissions</a> |
-    <a asp-page="/Puzzles/Feedback">View all feedback</a> |
-    <a asp-page="/Submissions/FreeformQueue">View freeform queue</a> |
+    Edit:
+    <a asp-page="Create">Create new puzzle</a> |
+    <a asp-page="/Responses/CreateBulkMulti">Bulk response create</a> |
     @if (!Model.Event.HideHints)
     {
+        <a asp-page="/Hints/CreateBulkMulti">Bulk hint create</a> @(" |")
         <a asp-page="/Hints/Responses">View all hint responses</a> @(" |")
-        <a asp-page="/Hints/AuthorIndex">View all hints taken</a> @(" |")
     }
     <a asp-page="/Puzzles/Checklist">View puzzle checklist</a>
+</p>
+<p>
+    Support:
+    <a asp-page="/Submissions/AuthorIndex">View all submissions</a> |
+    <a asp-page="/Puzzles/Feedback">View all feedback</a> |
+    @if (!Model.Event.HideHints)
+    {
+        <a asp-page="/Hints/AuthorIndex">View all hints taken</a> @(" |")
+    }
+    <a asp-page="/Submissions/FreeformQueue">View freeform queue</a>
 </p>
 <table class="table">
     <thead>

--- a/ServerCore/Pages/Responses/CreateBulkMulti.cshtml
+++ b/ServerCore/Pages/Responses/CreateBulkMulti.cshtml
@@ -1,17 +1,16 @@
-﻿@page "/{eventId}/{eventRole}/Responses/CreateBulk/{puzzleId}"
-@model ServerCore.Pages.Responses.CreateBulkModel
+﻿@page "/{eventId}/{eventRole}/Responses/CreateBulkMulti"
+@model ServerCore.Pages.Responses.CreateBulkMultiModel
 
 @{
-    ViewData["Title"] = "Create bulk response";
-    ViewData["AdminRoute"] = "../Responses/CreateBulk";
-    ViewData["AuthorRoute"] = "../Responses/CreateBulk";
+    ViewData["Title"] = "Create bulk response - multiple";
+    ViewData["AdminRoute"] = "../Responses/CreateBulkMulti";
+    ViewData["AuthorRoute"] = "../Responses/CreateBulkMulti";
     ViewData["PlayRoute"] = "../Submissions/Index";
-    ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
 }
 
-<h2>@Model.Puzzle.Name: Create responses (bulk)</h2>
+<h2>Create responses (bulk, multiple puzzles)</h2>
 <div>
-    <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
+    <a asp-page="/Puzzles/Index">Cancel</a>
 </div>
 
 <hr />
@@ -27,6 +26,7 @@
             <table>
                 <thead>
                     <tr>
+                        <th>PuzzleName</th>
                         <th>IsSolution</th>
                         <th>SubmittedText</th>
                         <th>ResponseText</th>
@@ -35,6 +35,10 @@
                 </thead>
                 <tbody>
                     <tr>
+                        <td>
+                            <textarea asp-for="PuzzleName"></textarea>
+                            <span asp-validation-for="PuzzleName" class="text-danger"></span>
+                        </td>
                         <td>
                             <textarea asp-for="IsSolution"></textarea>
                             <span asp-validation-for="IsSolution" class="text-danger"></span>


### PR DESCRIPTION
More Bulk Edits

Support bulk creation of hints, and also support deletion of existing responses/hints during bulk creation.

Also, support multi-puzzle bulk creation of hints/responses. Multi-puzzle is largely the same as single-puzzle except that it has an extra column for puzzle names, and it does not send mail to players.

I know there are some chunks of similar code here, but refactoring seemed a little tricky.