### PR TITLE
Remove double url escaping

### DIFF
--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml.cs
@@ -215,8 +215,7 @@ namespace ServerCore.Pages.Puzzles
             }
 
             ContentFile file = new ContentFile();
-            string fileName = WebUtility.UrlEncode(Path.GetFileName(uploadedFile.FileName));
-
+            string fileName = uploadedFile.FileName;
             file.ShortName = fileName;
             file.Puzzle = Puzzle;
             file.Event = Event;


### PR DESCRIPTION
Remove extra url escaping on file name uploads. The urls work correctly without it. Fixes #295 