### PR TITLE
Sync Client Support

### DIFF
--- a/ServerCore/SyncController.cs
+++ b/ServerCore/SyncController.cs
@@ -613,6 +613,9 @@ namespace ServerCore.Pages
             Dictionary<string, object> response = await responseTask;
             var responseSerialized = JsonConvert.SerializeObject(response);
             var initialSyncString = HttpUtility.JavaScriptStringEncode(responseSerialized);
+
+            fileContents = fileContents.Replace("@EVENTID", currentEvent.ID.ToString());
+            fileContents = fileContents.Replace("@PUZZLEID", puzzleId.ToString());
             fileContents = fileContents.Replace("@SYNC", initialSyncString);
 
             // Return the file contents to the user.


### PR DESCRIPTION
Make a custom sync client aware of the event ID and puzzle ID; this keeps us from having to update the client when migrating from event to event.