### PR TITLE
Detect duplicate team names

### DIFF
--- a/ServerCore/Helpers/TeamHelper.cs
+++ b/ServerCore/Helpers/TeamHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -157,6 +158,38 @@ namespace ServerCore.Helpers
 
             team.IsDisqualified = value;
             await context.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Detects whether another team has claimed this name, modulo capitalization and spaces.
+        /// </summary>
+        /// <param name="context">The context</param>
+        /// <param name="eventObj">The event the team name is requested in</param>
+        /// <param name="name">The name being requested</param>
+        /// <returns>True if the name is in use, false otherwise.</returns>
+        public static async Task<bool> IsTeamNameTakenAsync(
+            PuzzleServerContext context,
+            Event eventObj,
+            string name)
+        {
+            string TruncateName(string name)
+            {
+                return name.Replace(" ", "").ToLowerInvariant();
+            }
+
+            string truncatedName = TruncateName(name);
+
+            List<string> existingNames = await (from t in context.Teams where t.EventID == eventObj.ID select t.Name).ToListAsync();
+
+            foreach (string existingName in existingNames)
+            {
+                if (truncatedName == TruncateName(existingName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -87,6 +87,11 @@ namespace ServerCore.Pages.Teams
                 ModelState.AddModelError("Team.Name", "Name too long. Character limit: 50");
             }
 
+            if (await TeamHelper.IsTeamNameTakenAsync(_context, Event, Team.Name))
+            {
+                ModelState.AddModelError("Team.Name", "Another team has this name.");
+            }
+
             ModelState.Remove("Team.Event");
             if (!ModelState.IsValid)
             {

--- a/ServerCore/Pages/Teams/Edit.cshtml.cs
+++ b/ServerCore/Pages/Teams/Edit.cshtml.cs
@@ -73,6 +73,7 @@ namespace ServerCore.Pages.Teams
             if (await TeamHelper.IsTeamNameTakenAsync(_context, Event, Team.Name))
             {
                 ModelState.AddModelError("Team.Name", "Another team has this name.");
+                return Page();
             }
 
             // keep the room unchanged if an intern event, since interns can't edit their rooms

--- a/ServerCore/Pages/Teams/Edit.cshtml.cs
+++ b/ServerCore/Pages/Teams/Edit.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
+using ServerCore.Helpers;
 using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Teams
@@ -69,6 +70,10 @@ namespace ServerCore.Pages.Teams
                 return Page();
             }
 
+            if (await TeamHelper.IsTeamNameTakenAsync(_context, Event, Team.Name))
+            {
+                ModelState.AddModelError("Team.Name", "Another team has this name.");
+            }
 
             // keep the room unchanged if an intern event, since interns can't edit their rooms
             if (Event.IsInternEvent && EventRole != EventRole.admin)


### PR DESCRIPTION
This is not 100% foolproof, as two teams could theoretically create the same name within moments of each other, but it'll catch nearly all cases.