### PR TITLE
Fix team editing

### DIFF
--- a/ServerCore/Pages/Teams/Edit.cshtml.cs
+++ b/ServerCore/Pages/Teams/Edit.cshtml.cs
@@ -70,7 +70,7 @@ namespace ServerCore.Pages.Teams
                 return Page();
             }
 
-            if (await TeamHelper.IsTeamNameTakenAsync(_context, Event, Team.Name))
+            if (Team.Name != existingTeam.Name && await TeamHelper.IsTeamNameTakenAsync(_context, Event, Team.Name))
             {
                 ModelState.AddModelError("Team.Name", "Another team has this name.");
                 return Page();


### PR DESCRIPTION
Needs to only check for tean name usage when the team name is changing, otherwise it blocks all edits to an existing team lol