### PR TITLE
NIPD 2022 last-second tweaks

### DIFF
--- a/ServerCore/Pages/Shared/_Layout.cshtml
+++ b/ServerCore/Pages/Shared/_Layout.cshtml
@@ -21,7 +21,7 @@
         // Using ev here so that it isn't the same as Event that we bind in the <body>
         // Works fine if we use Event, but VS will yell at you with an error in the IDE
         var ev = (Model as ServerCore.ModelBases.EventSpecificPageModel)?.Event;
-        if ((ev != null) && ((ev.UrlString.StartsWith("pd")) || (ev.UrlString.StartsWith("nipd"))))
+        if ((ev?.UrlString != null) && ((ev.UrlString.StartsWith("pd")) || (ev.UrlString.StartsWith("nipd"))))
         {
             <link rel="stylesheet" href="~/css/@(ev.UrlString)/styles.min.css" />
         }

--- a/ServerCore/Pages/Teams/Edit.cshtml
+++ b/ServerCore/Pages/Teams/Edit.cshtml
@@ -42,7 +42,7 @@
             else
             {
                 <div class="form-group">
-                    <label asp-for="Team.CustomRoom" class="control-label">Team room</label>
+                    <label asp-for="Team.CustomRoom" class="control-label">Team room (please enter 'virtual' if playing remotely)</label>
                     <input asp-for="Team.CustomRoom" class="form-control" />
                     <span asp-validation-for="Team.CustomRoom" class="text-danger"></span>
                 </div>


### PR DESCRIPTION
1: Encourage remote teams to report as such so we can manage physical item planning
2. Fix a bug causing a crash when there is no UrlString property (caused by the original NIPD2022 changes) - observed while validating 1 in a local deployment