### PR TITLE
Allow puzzle names to be raw HTML

### DIFF
--- a/ServerCore/Helpers/RawHtmlHelper.cs
+++ b/ServerCore/Helpers/RawHtmlHelper.cs
@@ -15,7 +15,7 @@ namespace ServerCore.Helpers
         /// <returns>IHtmlContent containing either the raw html processed by Html.Raw or the entire string processed by Html.DisplayFor</returns>
         public static IHtmlContent Display<T>(string text, int eventId, IHtmlHelper<T> helper)
         {
-            if(text != null && text.EndsWith(")") && text.Contains("Html.Raw("))
+            if (text != null && text.EndsWith(")") && text.Contains("Html.Raw("))
             {
                 text = text.Replace("{eventId}", $"{eventId}");
                 int start = text.IndexOf("Html.Raw(") + 9;
@@ -24,6 +24,27 @@ namespace ServerCore.Helpers
             else
             {
                 return helper.DisplayFor(m => text);
+            }
+        }
+
+        /// <summary>
+        /// Helper for extracting plaintext from a string if present.
+        /// The syntax we look for is: {anything}Html.Raw({raw html})
+        /// If we see that syntax, we return the {anything} part only.
+        /// If we see anything else, we return the entire string, processed by the standard ASP.NET IHtmlHelper.
+        /// </summary>
+        /// <param name="text">text which might contain raw HTML in</param>
+        /// <returns>string containing either the plaintext part before the Html.Raw or the entire string</returns>
+        public static string Plaintext(string text, int eventId)
+        {
+            if (text != null && text.EndsWith(")") && text.Contains("Html.Raw("))
+            {
+                text = text.Replace("{eventId}", $"{eventId}");
+                return text.Substring(0, text.IndexOf("Html.Raw(")).TrimEnd();
+            }
+            else
+            {
+                return text;
             }
         }
     }

--- a/ServerCore/Pages/Events/FastestSolves.cshtml
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml
@@ -3,6 +3,7 @@
 
 @{
     @using System;
+    @using Helpers;
     ViewData["Title"] = "Fastest Solves";
     ViewData["AdminRoute"] = "/Events/FastestSolves";
     ViewData["AuthorRoute"] = "/Events/FastestSolves";
@@ -75,7 +76,7 @@
 
                 <tr>
                     <td>
-                        @(puzzle.PuzzleName)
+                        @(RawHtmlHelper.Display(puzzle.PuzzleName, Model.Event.ID, Html))
                     </td>
                     <td>
                         @(puzzle.SolveCount)

--- a/ServerCore/Pages/Events/Map.cshtml
+++ b/ServerCore/Pages/Events/Map.cshtml
@@ -2,6 +2,8 @@
 @model ServerCore.Pages.Events.MapModel
 
 @{
+    @using Helpers;
+
     ViewData["Title"] = "Puzzle State Map";
     ViewData["AdminRoute"] = "/Events/Map";
     ViewData["AuthorRoute"] = "/Events/Map";
@@ -31,7 +33,7 @@
                     @foreach (var puzzle in Model.Puzzles)
                     {
                         <th>
-                            <a asp-page="/Puzzles/Status" asp-route-puzzleId="@puzzle.Puzzle.ID">@(puzzle.Puzzle.Name) (@puzzle.SolveCount)</a>
+                            <a asp-page="/Puzzles/Status" asp-route-puzzleId="@puzzle.Puzzle.ID">@RawHtmlHelper.Plaintext(puzzle.Puzzle.Name, Model.Event.ID) (@puzzle.SolveCount)</a>
                         </th>
                     }
                 </tr>

--- a/ServerCore/Pages/Hints/Edit.cshtml.cs
+++ b/ServerCore/Pages/Hints/Edit.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
+using ServerCore.Helpers;
 using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Hints
@@ -64,7 +65,7 @@ namespace ServerCore.Pages.Hints
                                          where hspt.Hint.Id == Hint.Id && hspt.UnlockTime != null && pspt.PuzzleID == puzzleId && pspt.SolvedTime == null
                                          select tm.Member.Email).ToListAsync();
                 MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                    $"{Event.Name}: Hint updated for {puzzleName}",
+                    $"{Event.Name}: Hint updated for {RawHtmlHelper.Plaintext(puzzleName, Event.ID)}",
                     $"The new content for '{Hint.Description}' is: '{Hint.Content}'.");
             }
             catch (DbUpdateConcurrencyException)

--- a/ServerCore/Pages/Puzzles/Edit.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml.cs
@@ -125,16 +125,17 @@ namespace ServerCore.Pages.Puzzles
                                                       select tm.Member.Email).ToListAsync();
 
                     string subject, body;
+                    string puzzleName = RawHtmlHelper.Plaintext(Puzzle.Name, Event.ID);
 
                     if (String.IsNullOrEmpty(Puzzle.Errata))
                     {
-                        subject = $"{Event.Name}: Errata removed for {Puzzle.Name}";
-                        body = $"The errata for {Puzzle.Name} has been removed.";
+                        subject = $"{Event.Name}: Errata removed for {puzzleName}";
+                        body = $"The errata for {puzzleName} has been removed.";
                     }
                     else
                     {
-                        subject = $"{Event.Name}: Errata updated for {Puzzle.Name}";
-                        body = $"{Puzzle.Name} has been updated with the following errata:\n\n{Puzzle.Errata}";
+                        subject = $"{Event.Name}: Errata updated for {puzzleName}";
+                        body = $"{puzzleName} has been updated with the following errata:\n\n{Puzzle.Errata}";
                     }
 
                     MailHelper.Singleton.SendPlaintextBcc(teamMembers, subject, body);

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -2,6 +2,8 @@
 @model ServerCore.Pages.Puzzles.IndexModel
 
 @{
+    @using Helpers;
+
     ViewData["Title"] = "Puzzle Index";
     ViewData["AdminRoute"] = "/Puzzles/Index";
     ViewData["AuthorRoute"] = "/Puzzles/Index";
@@ -100,7 +102,7 @@
         {
             <tr>
                 <td>
-                    <a asp-Page="./Edit" asp-route-puzzleid=@item.Puzzle.ID>@Html.DisplayFor(modelItem => item.Puzzle.Name)</a>
+                    <a asp-Page="./Edit" asp-route-puzzleid=@item.Puzzle.ID>@RawHtmlHelper.Display(item.Puzzle.Name, Model.Event.ID, Html)</a>
                 </td>
                 <td>
                     @if (item.Puzzle.CustomURL != null)

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
@@ -170,7 +170,7 @@ namespace ServerCore.Pages.Submissions
 
             if (submission != null)
             {
-                MailHelper.Singleton.SendPlaintextOneAddress(submission.Submitter.Email, $"{submission.Puzzle.Name} Submission {Result}", $"Your submission for {submission.Puzzle.Name} has been {Result} with the response: {FreeformResponse}");
+                MailHelper.Singleton.SendPlaintextOneAddress(submission.Submitter.Email, $"{RawHtmlHelper.Plaintext(submission.Puzzle.Name, Event.ID)} Submission {Result}", $"Your submission for {submission.Puzzle.Name} has been {Result} with the response: {FreeformResponse}");
             }
 
             return RedirectToPage();

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -2,6 +2,8 @@
 @model ServerCore.Pages.Submissions.IndexModel
 
 @{
+    @using Helpers;
+
     ViewData["Title"] = "Create submissions";
     ViewData["AdminRoute"] = "../Submissions/AuthorIndex";
     ViewData["AuthorRoute"] = "../Submissions/AuthorIndex";
@@ -25,7 +27,7 @@
 
     // subject: Make this be about this puzzle
     mailtoUrl.Append("&subject=");
-    mailtoUrl.Append(Uri.EscapeDataString("[" + Model.Puzzle.Name + "]"));
+    mailtoUrl.Append(Uri.EscapeDataString("[" + RawHtmlHelper.Plaintext(Model.Puzzle.Name, Model.Event.ID) + "]"));
     // subject: Make this be from this team
     mailtoUrl.Append(Uri.EscapeDataString(" [" + Model.Team.Name + "]"));
 
@@ -49,7 +51,7 @@
 
 
 
-<h2>Submissions for @Model.Puzzle.Name</h2>
+<h2>Submissions for @RawHtmlHelper.Display(Model.Puzzle.Name, Model.Event.ID, Html)</h2>
 <hr />
 <div>
     <a asp-page="/Teams/Play" asp-route-teamId="@Model.Team.ID">Back to puzzle list</a>
@@ -93,7 +95,7 @@
         {
             <div class="alert alert-danger" role="alert">
                 <h4>Answer Submission Locked Indefinitely</h4>
-                <span>You've submitted too many wrong responses. Please <a href="@mailtoUrl">use this link to email us your answer for @Model.Puzzle.Name or ask for help</a>.</span>
+                <span>You've submitted too many wrong responses. Please <a href="@mailtoUrl">use this link to email us your answer for @RawHtmlHelper.Plaintext(Model.Puzzle.Name, Model.Event.ID) or ask for help</a>.</span>
             </div>
         }
         else if (Model.PuzzleState.IsTeamLockedOut)
@@ -228,7 +230,7 @@
 @if (!Model.PuzzleState.IsEmailOnlyMode)
 { 
     <h3>Need some help?</h3>
-    <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a href="@mailtoUrl">use this link to contact the author for @Model.Puzzle.Name</a>!</p>
+    <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a href="@mailtoUrl">use this link to contact the author for @RawHtmlHelper.Plaintext(Model.Puzzle.Name, Model.Event.ID)</a>!</p>
     <p>A pre-populated email form will appear and you should add details to the message body. Remember: the author may only know specifics about this puzzle and not others in the event.</p>
 }
 

--- a/ServerCore/Pages/Teams/Play.cshtml
+++ b/ServerCore/Pages/Teams/Play.cshtml
@@ -2,6 +2,8 @@
 @model ServerCore.Pages.Teams.PlayModel
 
 @{
+    @using Helpers;
+
     ViewData["Title"] = "Puzzles";
     ViewData["AdminRoute"] = "/Puzzles/Index";
     ViewData["AuthorRoute"] = "/Puzzles/Index";
@@ -98,7 +100,7 @@
         {
             <tr>
                 <td>
-                    @ServerCore.Helpers.RawHtmlHelper.Display(item.Group, Model.Event.ID, Html)
+                    @RawHtmlHelper.Display(item.Group, Model.Event.ID, Html)
                 </td>
                 <td>
                     @if (!string.IsNullOrWhiteSpace(item.Errata))
@@ -108,15 +110,15 @@
 
                     @if (item.CustomUrl != null)
                     {
-                        <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomUrl, item.ID, Model.Event.ID, Model.TeamPassword)" target="_blank">@item.Name</a>
+                    <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomUrl, item.ID, Model.Event.ID, Model.TeamPassword)" target="_blank">@RawHtmlHelper.Display(item.Name, Model.Event.ID, Html)</a>
                     }
                     else if (item.Content != null)
                     {
-                        @Html.ActionLink(item.Name, "Index", "Files", new { eventId = Model.Event.ID, filename = item.Content.ShortName }, new { target = "_blank" })
+                    <a asp-action="Index" asp-controller="Files" asp-route-eventId="@Model.Event.ID" asp-route-filename="@item.Content.ShortName" target="_blank">@RawHtmlHelper.Display(item.Name, Model.Event.ID, Html)</a>
                     }
                     else
                     {
-                        @Html.DisplayFor(modelItem => item.Name)
+                        @RawHtmlHelper.Display(item.Name, Model.Event.ID, Html)
                     }
 
                     @if (item.PieceMetaUsage != DataModel.PieceMetaUsage.None)

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -506,7 +506,7 @@ namespace ServerCore
                                              where sub.PuzzleID == response.PuzzleID && sub.SubmissionText == response.SubmittedText
                                              select tm.Member.Email).ToListAsync();
                     MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                        $"{puzzle.Event.Name}: {response.Puzzle.Name} Response updated for '{response.SubmittedText}'",
+                        $"{puzzle.Event.Name}: {RawHtmlHelper.Plaintext(response.Puzzle.Name, puzzle.Event.ID)} Response updated for '{response.SubmittedText}'",
                         $"The new response for this submission is: '{response.ResponseText}'.");
                 }
             }


### PR DESCRIPTION
The puzzle name appears in many more places than this, but this should cover all the player-facing cases as well as a couple of critical author/admin cases.