### PR TITLE
Fix Bulk Hints

### DIFF
--- a/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
+++ b/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
@@ -65,6 +65,10 @@ namespace ServerCore.Pages.Hints
             using StringReader costReader = new StringReader(Cost ?? string.Empty);
             using StringReader displayOrderReader = new StringReader(DisplayOrder ?? string.Empty);
 
+            var teams = from team in _context.Teams
+                        where team.Event == Event
+                        select team;
+
             while (true)
             {
                 string description = descriptionReader.ReadLine();
@@ -123,6 +127,11 @@ namespace ServerCore.Pages.Hints
                 };
 
                 _context.Hints.Add(hint);
+
+                foreach (Team team in teams)
+                {
+                    _context.HintStatePerTeam.Add(new HintStatePerTeam() { Hint = hint, Team = team });
+                }
             }
 
             if (!ModelState.IsValid)

--- a/ServerCore/Pages/Hints/CreateBulkMulti.cshtml.cs
+++ b/ServerCore/Pages/Hints/CreateBulkMulti.cshtml.cs
@@ -58,6 +58,10 @@ namespace ServerCore.Pages.Hints
 
             Dictionary<string, int> puzzleTitleLookup = new Dictionary<string, int>();
 
+            var teams = from team in _context.Teams
+                        where team.Event == Event
+                        select team;
+
             while (true)
             {
                 string puzzleName = puzzleNameReader.ReadLine();
@@ -164,6 +168,11 @@ namespace ServerCore.Pages.Hints
                 };
 
                 _context.Hints.Add(hint);
+
+                foreach (Team team in teams)
+                {
+                    _context.HintStatePerTeam.Add(new HintStatePerTeam() { Hint = hint, Team = team });
+                }
             }
 
             if (!ModelState.IsValid)

--- a/ServerCore/Pages/Teams/Hints.cshtml
+++ b/ServerCore/Pages/Teams/Hints.cshtml
@@ -44,13 +44,15 @@
     }
 </style>
 @{
+    @using Helpers;
+
     ViewData["Title"] = "Hints";
     ViewData["AdminRoute"] = "/Puzzles/Index";
     ViewData["AuthorRoute"] = "/Puzzles/Index";
     //Needs route data - ViewData["PlayRoute"] = "/Teams/Hints";
 }
 
-<h2>Hints for @Model.PuzzleName</h2>
+<h2>Hints for @RawHtmlHelper.Display(Model.PuzzleName, Model.Event.ID, Html)</h2>
 
 <div>
     <a asp-page="/Teams/Play">Back to puzzle list</a>


### PR DESCRIPTION
I wasn't aware that there was a table that needs to have entries added. Oops!

I also missed that the hints page, being player-visible, needs to have Html.Raw support for the puzzle name.