### PR TITLE
Fix Submit Answer link on puzzles

### DIFF
--- a/ServerCore/wwwroot/js/pd2022/help.js
+++ b/ServerCore/wwwroot/js/pd2022/help.js
@@ -99,7 +99,7 @@ async function helpClicked(event) {
 function answerClicked(event) {
 	let params = new URLSearchParams(window.location.search);
 	let link = document.createElement("a");
-	link.href = "https://puzzlehunt.azurewebsites.net/pd2022/play/Submissions/" + params.get("puzzleId");
+	link.href = "https://puzzlehunt.azurewebsites.net/" + params.get("eventId") + "/play/Submissions/" + params.get("puzzleId");
 	link.target = "_blank";
 	document.body.appendChild(link);
 	link.click();


### PR DESCRIPTION
No need for the URL to be event specific since we have all the info we need.