### PR TITLE
Show puzzle plaintext in Prerequisites list

### DIFF
--- a/Data/DataModel/Puzzle.cs
+++ b/Data/DataModel/Puzzle.cs
@@ -82,6 +82,25 @@ namespace ServerCore.DataModel
         public string Name { get; set; }
 
         /// <summary>
+        /// The plaintext name of the puzzle, which is a subset of the name when the name is of the form:
+        /// {plaintextName}Html.Raw({htmlName})
+        /// </summary>
+        [NotMapped]
+        public string PlaintextName
+        {
+            get
+            {
+                string name = this.Name;
+                if (name != null && name.EndsWith(")") && name.Contains("Html.Raw("))
+                {
+                    name = name.Replace("{eventId}", $"{this.EventID}");
+                    name = name.Substring(0, name.IndexOf("Html.Raw(")).TrimEnd();
+                }
+                return name;
+            }
+        }
+
+        /// <summary>
         /// True only if not a "fake" puzzle like "READ THIS INSTRUCTION PAGE" or "START THE EVENT"
         /// </summary>
         public bool IsPuzzle { get; set; } = false;

--- a/ServerCore/Helpers/RawHtmlHelper.cs
+++ b/ServerCore/Helpers/RawHtmlHelper.cs
@@ -26,26 +26,5 @@ namespace ServerCore.Helpers
                 return helper.DisplayFor(m => text);
             }
         }
-
-        /// <summary>
-        /// Helper for extracting plaintext from a string if present.
-        /// The syntax we look for is: {anything}Html.Raw({raw html})
-        /// If we see that syntax, we return the {anything} part only.
-        /// If we see anything else, we return the entire string, processed by the standard ASP.NET IHtmlHelper.
-        /// </summary>
-        /// <param name="text">text which might contain raw HTML in</param>
-        /// <returns>string containing either the plaintext part before the Html.Raw or the entire string</returns>
-        public static string Plaintext(string text, int eventId)
-        {
-            if (text != null && text.EndsWith(")") && text.Contains("Html.Raw("))
-            {
-                text = text.Replace("{eventId}", $"{eventId}");
-                return text.Substring(0, text.IndexOf("Html.Raw(")).TrimEnd();
-            }
-            else
-            {
-                return text;
-            }
-        }
     }
 }

--- a/ServerCore/Pages/Events/Map.cshtml
+++ b/ServerCore/Pages/Events/Map.cshtml
@@ -33,7 +33,7 @@
                     @foreach (var puzzle in Model.Puzzles)
                     {
                         <th>
-                            <a asp-page="/Puzzles/Status" asp-route-puzzleId="@puzzle.Puzzle.ID">@RawHtmlHelper.Plaintext(puzzle.Puzzle.Name, Model.Event.ID) (@puzzle.SolveCount)</a>
+                            <a asp-page="/Puzzles/Status" asp-route-puzzleId="@puzzle.Puzzle.ID">@puzzle.Puzzle.PlaintextName (@puzzle.SolveCount)</a>
                         </th>
                     }
                 </tr>

--- a/ServerCore/Pages/Hints/Edit.cshtml.cs
+++ b/ServerCore/Pages/Hints/Edit.cshtml.cs
@@ -57,7 +57,7 @@ namespace ServerCore.Pages.Hints
             {
                 await _context.SaveChangesAsync();
 
-                var puzzleName = await _context.Hints.Where(m => m.Id == Hint.Id).Select(m => m.Puzzle.Name).FirstOrDefaultAsync();
+                var puzzle = await _context.Hints.Where(m => m.Id == Hint.Id).Select(m => m.Puzzle).FirstOrDefaultAsync();
 
                 var teamMembers = await (from tm in _context.TeamMembers
                                          join hspt in _context.HintStatePerTeam on tm.Team equals hspt.Team
@@ -65,7 +65,7 @@ namespace ServerCore.Pages.Hints
                                          where hspt.Hint.Id == Hint.Id && hspt.UnlockTime != null && pspt.PuzzleID == puzzleId && pspt.SolvedTime == null
                                          select tm.Member.Email).ToListAsync();
                 MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                    $"{Event.Name}: Hint updated for {RawHtmlHelper.Plaintext(puzzleName, Event.ID)}",
+                    $"{Event.Name}: Hint updated for {puzzle.PlaintextName}",
                     $"The new content for '{Hint.Description}' is: '{Hint.Content}'.");
             }
             catch (DbUpdateConcurrencyException)

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -210,7 +210,7 @@
                     {
                         <tr>
                             <td>
-                                <a asp-page="./Edit" asp-route-id="@(pre.ID)">@(pre.Name)</a>
+                                <a asp-page="./Edit" asp-route-id="@(pre.ID)">@(pre.PlaintextName)</a>
                             </td>
                             <td>
                                 <a asp-page-handler="RemovePrerequisite" asp-route-id="@Model.Puzzle.ID" asp-route-prerequisite="@(pre.ID)">Remove</a>
@@ -219,7 +219,7 @@
                     }
                     <tr>
                         <td>
-                            <select class="form-control" asp-for="NewPrerequisiteID" asp-items="@(new SelectList(Model.PotentialPrerequisites, "ID", "Name"))"></select>
+                            <select class="form-control" asp-for="NewPrerequisiteID" asp-items="@(new SelectList(Model.PotentialPrerequisites, "ID", "PlaintextName"))"></select>
                         </td>
                         <td>
                             <input type="submit" value="Add" asp-page-handler="AddPrerequisite" class="btn btn-default" />
@@ -244,7 +244,7 @@
                     {
                         <tr>
                             <td>
-                                <a asp-page="./Edit" asp-route-id="@(p.ID)">@(p.Name)</a>
+                                <a asp-page="./Edit" asp-route-id="@(p.ID)">@(p.PlaintextName)</a>
                             </td>
                             <td>
                                 <a asp-page-handler="RemovePrerequisiteOf" asp-route-id="@Model.Puzzle.ID" asp-route-prerequisiteOf="@(p.ID)">Remove</a>
@@ -253,7 +253,7 @@
                     }
                     <tr>
                         <td>
-                            <select class="form-control" asp-for="NewPrerequisiteOfID" asp-items="@(new SelectList(Model.PotentialPrerequisitesOf, "ID", "Name"))"></select>
+                            <select class="form-control" asp-for="NewPrerequisiteOfID" asp-items="@(new SelectList(Model.PotentialPrerequisitesOf, "ID", "PlaintextName"))"></select>
                         </td>
                         <td>
                             <input type="submit" value="Add" asp-page-handler="AddPrerequisiteOf" class="btn btn-default" />

--- a/ServerCore/Pages/Puzzles/Edit.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml.cs
@@ -125,7 +125,7 @@ namespace ServerCore.Pages.Puzzles
                                                       select tm.Member.Email).ToListAsync();
 
                     string subject, body;
-                    string puzzleName = RawHtmlHelper.Plaintext(Puzzle.Name, Event.ID);
+                    string puzzleName = Puzzle.PlaintextName;
 
                     if (String.IsNullOrEmpty(Puzzle.Errata))
                     {

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
@@ -170,7 +170,7 @@ namespace ServerCore.Pages.Submissions
 
             if (submission != null)
             {
-                MailHelper.Singleton.SendPlaintextOneAddress(submission.Submitter.Email, $"{RawHtmlHelper.Plaintext(submission.Puzzle.Name, Event.ID)} Submission {Result}", $"Your submission for {submission.Puzzle.Name} has been {Result} with the response: {FreeformResponse}");
+                MailHelper.Singleton.SendPlaintextOneAddress(submission.Submitter.Email, $"{submission.Puzzle.PlaintextName} Submission {Result}", $"Your submission for {submission.Puzzle.Name} has been {Result} with the response: {FreeformResponse}");
             }
 
             return RedirectToPage();

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -27,7 +27,7 @@
 
     // subject: Make this be about this puzzle
     mailtoUrl.Append("&subject=");
-    mailtoUrl.Append(Uri.EscapeDataString("[" + RawHtmlHelper.Plaintext(Model.Puzzle.Name, Model.Event.ID) + "]"));
+    mailtoUrl.Append(Uri.EscapeDataString("[" + Model.Puzzle.PlaintextName + "]"));
     // subject: Make this be from this team
     mailtoUrl.Append(Uri.EscapeDataString(" [" + Model.Team.Name + "]"));
 
@@ -95,7 +95,7 @@
         {
             <div class="alert alert-danger" role="alert">
                 <h4>Answer Submission Locked Indefinitely</h4>
-                <span>You've submitted too many wrong responses. Please <a href="@mailtoUrl">use this link to email us your answer for @RawHtmlHelper.Plaintext(Model.Puzzle.Name, Model.Event.ID) or ask for help</a>.</span>
+                <span>You've submitted too many wrong responses. Please <a href="@mailtoUrl">use this link to email us your answer for @Model.Puzzle.PlaintextName or ask for help</a>.</span>
             </div>
         }
         else if (Model.PuzzleState.IsTeamLockedOut)
@@ -230,7 +230,7 @@
 @if (!Model.PuzzleState.IsEmailOnlyMode)
 { 
     <h3>Need some help?</h3>
-    <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a href="@mailtoUrl">use this link to contact the author for @RawHtmlHelper.Plaintext(Model.Puzzle.Name, Model.Event.ID)</a>!</p>
+    <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a href="@mailtoUrl">use this link to contact the author for @Model.Puzzle.PlaintextName</a>!</p>
     <p>A pre-populated email form will appear and you should add details to the message body. Remember: the author may only know specifics about this puzzle and not others in the event.</p>
 }
 

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -506,7 +506,7 @@ namespace ServerCore
                                              where sub.PuzzleID == response.PuzzleID && sub.SubmissionText == response.SubmittedText
                                              select tm.Member.Email).ToListAsync();
                     MailHelper.Singleton.SendPlaintextBcc(teamMembers,
-                        $"{puzzle.Event.Name}: {RawHtmlHelper.Plaintext(response.Puzzle.Name, puzzle.Event.ID)} Response updated for '{response.SubmittedText}'",
+                        $"{puzzle.Event.Name}: {puzzle.PlaintextName} Response updated for '{response.SubmittedText}'",
                         $"The new response for this submission is: '{response.ResponseText}'.");
                 }
             }


### PR DESCRIPTION
To expose the plaintext name to ASP.NET's SelectList method, the plaintext name code needed to move into the datamodel via a [NotMapped] property.