### PR TITLE
improve reporting of duplicate submissions

### DIFF
--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -122,11 +122,14 @@
                 </div>
             }
 
-            @if (Model.DuplicateSubmission)
+            @if (Model.DuplicateSubmission != null)
             {
             <div class="alert alert-danger" role="alert">
                 <h4>Oops</h4>
                 <span>You've already submitted @Model.SubmissionText!</span>
+                <div>
+                @ServerCore.Helpers.RawHtmlHelper.Display(Model.DuplicateSubmission, Model.Event.ID, Html);
+                </div>
             </div>
             }
             <div class="row">

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -97,7 +97,7 @@ namespace ServerCore.Pages.Submissions
             // Soft enforcement of duplicates to give a friendly message in most cases
             DuplicateSubmission = (from sub in Submissions
                                    where sub.SubmissionText == ServerCore.DataModel.Response.FormatSubmission(submissionText)
-                                   select sub).FirstOrDefault(null).?ResponseText;
+                                   select sub).FirstOrDefault(null)?.ResponseText;
 
             if (DuplicateSubmission != null)
             {

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -36,7 +36,7 @@ namespace ServerCore.Pages.Submissions
 
         public IList<Puzzle> PuzzlesCausingGlobalLockout { get; set; }
 
-        public bool DuplicateSubmission { get; set; }
+        public string DuplicateSubmission { get; set; }
 
         [BindProperty]
         public bool AllowFreeformSharing { get; set; }
@@ -97,9 +97,9 @@ namespace ServerCore.Pages.Submissions
             // Soft enforcement of duplicates to give a friendly message in most cases
             DuplicateSubmission = (from sub in Submissions
                                    where sub.SubmissionText == ServerCore.DataModel.Response.FormatSubmission(submissionText)
-                                   select sub).Any();
+                                   select sub).FirstOrDefault(null).?ResponseText;
 
-            if (DuplicateSubmission)
+            if (DuplicateSubmission != null)
             {
                 return Page();
             }


### PR DESCRIPTION
When a user enters a duplicate submission, rather than just telling them they already submitted it, it will now tell them what the response was. This is helpful in data confirmation puzzles, especially when multiple people are working together.

I made a very small change to Submissions/Index.cshtml.cs but it shows as a large change because GitHub normalized the line endings. The actual changes are on lines 39, 100, 102.