### PR TITLE
Change All/Unsolved Filter from radio buttons to link

### DIFF
--- a/ServerCore/Pages/Events/FastestSolves.cshtml
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml
@@ -15,19 +15,10 @@
 <h2>Fastest Solves</h2>
 <br/>
 <div>
-    <a class="radioButton"
-       asp-page="./FastestSolves"
+    <a asp-page="./FastestSolves"
        asp-route-sort="@Model.Sort"
-       asp-route-stateFilter="@FastestSolvesModel.PuzzleStateFilter.All">
-
-        <input id="StateFilter" name="StateFilter" value="All" type="radio" @(unsolvedFilter ? "" : "checked")> All
-    </a>
-    <a class="radioButton"
-       asp-page="./FastestSolves"
-       asp-route-sort="@Model.Sort"
-       asp-route-stateFilter="@FastestSolvesModel.PuzzleStateFilter.Unsolved">
-
-        <input id="StateFilter" name="StateFilter" value="Unsolved" type="radio" @(unsolvedFilter ? "checked" : "")> Unsolved
+       asp-route-stateFilter=@(unsolvedFilter ? FastestSolvesModel.PuzzleStateFilter.All : FastestSolvesModel.PuzzleStateFilter.Unsolved)>
+        Show @(unsolvedFilter ? "All" : "Unsolved") Puzzles
     </a>
 </div>
 <br/>

--- a/ServerCore/Pages/Teams/Play.cshtml
+++ b/ServerCore/Pages/Teams/Play.cshtml
@@ -39,11 +39,11 @@
 </div>
 <br/>
 <div>
-    <a class="radioButton" asp-page="./Play" asp-route-teamId="@Model.TeamID" asp-route-sort="@Model.Sort" asp-route-stateFilter="@PlayModel.PuzzleStateFilter.All">
-        <input id="StateFilter" name="StateFilter" value="All" type="radio" @(unsolvedFilter ? "" : "checked")> All
-    </a>
-    <a class="radioButton" asp-page="./Play" asp-route-teamId="@Model.TeamID" asp-route-sort="@Model.Sort" asp-route-stateFilter="@PlayModel.PuzzleStateFilter.Unsolved">
-        <input id="StateFilter" name="StateFilter" value="Unsolved" type="radio" @(unsolvedFilter ? "checked" : "")> Unsolved
+    <a asp-page="./Play" 
+       asp-route-teamId="@Model.TeamID" 
+       asp-route-sort="@Model.Sort" 
+       asp-route-stateFilter=@(unsolvedFilter ? PlayModel.PuzzleStateFilter.All : PlayModel.PuzzleStateFilter.Unsolved)>
+        Show @(unsolvedFilter ? "All" : "Unsolved") Puzzles
     </a>
 </div>
 <br/>


### PR DESCRIPTION
Radio buttons are traditionally used as selectors, not as links.  Their behavior as links is unpredicatable, and in this case only clicking on the text triggered a navigation.  Clicking on the radio buttons did not, which is confusing to the user.  Eliminate the confusion by removing the radio button and showing a navigation link.

This affects the puzzles list and fastest solves pages. A search of the codebase indicated that all other uses of radio buttons were as input controls that did not trigger navigation, so they were left as is.

New UI: 
![image](https://user-images.githubusercontent.com/2019044/192408626-13308902-23ae-4588-b3c9-4e11b06912d9.png)

Old UI for comparison:
![image](https://user-images.githubusercontent.com/2019044/192408643-52e65b0b-b3d8-43dd-95d8-a63dd895489e.png)


Fixes #748