### PR TITLE
Fixed submission answers to show alerts when partial or incorrect

### DIFF
--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -122,13 +122,20 @@
                 </div>
             }
 
-            @if (Model.DuplicateSubmission)
+            if (!string.IsNullOrEmpty(Model.AnswerRedAlertMessage))
             {
-            <div class="alert alert-danger" role="alert">
-                <h4>Oops</h4>
-                <span>You've already submitted @Model.SubmissionText!</span>
-            </div>
+                <div class="alert alert-danger" role="alert">
+                    <h4>@Model.AnswerRedAlertMessage</h4>
+                </div>
             }
+
+            if (!string.IsNullOrEmpty(Model.AnswerYellowAlertMessage))
+            {
+                <div class="alert alert-warning" role="alert">
+                    <h4>@Model.AnswerYellowAlertMessage</h4>
+                </div>
+            }
+
             <div class="row">
                 <div class="col-md-4">
                     <form method="post">

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -140,7 +140,7 @@ namespace ServerCore.Pages.Submissions
             if (submission.Response == null)
             {
                 // If incorrect
-                AnswerRedAlertMessage = "Incorrect";
+                AnswerRedAlertMessage = $"\"{submission.SubmissionText}\" is incorrect";
                 await CheckAndHandleLockout(submission);
             }
             else if (submission.Response.IsSolution)
@@ -157,7 +157,7 @@ namespace ServerCore.Pages.Submissions
             else
             {
                 // Is partial
-                AnswerYellowAlertMessage = string.Format("Partial Answer: {0}", submission.Response.ResponseText);
+                AnswerYellowAlertMessage = string.Format($"\"{submission.SubmissionText}\" has partial answer: \"{submission.Response.ResponseText}\"");
             }
             
             _context.Submissions.Add(submission);


### PR DESCRIPTION
Currently, when a user submits a partial or an incorrect answer, they have to scroll down to see what happened.

Now, if the player submits an incorrect answer, a red alert box will pop up to say "Incorrect".
<img width="760" alt="image" src="https://user-images.githubusercontent.com/4121745/215673872-0e4881a8-2b3a-4154-a27f-71509286588e.png">

If the player submits a partially correct answer, a yellow alert box will pop up to give them the partial.
<img width="361" alt="image" src="https://user-images.githubusercontent.com/4121745/215673695-e3429cca-3265-45d0-85c2-d9ebe7fab1b6.png">

![image](https://user-images.githubusercontent.com/4121745/215673782-037acc62-8826-4361-b641-88b6b486bbd2.png)


