### PR TITLE
Add a null check to team composition

### DIFF
--- a/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
+++ b/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
@@ -145,7 +145,7 @@ namespace ServerCore.Pages.Teams
 
                 string email = groupMember.TeamMember.Email;
                 string alias = groupMember.TeamMember.EmployeeAlias;
-                if (email.EndsWith("@microsoft.com"))
+                if (email != null && email.EndsWith("@microsoft.com"))
                 {
                     if (email.StartsWith("t-"))
                     {


### PR DESCRIPTION
Simple one-liner left over from PD - I know we have other changes to make tis less likely, but might as well fix it anyway