### PR TITLE
Fixed edit and team composition summary sort order

### DIFF
--- a/ServerCore/Pages/Teams/Edit.cshtml
+++ b/ServerCore/Pages/Teams/Edit.cshtml
@@ -7,6 +7,7 @@
     //Needs route data - ViewData["AuthorRoute"] = "/Teams/Status";
     //Needs route data - ViewData["PlayRoute"] = "/Teams/Edit";
     Layout = "_teamLayout.cshtml";
+    bool canChangeTeamName = Model.CanChangeTeamName();
 }
 
 <h2>@Html.DisplayFor(model => model.Team.Name): Edit</h2>
@@ -23,7 +24,14 @@
             <input asp-for="Team.Password" class="hidden" />
             <div class="form-group">
                 <label asp-for="Team.Name" class="control-label">Team name</label>
-                <input asp-for="Team.Name" class="form-control" />
+                @if (canChangeTeamName)
+                {
+                    <input asp-for="Team.Name" class="form-control" />
+                }
+                else
+                {
+                    <input class="form-control" asp-for="Team.Name" value="@Model.Team.Name" readonly />
+                }
                 <span asp-validation-for="Team.Name" class="text-danger"></span>
             </div>
             <!-- TODO: Conditionally show/hide based on event property (not needed for PuzzleHunt) -->

--- a/ServerCore/Pages/Teams/Edit.cshtml.cs
+++ b/ServerCore/Pages/Teams/Edit.cshtml.cs
@@ -57,11 +57,11 @@ namespace ServerCore.Pages.Teams
                 return NotFound();
             }
 
-            // Enforce the name change cutoff
-            if (Team.Name != existingTeam.Name && EventRole != EventRole.admin && !Event.CanChangeTeamName)
+            // If the name cannot be changed, ignore input
+            // Note: It should generally never reach this point because the form itself should not allow this to change.
+            if (!this.CanChangeTeamName())
             {
-                ModelState.AddModelError("Team.Name", "Team names for this event can no longer be changed by players.");
-                return Page();
+                Team.Name = existingTeam.Name;
             }
 
             if (Team.Name.Length > 50)
@@ -104,6 +104,11 @@ namespace ServerCore.Pages.Teams
             }
 
             return RedirectToPage("./Details", new { eventId = Event.ID, eventRole = EventRole, teamId = Team.ID });
+        }
+
+        public bool CanChangeTeamName()
+        {
+            return EventRole == EventRole.admin || Event.CanChangeTeamName;
         }
 
         private bool TeamExists(int teamId)

--- a/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
+++ b/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
@@ -89,13 +89,10 @@ namespace ServerCore.Pages.Teams
                 .GroupBy(intermediate => intermediate.TeamID)
                 .Select(this.MapToTeamComposition);
 
-            if (SortDirection == SortDirectionEnum.Ascend)
+            this.SortTeamComposition();
+            if (SortDirection == SortDirectionEnum.Descend)
             {
-                TeamCompositions = TeamCompositions.OrderBy(this.GetSortSelector());
-            }
-            else
-            {
-                TeamCompositions = TeamCompositions.OrderByDescending(this.GetSortSelector());
+                TeamCompositions = TeamCompositions.Reverse();
             }
 
             return Page();
@@ -111,25 +108,32 @@ namespace ServerCore.Pages.Teams
                 });
         }
 
-        private Func<TeamComposition, string> GetSortSelector()
+        private void SortTeamComposition()
         {
             switch (SortBy)
             {
                 case SortEnum.EmployeeCount:
-                    return teamComp => teamComp.EmployeeCount.ToString();
+                    TeamCompositions = TeamCompositions.OrderBy(teamComp => teamComp.EmployeeCount);
+                    break;
                 case SortEnum.InternCount:
-                    return teamComp => teamComp.InternCount.ToString();
+                    TeamCompositions = TeamCompositions.OrderBy(teamComp => teamComp.InternCount);
+                    break;
                 case SortEnum.NonMicrosoftAndPossibleAliases:
-                    return teamComp => (teamComp.NonMicrosoftCount + teamComp.PossibleEmployeeAliases.Count).ToString();
+                    TeamCompositions = TeamCompositions.OrderBy(teamComp => teamComp.NonMicrosoftCount + teamComp.PossibleEmployeeAliases.Count);
+                    break;
                 case SortEnum.NonMicrosoftCount:
-                    return teamComp => teamComp.NonMicrosoftCount.ToString();
+                    TeamCompositions = TeamCompositions.OrderBy(teamComp => teamComp.NonMicrosoftCount);
+                    break;
                 case SortEnum.PossibleEmployeeAliasas:
-                    return teamComp => teamComp.PossibleEmployeeAliases.Count.ToString();
+                    TeamCompositions = TeamCompositions.OrderBy(teamComp => teamComp.PossibleEmployeeAliases.Count);
+                    break;
                 case SortEnum.Total:
-                    return teamComp => teamComp.Total.ToString();
+                    TeamCompositions = TeamCompositions.OrderBy(teamComp => teamComp.Total);
+                    break;
                 case SortEnum.Title:
                 default:
-                    return teamComp => teamComp.TeamName;
+                    TeamCompositions = TeamCompositions.OrderBy(teamComp => teamComp.TeamName);
+                    break;
             }
         }
 


### PR DESCRIPTION
Based on an old PR https://github.com/PuzzleServer/mainpuzzleserver/pull/551

Fixed the following bugs:
1. Disable text box when not allowed the change name instead of throwing an error.
Disabled text block
![image](https://user-images.githubusercontent.com/4121745/216571013-db012ee5-2633-46ab-9226-67ac9226f338.png)

2. Fix alphanumeric sorting of team composition page (before it would sort numbers as if they were strings)