### PR TITLE
Add page to experiment with iframe embedding of puzzles directly on the website

### DIFF
--- a/PuzzleServer.sln
+++ b/PuzzleServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33403.182
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerCore", "ServerCore\ServerCore.csproj", "{67B91CCE-4E3D-4F0F-8A76-EAFD37C5F949}"
 EndProject

--- a/ServerCore/Pages/Submissions/SubmitProto.cshtml
+++ b/ServerCore/Pages/Submissions/SubmitProto.cshtml
@@ -1,0 +1,19 @@
+﻿@page "/{eventId}/{eventRole}/Submissions/SubmitProto"
+@model ServerCore.Pages.Submissions.SubmitProtoModel
+
+@{
+    @using Helpers;
+
+    ViewData["Title"] = "Solve here and submit your answer";
+    ViewData["AdminRoute"] = "../Submissions/AuthorIndex";
+    ViewData["AuthorRoute"] = "../Submissions/AuthorIndex";
+    // TODO: Needs to handle implicit teams - ViewData["PlayRoute"] = "../Submissions/Index";
+    ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
+}
+
+@using System.Text @* for StringBuilder *@
+
+<h2>Solve and submit answers for your puzzle</h2>
+<hr />
+<iframe title="Puzzle" width="1500" height="800" sandbox="allow-same-origin allow-scripts" credentialless src="https://puzzlehunt.azurewebsites.net/4/Files/example-puzzle%2Findex.html"></iframe>
+<iframe title="Puzzle" width="1500" height="800" sandbox="allow-same-origin allow-scripts" credentialless src="https://puzzleserverteststore.blob.core.windows.net/evt4/GINMPx+Ko8rDJnnhDY4_JA==/example-puzzle/index.html"></iframe>

--- a/ServerCore/Pages/Submissions/SubmitProto.cshtml.cs
+++ b/ServerCore/Pages/Submissions/SubmitProto.cshtml.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Submissions
+{
+    public class SubmitProtoModel : EventSpecificPageModel
+    {
+        public SubmitProtoModel(PuzzleServerContext serverContext, UserManager<IdentityUser> manager) : base(serverContext, manager)
+        {
+        }
+
+        public async Task<IActionResult> OnGetAsync(int puzzleId)
+        {
+            await SetupContext(puzzleId);
+
+            return Page();
+        }
+
+        private async Task SetupContext(int puzzleId)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Route to test page is {event}/{role}/Submissions/SubmitProto.  Note that the allow-same-origin permission is required so that we pass the same origin test when we're running on the server, since it has the same origin policy turned on.  The allow-scripts permission is self-explanatory since puzzles use scripts for interactivity.  The credentialless attribute is a brand new feature in literally THE latest version of Chrome and Edge that lifts some of the cross-origin restrictions on loading content AND improves security by restricting access the iframe content has to content from the surrounding page:  https://developer.mozilla.org/en-US/docs/Web/Security/IFrame_credentialless.  