### PR TITLE
Add prototype list of puzzles that links to prototype submission page instead of regular submission page

### DIFF
--- a/PuzzleServer.sln
+++ b/PuzzleServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33403.182
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerCore", "ServerCore\ServerCore.csproj", "{67B91CCE-4E3D-4F0F-8A76-EAFD37C5F949}"
 EndProject

--- a/ServerCore/Pages/Submissions/SubmitProto.cshtml
+++ b/ServerCore/Pages/Submissions/SubmitProto.cshtml
@@ -1,19 +1,30 @@
-﻿@page "/{eventId}/{eventRole}/Submissions/SubmitProto"
+﻿@page "/{eventId}/{eventRole}/SubmitProto/{puzzleId}"
 @model ServerCore.Pages.Submissions.SubmitProtoModel
 
 @{
     @using Helpers;
-
     ViewData["Title"] = "Solve here and submit your answer";
     ViewData["AdminRoute"] = "../Submissions/AuthorIndex";
     ViewData["AuthorRoute"] = "../Submissions/AuthorIndex";
-    // TODO: Needs to handle implicit teams - ViewData["PlayRoute"] = "../Submissions/Index";
     ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
 }
 
-@using System.Text @* for StringBuilder *@
-
-<h2>Solve and submit answers for your puzzle</h2>
+<h2>Solve and submit answers for @RawHtmlHelper.Display(Model.Puzzle.Name, Model.Event.ID, Html)</h2>
 <hr />
-<iframe title="Puzzle" width="1500" height="800" sandbox="allow-same-origin allow-scripts" credentialless src="https://puzzlehunt.azurewebsites.net/4/Files/example-puzzle%2Findex.html"></iframe>
-<iframe title="Puzzle" width="1500" height="800" sandbox="allow-same-origin allow-scripts" credentialless src="https://puzzleserverteststore.blob.core.windows.net/evt4/GINMPx+Ko8rDJnnhDY4_JA==/example-puzzle/index.html"></iframe>
+<style>
+    #puzzle-frame {
+        width: 100%;
+        height: calc(100vh - 265px);
+    }
+</style>
+@if (Model.Puzzle.CustomURL != null)
+{
+    <iframe id="puzzle-frame" title="@Model.Puzzle.Name" sandbox="allow-same-origin allow-scripts" src="@Model.Puzzle.CustomURL"></iframe>
+}
+else if (Model.PuzzleFile != null)
+{
+    <iframe id="puzzle-frame" title="@Model.Puzzle.Name" sandbox="allow-same-origin allow-scripts" src="@Model.PuzzleFile.ShortName"></iframe>
+}
+else {
+    <div>This puzzle has no online content. Please look elsewhere for what you need to solve it.</div>
+}

--- a/ServerCore/Pages/Submissions/SubmitProto.cshtml
+++ b/ServerCore/Pages/Submissions/SubmitProto.cshtml
@@ -1,0 +1,19 @@
+﻿@page "/{eventId}/{eventRole}/Submissions/SubmitProto"
+@model ServerCore.Pages.Submissions.SubmitProtoModel
+
+@{
+    @using Helpers;
+
+    ViewData["Title"] = "Solve here and submit your answer";
+    ViewData["AdminRoute"] = "../Submissions/AuthorIndex";
+    ViewData["AuthorRoute"] = "../Submissions/AuthorIndex";
+    // TODO: Needs to handle implicit teams - ViewData["PlayRoute"] = "../Submissions/Index";
+    ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
+}
+
+@using System.Text @* for StringBuilder *@
+
+<h2>Solve and submit answers for your puzzle</h2>
+<hr />
+<iframe title="Puzzle" width="1500" height="800" sandbox="allow-same-origin allow-scripts" credentialless src="https://puzzlehunt.azurewebsites.net/4/Files/example-puzzle%2Findex.html"></iframe>
+<iframe title="Puzzle" width="1500" height="800" sandbox="allow-same-origin allow-scripts" credentialless src="https://puzzleserverteststore.blob.core.windows.net/evt4/GINMPx+Ko8rDJnnhDY4_JA==/example-puzzle/index.html"></iframe>

--- a/ServerCore/Pages/Submissions/SubmitProto.cshtml.cs
+++ b/ServerCore/Pages/Submissions/SubmitProto.cshtml.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -8,16 +5,20 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.Helpers;
 using ServerCore.ModelBases;
 
 namespace ServerCore.Pages.Submissions
 {
+    [Authorize(Policy = "PlayerCanSeePuzzle")]
     public class SubmitProtoModel : EventSpecificPageModel
     {
         public SubmitProtoModel(PuzzleServerContext serverContext, UserManager<IdentityUser> manager) : base(serverContext, manager)
         {
         }
+
+        public Puzzle Puzzle { get; set; }
+
+        public ContentFile PuzzleFile { get; set; }
 
         public async Task<IActionResult> OnGetAsync(int puzzleId)
         {
@@ -28,7 +29,12 @@ namespace ServerCore.Pages.Submissions
 
         private async Task SetupContext(int puzzleId)
         {
+            Puzzle = await _context.Puzzles.Where(
+                (p) => p.ID == puzzleId).FirstOrDefaultAsync();
 
+            PuzzleFile = await _context.ContentFiles.Where(
+                (f) => (f.Event == Event) && (f.Puzzle.ID == puzzleId) && (f.FileType == ContentFileType.Puzzle)
+                ).FirstOrDefaultAsync();
         }
     }
 }

--- a/ServerCore/Pages/Submissions/SubmitProto.cshtml.cs
+++ b/ServerCore/Pages/Submissions/SubmitProto.cshtml.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Submissions
+{
+    public class SubmitProtoModel : EventSpecificPageModel
+    {
+        public SubmitProtoModel(PuzzleServerContext serverContext, UserManager<IdentityUser> manager) : base(serverContext, manager)
+        {
+        }
+
+        public async Task<IActionResult> OnGetAsync(int puzzleId)
+        {
+            await SetupContext(puzzleId);
+
+            return Page();
+        }
+
+        private async Task SetupContext(int puzzleId)
+        {
+
+        }
+    }
+}

--- a/ServerCore/Pages/Teams/PlayProto.cshtml
+++ b/ServerCore/Pages/Teams/PlayProto.cshtml
@@ -1,0 +1,31 @@
+﻿@page "/{eventId}/{eventRole}/Teams/{teamId}/PlayProto"
+@model ServerCore.Pages.Teams.PlayProtoModel
+
+@{
+    @using Helpers;
+
+    ViewData["Title"] = "Puzzles";
+    ViewData["AdminRoute"] = "/Puzzles/Index";
+    ViewData["AuthorRoute"] = "/Puzzles/Index";
+}
+
+<h2>Puzzles</h2>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                <div>Puzzle</div>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var puz in Model.PuzzleViews)
+        {
+            <tr>
+                <td>
+                    <a asp-page="/Submissions/SubmitProto" asp-route-puzzleId="@puz.ID">@RawHtmlHelper.Display(puz.Name, Model.Event.ID, Html)</a>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/ServerCore/Pages/Teams/PlayProto.cshtml.cs
+++ b/ServerCore/Pages/Teams/PlayProto.cshtml.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Teams
+{
+    [Authorize(Policy = "PlayerIsOnTeam")]
+    public class PlayProtoModel : EventSpecificPageModel
+    {
+        public PlayProtoModel(PuzzleServerContext serverContext, UserManager<IdentityUser> manager) : base(serverContext, manager)
+        {
+        }
+
+        public IList<PuzzleView> PuzzleViews { get; set; }
+
+        public int TeamID { get; set; }
+
+        public string TeamPassword { get; set; }
+
+        public async Task OnGetAsync(int teamId)
+        {
+            TeamID = teamId;
+            Team myTeam = await UserEventHelper.GetTeamForPlayer(_context, Event, LoggedInUser);
+            if (myTeam != null)
+            {
+                TeamID = myTeam.ID;
+                TeamPassword = myTeam.Password;
+                await PuzzleStateHelper.CheckForTimedUnlocksAsync(_context, Event, myTeam);
+            }
+            else
+            {
+                throw new Exception("Not currently registered for a team");
+            }
+
+            // all puzzles for this event that are real puzzles
+            var puzzlesInEventQ = _context.Puzzles.Where(puzzle => puzzle.Event.ID == this.Event.ID && puzzle.IsPuzzle);
+
+            // unless we're in a global lockout, then filter to those!
+            var puzzlesCausingGlobalLockoutQ = PuzzleStateHelper.PuzzlesCausingGlobalLockout(_context, Event, myTeam);
+            if (await puzzlesCausingGlobalLockoutQ.AnyAsync())
+            {
+                puzzlesInEventQ = puzzlesCausingGlobalLockoutQ;
+            }
+
+            // all puzzle states for this team that are unlocked (note: IsUnlocked bool is going to harm perf, just null check the time here)
+            // Note that it's OK if some puzzles do not yet have a state record; those puzzles are clearly still locked and hence invisible.
+            // All puzzles will show if all answers have been released)
+            var stateForTeamQ = _context.PuzzleStatePerTeam.Where(state => state.TeamID == this.TeamID && (state.UnlockedTime != null));
+
+            // join 'em (note: just getting all properties for max flexibility, can pick and choose columns for perf later)
+            // Note: EF gotcha is that you have to join into anonymous types in order to not lose valuable stuff
+            var visiblePuzzlesQ = from Puzzle puzzle in puzzlesInEventQ
+                                  join PuzzleStatePerTeam pspt in stateForTeamQ on puzzle.ID equals pspt.PuzzleID
+                                  select new PuzzleView { ID = puzzle.ID, Name = puzzle.Name, CustomUrl = puzzle.CustomURL };
+
+            PuzzleViews = await visiblePuzzlesQ.ToListAsync();
+
+            Dictionary<int, ContentFile> files = await (from file in _context.ContentFiles
+                                                        where file.Event == Event && file.FileType == ContentFileType.Puzzle
+                                                        select file).ToDictionaryAsync(file => file.PuzzleID);
+
+            foreach (var puzzleView in PuzzleViews)
+            {
+                files.TryGetValue(puzzleView.ID, out ContentFile content);
+                puzzleView.Content = content;
+            }
+        }
+
+        public class PuzzleView
+        {
+            public int ID { get; set; }
+            public string Name { get; set; }
+            public string CustomUrl { get; set; }
+            public ContentFile Content { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Minimum POC.  After proving this works, these separate files will be removed and the necessary changes will be ported to the existing puzzle lists and submission pages.  The main test that needs to happen on the server is for PDF files, since I couldn't figure out how to upload PDFs on my local test instance.  

For PDFs, it may also be useful to have a download link below the frame in case the browser has trouble rendering the PDF and they want to use a different PDF viewer.  For puzzles that have no content, the message saying so also won't be necessary in production.  

The real changes will also create a new event property, which will be disabled by default, to use the embedded puzzle format, since not all events may want it.  

