### PR TITLE
Add admin wiki to homepage

### DIFF
--- a/ServerCore/Pages/Resources/Default/HomePartial.cshtml
+++ b/ServerCore/Pages/Resources/Default/HomePartial.cshtml
@@ -14,6 +14,7 @@
         if (eventPage?.EventRole == ModelBases.EventRole.admin)
         {
             <p><b>Since you're an admin:</b> Either set the HomePartial field of your event to match a folder in the Pages\Resources directory, or place raw HTML into the HomeContent field of your event.</p>
+            <p> Also, take a look at <a href="https://github.com/PuzzleServer/mainpuzzleserver/wiki/Admins:-How-to-use-the-site" target="_blank">Admins: How to use the site</a> wiki for more information on how to use this site as an admin.</p>
         }
         if (eventPage?.EventRole == ModelBases.EventRole.author)
         {


### PR DESCRIPTION
Add link to admin wiki in homepage.

As an admin, you will see
![image](https://user-images.githubusercontent.com/4121745/221739412-146d983a-4342-4dfe-8d77-afda63c0c6c4.png)


As a player, you will see
![image](https://user-images.githubusercontent.com/4121745/221739379-9d1b3035-85b8-4eee-a567-491990abb5fa.png)
