### PR TITLE
send prerequisites to the correct place

### DIFF
--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -210,7 +210,7 @@
                     {
                         <tr>
                             <td>
-                                <a asp-page="./Edit" asp-route-id="@(pre.ID)">@(pre.PlaintextName)</a>
+                                <a asp-page="./Edit" asp-route-puzzleid="@(pre.ID)">@(pre.PlaintextName)</a>
                             </td>
                             <td>
                                 <a asp-page-handler="RemovePrerequisite" asp-route-id="@Model.Puzzle.ID" asp-route-prerequisite="@(pre.ID)">Remove</a>
@@ -244,7 +244,7 @@
                     {
                         <tr>
                             <td>
-                                <a asp-page="./Edit" asp-route-id="@(p.ID)">@(p.PlaintextName)</a>
+                                <a asp-page="./Edit" asp-route-puzzleid="@(p.ID)">@(p.PlaintextName)</a>
                             </td>
                             <td>
                                 <a asp-page-handler="RemovePrerequisiteOf" asp-route-id="@Model.Puzzle.ID" asp-route-prerequisiteOf="@(p.ID)">Remove</a>


### PR DESCRIPTION
Currently, clicking on a puzzle in the prerequisite list just links you back to the top of the current puzzle.
This fix makes sure the link will actually take you to the prerequisite puzzle

The problem was that the link was creating /admin/Puzzles/Edit/[currentPuzzleId]?Id=[prerequisitePuzzleId]

What we wanted was /admin/Puzzles/Edit/[prerequisitePuzzleId]

For example, for the GetHoppingPuzzle (id1) we want all the other links to link to the edits of the other puzzle ids
<img width="537" alt="image" src="https://user-images.githubusercontent.com/4121745/224874985-3408cb9a-da94-4517-8e81-fe4c43653694.png">


