### PR TITLE
Fix display name html

### DIFF
--- a/Data/DataModel/Swag.cs
+++ b/Data/DataModel/Swag.cs
@@ -16,13 +16,10 @@ namespace ServerCore.DataModel
 
         public virtual PuzzleUser Player { get; set; }
 
-        [Display(Name ="Lunch Selection")]
         public string Lunch { get; set; }
 
-        [Display(Name = "Dietary Modifications (e.g. no cheese)")]
         public string LunchModifications { get; set; }
 
-        [Display(Name = "T-Shirt Size")]
         public string ShirtSize { get; set; }
     }
 }

--- a/ServerCore/Pages/Events/AddAdminOrAuthor.cshtml
+++ b/ServerCore/Pages/Events/AddAdminOrAuthor.cshtml
@@ -19,10 +19,10 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Users[0].Name)
+                Name
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Users[0].Email)
+                Email
             </th>
             <th>
             </th>
@@ -33,10 +33,10 @@
         {
         <tr>
             <td>
-                @Html.DisplayFor(modelItem => item.Name)
+                @item.Name
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Email)
+                @item.Email
             </td>
             <td>
                 @if (Model.addAdmin)

--- a/ServerCore/Pages/Events/Create.cshtml
+++ b/ServerCore/Pages/Events/Create.cshtml
@@ -52,21 +52,21 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.IsInternEvent" /> @Html.DisplayNameFor(model => model.Event.IsInternEvent)
+                        <input asp-for="Event.IsInternEvent" /> IsInternEvent
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.EventHasSwag" /> @Html.DisplayNameFor(model => model.Event.EventHasSwag)
+                        <input asp-for="Event.EventHasSwag" /> EventHasSwag
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.HideHints" /> @Html.DisplayNameFor(model => model.Event.HideHints)
+                        <input asp-for="Event.HideHints" /> HideHints
                     </label>
                 </div>
             </div>
@@ -123,21 +123,21 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.StandingsOverride" /> @Html.DisplayNameFor(model => model.Event.StandingsOverride)
+                        <input asp-for="Event.StandingsOverride" /> StandingsOverride
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.ShowFastestSolves" /> @Html.DisplayNameFor(model => model.Event.ShowFastestSolves)
+                        <input asp-for="Event.ShowFastestSolves" /> ShowFastestSolves
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="Event.AllowFeedback" /> @Html.DisplayNameFor(model => model.Event.AllowFeedback)
+                        <input asp-for="Event.AllowFeedback" /> AllowFeedback
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Events/CreateDemo.cshtml
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml
@@ -31,14 +31,14 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="AddCreatorToLoneWolfTeam" /> @Html.DisplayNameFor(model => model.AddCreatorToLoneWolfTeam)
+                        <input asp-for="AddCreatorToLoneWolfTeam" /> AddCreatorToLoneWolfTeam
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="StartTheEvent" /> @Html.DisplayNameFor(model => model.StartTheEvent)
+                        <input asp-for="StartTheEvent" /> StartTheEvent
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Events/Delete.cshtml
+++ b/ServerCore/Pages/Events/Delete.cshtml
@@ -27,10 +27,13 @@
             UrlString
         </dt>
         <dd>
-            HomePartial
-            </dt>
-        <dd>
             @Model.Event.UrlString
+        </dd>
+        <dt>
+            HomePartial
+        </dt>
+        <dd>
+            @Model.Event.HomePartial
         </dd>
         <dt>
             MaxNumberOfTeams

--- a/ServerCore/Pages/Events/Delete.cshtml
+++ b/ServerCore/Pages/Events/Delete.cshtml
@@ -18,127 +18,127 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.Event.Name)
+            Name
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.Name)
+            @Model.Event.Name
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.UrlString)
+            UrlString
         </dt>
         <dd>
-            @Html.DisplayNameFor(model => model.Event.HomePartial)
+            HomePartial
             </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.UrlString)
+            @Model.Event.UrlString
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.MaxNumberOfTeams)
+            MaxNumberOfTeams
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.MaxNumberOfTeams)
+            @Model.Event.MaxNumberOfTeams
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.MaxTeamSize)
+            MaxTeamSize
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.MaxTeamSize)
+            @Model.Event.MaxTeamSize
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.MaxExternalsPerTeam)
+            MaxExternalsPerTeam
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.MaxExternalsPerTeam)
+            @Model.Event.MaxExternalsPerTeam
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.IsInternEvent)
+            IsInternEvent
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.IsInternEvent)
+            @Model.Event.IsInternEvent
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.HideHints)
+            HideHints
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.HideHints)
+            @Model.Event.HideHints
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamRegistrationBegin)
+            TeamRegistrationBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamRegistrationBegin)
+            @Model.Event.TeamRegistrationBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamRegistrationEnd)
+            TeamRegistrationEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamRegistrationEnd)
+            @Model.Event.TeamRegistrationEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamNameChangeEnd)
+            TeamNameChangeEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamNameChangeEnd)
+            @Model.Event.TeamNameChangeEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamMembershipChangeEnd)
+            TeamMembershipChangeEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamMembershipChangeEnd)
+            @Model.Event.TeamMembershipChangeEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamMiscDataChangeEnd)
+            TeamMiscDataChangeEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamMiscDataChangeEnd)
+            @Model.Event.TeamMiscDataChangeEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamDeleteEnd)
+            TeamDeleteEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamDeleteEnd)
+            @Model.Event.TeamDeleteEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.EventBegin)
+            EventBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.EventBegin)
+            @Model.Event.EventBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.AnswerSubmissionEnd)
+            AnswerSubmissionEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.AnswerSubmissionEnd)
+            @Model.Event.AnswerSubmissionEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.AnswersAvailableBegin)
+            AnswersAvailableBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.AnswersAvailableBegin)
+            @Model.Event.AnswersAvailableBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.StandingsAvailableBegin)
+            StandingsAvailableBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.StandingsAvailableBegin)
+            @Model.Event.StandingsAvailableBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.StandingsOverride)
+            StandingsOverride
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.StandingsOverride)
+            @Model.Event.StandingsOverride
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.ShowFastestSolves)
+            ShowFastestSolves
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.ShowFastestSolves)
+            @Model.Event.ShowFastestSolves
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.AllowFeedback)
+            AllowFeedback
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.AllowFeedback)
+            @Model.Event.AllowFeedback
         </dd>
     </dl>
 

--- a/ServerCore/Pages/Events/Details.cshtml
+++ b/ServerCore/Pages/Events/Details.cshtml
@@ -17,142 +17,142 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.Event.Name)
+            Name
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.Name)
+            @Model.Event.Name
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.UrlString)
+            UrlString
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.UrlString)
+            @Model.Event.UrlString
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.HomePartial)
+            HomePartial
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.HomePartial)
+            @Model.Event.HomePartial
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.ContactEmail)
+            ContactEmail
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.ContactEmail)
+            @Model.Event.ContactEmail
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.MaxNumberOfTeams)
+            MaxNumberOfTeams
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.MaxNumberOfTeams)
+            @Model.Event.MaxNumberOfTeams
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.MaxTeamSize)
+            MaxTeamSize
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.MaxTeamSize)
+            @Model.Event.MaxTeamSize
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.MaxExternalsPerTeam)
+            MaxExternalsPerTeam
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.MaxExternalsPerTeam)
+            @Model.Event.MaxExternalsPerTeam
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.IsInternEvent)
+            IsInternEvent
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.IsInternEvent)
+            @Model.Event.IsInternEvent
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.EventHasSwag)
+            EventHasSwag
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.EventHasSwag)
+            @Model.Event.EventHasSwag
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.HideHints)
+            HideHints
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.HideHints)
+            @Model.Event.HideHints
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamRegistrationBegin)
+            TeamRegistrationBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamRegistrationBegin)
+            @Model.Event.TeamRegistrationBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamRegistrationEnd)
+            TeamRegistrationEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamRegistrationEnd)
+            @Model.Event.TeamRegistrationEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamNameChangeEnd)
+            TeamNameChangeEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamNameChangeEnd)
+            @Model.Event.TeamNameChangeEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamMembershipChangeEnd)
+            TeamMembershipChangeEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamMembershipChangeEnd)
+            @Model.Event.TeamMembershipChangeEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamMiscDataChangeEnd)
+            TeamMiscDataChangeEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamMiscDataChangeEnd)
+            @Model.Event.TeamMiscDataChangeEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.TeamDeleteEnd)
+            TeamDeleteEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.TeamDeleteEnd)
+            @Model.Event.TeamDeleteEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.EventBegin)
+            EventBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.EventBegin)
+            @Model.Event.EventBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.AnswerSubmissionEnd)
+            AnswerSubmissionEnd
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.AnswerSubmissionEnd)
+            @Model.Event.AnswerSubmissionEnd
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.AnswersAvailableBegin)
+            AnswersAvailableBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.AnswersAvailableBegin)
+            @Model.Event.AnswersAvailableBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.StandingsAvailableBegin)
+            StandingsAvailableBegin
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.StandingsAvailableBegin)
+            @Model.Event.StandingsAvailableBegin
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.StandingsOverride)
+            StandingsOverride
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.StandingsOverride)
+            @Model.Event.StandingsOverride
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.ShowFastestSolves)
+            ShowFastestSolves
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.ShowFastestSolves)
+            @Model.Event.ShowFastestSolves
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Event.AllowFeedback)
+            AllowFeedback
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Event.AllowFeedback)
+            @Model.Event.AllowFeedback
         </dd>
     </dl>
 </div>

--- a/ServerCore/Pages/Events/Edit.cshtml
+++ b/ServerCore/Pages/Events/Edit.cshtml
@@ -58,21 +58,21 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="EditableEvent.IsInternEvent" /> @Html.DisplayNameFor(model => model.EditableEvent.IsInternEvent)
+                        <input asp-for="EditableEvent.IsInternEvent" /> IsInternEvent
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="EditableEvent.EventHasSwag" /> @Html.DisplayNameFor(model => model.EditableEvent.EventHasSwag)
+                        <input asp-for="EditableEvent.EventHasSwag" /> EventHasSwag
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="EditableEvent.HideHints" /> @Html.DisplayNameFor(model => model.EditableEvent.HideHints)
+                        <input asp-for="EditableEvent.HideHints" /> HideHints
                     </label>
                 </div>
             </div>
@@ -129,21 +129,21 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="EditableEvent.StandingsOverride" /> @Html.DisplayNameFor(model => model.EditableEvent.StandingsOverride)
+                        <input asp-for="EditableEvent.StandingsOverride" /> StandingsOverride
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="EditableEvent.ShowFastestSolves" /> @Html.DisplayNameFor(model => model.EditableEvent.ShowFastestSolves)
+                        <input asp-for="EditableEvent.ShowFastestSolves" /> ShowFastestSolves
                     </label>
                 </div>
             </div>
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="EditableEvent.AllowFeedback" /> @Html.DisplayNameFor(model => model.EditableEvent.AllowFeedback)
+                        <input asp-for="EditableEvent.AllowFeedback" /> AllowFeedback
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Events/FastestSolves.cshtml
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml
@@ -31,7 +31,7 @@
                                                                       FastestSolvesModel.SortOrder.PuzzleDescending))"
                             asp-route-stateFilter="@Model.StateFilter">
 
-                            @Html.DisplayNameFor(model => model.Puzzles[0].PuzzleName)
+                            PuzzleName
                         </a>
                     </th>
                     <th>

--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -15,13 +15,13 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Events[0].Name)
+                Name
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Events[0].UrlString)
+                UrlString
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Events[0].IsInternEvent)
+                IsInternEvent
             </th>
             <th></th>
         </tr>
@@ -31,14 +31,14 @@
         <tr>
             <td>
                 <a asp-page="/EventSpecific/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="play">
-                    @Html.DisplayFor(modelItem => item.Name)
+                    @item.Name
                 </a>
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.UrlString)
+                @item.UrlString
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.IsInternEvent)
+                @item.IsInternEvent
             </td>
             <td>
                 <a asp-page="./Edit" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Edit</a> |

--- a/ServerCore/Pages/Events/Map.cshtml
+++ b/ServerCore/Pages/Events/Map.cshtml
@@ -22,13 +22,13 @@
                         Rank
                     </th>
                     <th>
-                        @Html.DisplayNameFor(model => model.Teams[0].Team.Name)
+                        Name
                     </th>
                     <th>
                         Puzzles
                     </th>
                     <th>
-                        @Html.DisplayNameFor(model => model.Teams[0].Score)
+                        Score
                     </th>
                     @foreach (var puzzle in Model.Puzzles)
                     {
@@ -49,10 +49,10 @@
                         <a asp-page="/Teams/Status" asp-route-teamId="@team.Team.ID">@(team.Team.Name)</a>
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => team.SolveCount)
+                        @team.SolveCount
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => team.Score)
+                        @team.Score
                     </td>
             @for (int x = 0; x < Model.Puzzles.Count; x++)
             {

--- a/ServerCore/Pages/Events/PlayerSubmissions.cshtml
+++ b/ServerCore/Pages/Events/PlayerSubmissions.cshtml
@@ -44,7 +44,7 @@ else
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => submission.TeamName)
+                    @submission.TeamName
                 </td>
                 <td>
                     @if (submission.Linkify)
@@ -53,7 +53,7 @@ else
                     }
                     else
                     {
-                        @Html.DisplayFor(modelItem => submission.SubmissionText)
+                        @submission.SubmissionText
                     }
                 </td>
             </tr>

--- a/ServerCore/Pages/Events/Players.cshtml
+++ b/ServerCore/Pages/Events/Players.cshtml
@@ -17,13 +17,13 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Admins[0].Name)
+                Name
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Admins[0].Email)
+                Email
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Admins[0].EmployeeAlias)
+                EmployeeAlias
             </th>
             <th>
             </th>
@@ -37,18 +37,18 @@
                 <td>
                     @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
-                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Name)</a>
+                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@item.Name</a>
                     }
                     else
                     {
-                        @Html.DisplayFor(modelItem => item.Name)
+                        @item.Name
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Email)
+                    @item.Email
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.EmployeeAlias)
+                    @item.EmployeeAlias
                 </td>
                 <td>
                     <a asp-page-handler="RemoveAdmin" asp-route-userId=@item.ID onclick="return confirm('Are you sure you want to remove @item.Name from the event admins?')">Remove</a>
@@ -70,13 +70,13 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Authors[0].Item1.Name)
+                Name
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Authors[0].Item1.Email)
+                Email
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Authors[0].Item1.EmployeeAlias)
+                EmployeeAlias
             </th>
             <th>
                 Puzzle count
@@ -93,21 +93,21 @@
                 <td>
                     @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
-                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Item1.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Item1.Name)</a>
+                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Item1.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@item.Item1.Name</a>
                     }
                     else
                     {
-                        @Html.DisplayFor(modelItem => item.Item1.Name)
+                        @item.Item1.Name
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Item1.Email)
+                    @item.Item1.Email
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Item1.EmployeeAlias)
+                    @item.Item1.EmployeeAlias
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Item2)
+                    @item.Item2
                 </td>
                 <td>
                     <a asp-page-handler="RemoveAuthor" asp-route-userId=@item.Item1.ID onclick="return confirm('Are you sure you want to remove @item.Item1.Name from the event authors?')">Remove</a>
@@ -128,13 +128,13 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Players[0].Name)
+                Name
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Players[0].Email)
+                Email
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Players[0].EmployeeAlias)
+                EmployeeAlias
             </th>
             <th>
                 Team Name
@@ -149,21 +149,21 @@
                 <td>
                     @if (Model.LoggedInUser.IsGlobalAdmin)
                     {
-                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Name)</a>
+                        <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@item.Name</a>
                     }
                     else
                     {
-                        @Html.DisplayFor(modelItem => item.Name)
+                        @item.Name
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Email)
+                    @item.Email
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.EmployeeAlias)
+                    @item.EmployeeAlias
                 </td>
                 <td>
-                    <a asp-page="/Teams/Details" asp-route-teamId="@item.TeamID">@Html.DisplayFor(modelItem => item.TeamName)</a>
+                    <a asp-page="/Teams/Details" asp-route-teamId="@item.TeamID">@item.TeamName</a>
                 </td>
                 <td></td>
             </tr>

--- a/ServerCore/Pages/Events/Standings.cshtml
+++ b/ServerCore/Pages/Events/Standings.cshtml
@@ -20,7 +20,7 @@
                     </th>
                     <th>
                         <a asp-page="./Standings" asp-route-sort="@(Model.SortForColumnLink(StandingsModel.SortOrder.NameAscending, StandingsModel.SortOrder.NameDescending))">
-                            @Html.DisplayNameFor(model => model.Teams[0].Team.Name)
+                            Name
                         </a>
                     </th>
                     <th>
@@ -30,7 +30,7 @@
                     </th>
                     <th>
                         <a asp-page="./Standings" asp-route-sort="@(Model.SortForColumnLink(StandingsModel.SortOrder.ScoreDescending, StandingsModel.SortOrder.ScoreAscending))">
-                            @Html.DisplayNameFor(model => model.Teams[0].Score)
+                            Score
                         </a>
                     </th>
                     @if (!Model.Event.HideHints)
@@ -60,18 +60,18 @@
                         @(team.Team.Name)
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => team.SolveCount)
+                        @(team.SolveCount)
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => team.Score)
+                        @(team.Score)
                     </td>
                     @if (!Model.Event.HideHints)
                     {
                         <td>
-                            @Html.DisplayFor(modelItem => team.Team.HintCoinsEarned)
+                            @(team.Team.HintCoinsEarned)
                         </td>
                         <td>
-                            @Html.DisplayFor(modelItem => team.Team.HintCoinsUsed)
+                            @(team.Team.HintCoinsUsed)
                         </td>
                     }
                 </tr>

--- a/ServerCore/Pages/Hints/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Hints/AuthorIndex.cshtml
@@ -46,17 +46,17 @@
                 </th>
                 <th>
                     <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.DescriptionAscending, AuthorIndexModel.SortOrder.DescriptionDescending))">
-                        @Html.DisplayNameFor(model => model.HintViews[0].Description)
+                        Description
                     </a>
                 </th>
                 <th>
                     <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.CostAscending, AuthorIndexModel.SortOrder.CostDescending))">
-                        @Html.DisplayNameFor(model => model.HintViews[0].Cost)
+                        Cost
                     </a>
                 </th>
                 <th>
                     <a asp-page="./AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@Model.Team?.ID" asp-route-sort="@(Model.SortForColumnLink(AuthorIndexModel.SortOrder.TimeAscending, AuthorIndexModel.SortOrder.TimeDescending))">
-                        @Html.DisplayNameFor(model => model.HintViews[0].UnlockTime)
+                        UnlockTime
                     </a>
                 </th>
                 <th></th>
@@ -67,16 +67,16 @@
             {
             <tr>
                 <td>
-                    <a asp-page="AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@item.TeamId">@Html.DisplayFor(modelItem => item.TeamName)</a>
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@item.TeamId">@item.TeamName</a>
                 </td>
                 <td>
-                    <a asp-page="AuthorIndex" asp-route-puzzleId="@item.PuzzleId" asp-route-teamId="@Model.Team?.ID">@Html.DisplayFor(modelItem => item.PuzzleName)</a>
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@item.PuzzleId" asp-route-teamId="@Model.Team?.ID">@item.PuzzleName</a>
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Description)
+                    @item.Description
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Cost)
+                    @item.Cost
                 </td>
                 <td>
                     @Html.Raw(Model.LocalTime(item.UnlockTime))

--- a/ServerCore/Pages/Hints/CreateBulk.cshtml
+++ b/ServerCore/Pages/Hints/CreateBulk.cshtml
@@ -55,7 +55,7 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="DeleteExisting" /> @Html.DisplayNameFor(model => model.DeleteExisting)
+                        <input asp-for="DeleteExisting" /> DeleteExisting
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Hints/CreateBulkMulti.cshtml
+++ b/ServerCore/Pages/Hints/CreateBulkMulti.cshtml
@@ -59,7 +59,7 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="DeleteExisting" /> @Html.DisplayNameFor(model => model.DeleteExisting)
+                        <input asp-for="DeleteExisting" /> DeleteExisting
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Hints/Delete.cshtml
+++ b/ServerCore/Pages/Hints/Delete.cshtml
@@ -17,22 +17,22 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.Hint.Description)
+            Description
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Hint.Description)
+            @Model.Hint.Description
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Hint.Content)
+            Content
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Hint.Content)
+            @Model.Hint.Content
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Hint.Cost)
+            Cost
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Hint.Cost)
+            @Model.Hint.Cost
         </dd>
     </dl>
 

--- a/ServerCore/Pages/Hints/Details.cshtml
+++ b/ServerCore/Pages/Hints/Details.cshtml
@@ -21,28 +21,28 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.Hint.Description)
+            Description
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Hint.Description)
+            @Model.Hint.Description
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Hint.Content)
+            Content
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Hint.Content)
+            @Model.Hint.Content
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Hint.Cost)
+            Cost
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Hint.Cost)
+            @Model.Hint.Cost
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Hint.DisplayOrder)
+            DisplayOrder
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Hint.DisplayOrder)
+            @Model.Hint.DisplayOrder
         </dd>
     </dl>
 </div>

--- a/ServerCore/Pages/Hints/Index.cshtml
+++ b/ServerCore/Pages/Hints/Index.cshtml
@@ -20,16 +20,16 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Hints[0].Description)
+                Description
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Hints[0].Content)
+                Content
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Hints[0].Cost)
+                Cost
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Hints[0].DisplayOrder)
+                DisplayOrder
             </th>
             <th>
                 Actions
@@ -41,16 +41,16 @@
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Description)
+                    @item.Description
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Content)
+                    @item.Content
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Cost)
+                    @item.Cost
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.DisplayOrder)
+                    @item.DisplayOrder
                 </td>
                 <td>
                     <div class="shortcut-menu-dropdown">

--- a/ServerCore/Pages/Hints/Responses.cshtml
+++ b/ServerCore/Pages/Hints/Responses.cshtml
@@ -22,15 +22,15 @@
                 </th>
                 <th>
                     <a asp-page="./Responses" asp-route-sort="@(Model.SortForColumnLink(ResponsesModel.SortOrder.DescriptionAscending, ResponsesModel.SortOrder.DescriptionDescending))">
-                        @Html.DisplayNameFor(model => model.HintViews[0].Description)
+                        Description
                     </a>
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.HintViews[0].Content)
+                    Content
                 </th>
                 <th>
                     <a asp-page="./Responses" asp-route-sort="@(Model.SortForColumnLink(ResponsesModel.SortOrder.CostAscending, ResponsesModel.SortOrder.CostDescending))">
-                        @Html.DisplayNameFor(model => model.HintViews[0].Cost)
+                        Cost
                     </a>
                 </th>
             </tr>
@@ -40,16 +40,16 @@
             {
                 <tr>
                     <td>
-                        @Html.DisplayFor(modelItem => item.PuzzleName)
+                        @item.PuzzleName
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => item.Description)
+                        @item.Description
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => item.Content)
+                        @item.Content
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => item.Cost)
+                        @item.Cost
                     </td>
                 </tr>
             }

--- a/ServerCore/Pages/Pieces/Delete.cshtml
+++ b/ServerCore/Pages/Pieces/Delete.cshtml
@@ -16,22 +16,22 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.Piece.Puzzle)
+            Puzzle
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Piece.Puzzle.Name)
+            @Model.Piece.Puzzle.Name
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Piece.ProgressLevel)
+            ProgressLevel
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Piece.ProgressLevel)
+            @Model.Piece.ProgressLevel
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Piece.Contents)
+            Contents
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Piece.Contents)
+            @Model.Piece.Contents
         </dd>
     </dl>
     

--- a/ServerCore/Pages/Pieces/Index.cshtml
+++ b/ServerCore/Pages/Pieces/Index.cshtml
@@ -15,10 +15,10 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Pieces[0].ProgressLevel)
+                ProgressLevel
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Pieces[0].Contents)
+                Contents
             </th>
             <th></th>
         </tr>
@@ -27,10 +27,10 @@
 @foreach (var item in Model.Pieces) {
         <tr>
             <td>
-                @Html.DisplayFor(modelItem => item.ProgressLevel)
+                @item.ProgressLevel
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Contents)
+                @item.Contents
             </td>
             <td>
                 <a asp-page="./Edit" asp-route-puzzleId="@Model.PuzzleId" asp-route-id="@item.ID">Edit</a> |

--- a/ServerCore/Pages/Puzzles/Checklist.cshtml
+++ b/ServerCore/Pages/Puzzles/Checklist.cshtml
@@ -64,7 +64,7 @@
                 @ServerCore.Helpers.RawHtmlHelper.Display(item.Puzzle.Group, Model.Event.ID, Html)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Authors)
+                @item.Authors
             </td>
             <td>
                 @if (item.Puzzle.CustomURL != null)
@@ -87,17 +87,17 @@
                 }
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Puzzle.MinPrerequisiteCount) of @Html.DisplayFor(modelItem => item.PrerequisitesCount)
+                @(item.Puzzle.MinPrerequisiteCount) of @(item.PrerequisitesCount)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Prerequisites)
+                @(item.Prerequisites)
                 @if (item.Puzzle.MinPrerequisiteCount > item.PrerequisitesCount)
                 {
                     <font color="red">WARNING: Fewer prereqs than min</font>
                 }
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Responses.ResponseCount)
+                @(item.Responses.ResponseCount)
             </td>
             <td>
                 @if (item.Responses.HasAnswer)
@@ -108,10 +108,10 @@
             @if (!Model.Event.HideHints)
             {
                 <td>
-                    @Html.DisplayFor(modelItem => item.Hints)
+                    @(item.Hints)
                 </td>
                 <td>
-                    $@Html.DisplayFor(modelItem => item.TotalHintCost)
+                    @(item.TotalHintCost)
                 </td>
             }
         </tr>

--- a/ServerCore/Pages/Puzzles/Delete.cshtml
+++ b/ServerCore/Pages/Puzzles/Delete.cshtml
@@ -22,100 +22,100 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.Name)
+            Name
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.Name)
+            @Model.Puzzle.Name
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.IsPuzzle)
+            IsPuzzle
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.IsPuzzle)
+            @Model.Puzzle.IsPuzzle
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.IsMetaPuzzle)
+            IsMetaPuzzle
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.IsMetaPuzzle)
+            @Model.Puzzle.IsMetaPuzzle
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.IsFinalPuzzle)
+            IsFinalPuzzle
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.IsFinalPuzzle)
+            @Model.Puzzle.IsFinalPuzzle
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.IsCheatCode)
+            IsCheatCode
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.IsCheatCode)
+            @Model.Puzzle.IsCheatCode
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.SolveValue)
+            SolveValue
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.SolveValue)
+            @Model.Puzzle.SolveValue
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.Token)
+            Token
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.Token)
+            @Model.Puzzle.Token
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.Group)
+            Group
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.Group)
+            @Model.Puzzle.Group
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.OrderInGroup)
+            OrderInGroup
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.OrderInGroup)
+            @Model.Puzzle.OrderInGroup
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.IsGloballyVisiblePrerequisite)
+            IsGloballyVisiblePrerequisite
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.IsGloballyVisiblePrerequisite)
+            @Model.Puzzle.IsGloballyVisiblePrerequisite
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.MinPrerequisiteCount)
+            MinPrerequisiteCount
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.MinPrerequisiteCount)
+            @Model.Puzzle.MinPrerequisiteCount
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.MinutesToAutomaticallySolve)
+            MinutesToAutomaticallySolve
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.MinutesToAutomaticallySolve)
+            @Model.Puzzle.MinutesToAutomaticallySolve
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.MinutesOfEventLockout)
+            MinutesOfEventLockout
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.MinutesOfEventLockout)
+            @Model.Puzzle.MinutesOfEventLockout
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.MaxAnnotationKey)
+            MaxAnnotationKey
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.MaxAnnotationKey)
+            @Model.Puzzle.MaxAnnotationKey
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.CustomURL)
+            CustomURL
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.CustomURL)
+            @Model.Puzzle.CustomURL
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Puzzle.CustomSolutionURL)
+            CustomSolutionURL
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Puzzle.CustomSolutionURL)
+            @Model.Puzzle.CustomSolutionURL
         </dd>
     </dl>
 

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -101,7 +101,7 @@
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsGloballyVisiblePrerequisite" /> IsGloballyVisiblePrerequisite)
+                                        <input asp-for="Puzzle.IsGloballyVisiblePrerequisite" /> IsGloballyVisiblePrerequisite
                                     </label>
                                 </div>
                             </div>
@@ -126,7 +126,7 @@
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsFreeform" /> IsFreeform)
+                                        <input asp-for="Puzzle.IsFreeform" /> IsFreeform
                                     </label>
                                 </div>
                             </div>

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -49,35 +49,35 @@
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsPuzzle" /> @Html.DisplayNameFor(model => model.Puzzle.IsPuzzle)
+                                        <input asp-for="Puzzle.IsPuzzle" /> IsPuzzle
                                     </label>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsMetaPuzzle" /> @Html.DisplayNameFor(model => model.Puzzle.IsMetaPuzzle)
+                                        <input asp-for="Puzzle.IsMetaPuzzle" /> IsMetaPuzzle
                                     </label>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsFinalPuzzle" /> @Html.DisplayNameFor(model => model.Puzzle.IsFinalPuzzle)
+                                        <input asp-for="Puzzle.IsFinalPuzzle" /> IsFinalPuzzle
                                     </label>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsCheatCode" /> @Html.DisplayNameFor(model => model.Puzzle.IsCheatCode)
+                                        <input asp-for="Puzzle.IsCheatCode" /> IsCheatCode
                                     </label>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.HasDataConfirmation" /> @Html.DisplayNameFor(model => model.Puzzle.HasDataConfirmation)
+                                        <input asp-for="Puzzle.HasDataConfirmation" /> HasDataConfirmation
                                     </label>
                                 </div>
                             </div>
@@ -101,7 +101,7 @@
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsGloballyVisiblePrerequisite" /> @Html.DisplayNameFor(model => model.Puzzle.IsGloballyVisiblePrerequisite)
+                                        <input asp-for="Puzzle.IsGloballyVisiblePrerequisite" /> IsGloballyVisiblePrerequisite)
                                     </label>
                                 </div>
                             </div>
@@ -126,7 +126,7 @@
                             <div class="form-group">
                                 <div class="checkbox">
                                     <label>
-                                        <input asp-for="Puzzle.IsFreeform" /> @Html.DisplayNameFor(model => model.Puzzle.IsFreeform)
+                                        <input asp-for="Puzzle.IsFreeform" /> IsFreeform)
                                     </label>
                                 </div>
                             </div>

--- a/ServerCore/Pages/Puzzles/Feedback.cshtml
+++ b/ServerCore/Pages/Puzzles/Feedback.cshtml
@@ -24,8 +24,8 @@ else
 }
 <div>
     <br />
-    <h4><b>Avg Fun Rating:</b> @Html.DisplayFor(x => x.FunScore) / @FeedbackModel.FeedbackMax</h4>
-    <h4><b>Avg Difficulty Rating:</b> @Html.DisplayFor(x => x.DiffScore) / @FeedbackModel.FeedbackMax</h4>
+    <h4><b>Avg Fun Rating:</b> @Model.FunScore / @FeedbackModel.FeedbackMax</h4>
+    <h4><b>Avg Difficulty Rating:</b> @Model.DiffScore / @FeedbackModel.FeedbackMax</h4>
 </div>
 
 <br>
@@ -37,25 +37,25 @@ else
                 Puzzle
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].TeamName)
+                TeamName
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Submitter.Name)
+                Submitter.Name
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Submitter.Email)
+                Submitter.Email
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Feedback.SubmissionTime)
+                Feedback.SubmissionTime
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Feedback.WrittenFeedback)
+                Feedback.WrittenFeedback
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Feedback.Difficulty)
+                Feedback.Difficulty
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Feedbacks[0].Feedback.Fun)
+                Feedback.Fun
             </th>
         </tr>
     </thead>
@@ -64,28 +64,28 @@ else
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Puzzle.Name)
+                    @item.Puzzle.Name
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.TeamName)
+                    @item.TeamName
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Submitter.Name)
+                    @item.Submitter.Name
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Submitter.Email)
+                    @item.Submitter.Email
                 </td>
                 <td>
                     @Html.Raw(Model.LocalTime(item.Feedback.SubmissionTime))
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Feedback.WrittenFeedback)
+                    @item.Feedback.WrittenFeedback
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Feedback.Difficulty)
+                    @item.Feedback.Difficulty
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Feedback.Fun)
+                    @item.Feedback.Fun
                 </td>
             </tr>
         }

--- a/ServerCore/Pages/Puzzles/Feedback.cshtml
+++ b/ServerCore/Pages/Puzzles/Feedback.cshtml
@@ -12,7 +12,7 @@
 @if (Model.PuzzleName != null)
 {
     Layout = "_puzzleManagementLayout.cshtml";
-    <h2>@Html.DisplayFor(model => model.PuzzleName): Feedback</h2>
+    <h2>@(Model.PuzzleName): Feedback</h2>
 }
 else
 {

--- a/ServerCore/Pages/Puzzles/Feedback.cshtml
+++ b/ServerCore/Pages/Puzzles/Feedback.cshtml
@@ -24,8 +24,8 @@ else
 }
 <div>
     <br />
-    <h4><b>Avg Fun Rating:</b> @Model.FunScore / @FeedbackModel.FeedbackMax</h4>
-    <h4><b>Avg Difficulty Rating:</b> @Model.DiffScore / @FeedbackModel.FeedbackMax</h4>
+    <h4><b>Avg Fun Rating:</b> @Html.DisplayFor(x => x.FunScore) / @FeedbackModel.FeedbackMax</h4>
+    <h4><b>Avg Difficulty Rating:</b> @Html.DisplayFor(x => x.DiffScore) / @FeedbackModel.FeedbackMax</h4>
 </div>
 
 <br>

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -60,7 +60,7 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Puzzles[0].Puzzle.Name)
+                Name
             </th>
             <th>
                 Puzzle file
@@ -72,10 +72,10 @@
                 @(Model.Event.TermForGroup ?? "Group")
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Puzzles[0].Puzzle.OrderInGroup)
+                OrderInGroup
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Puzzles[0].Puzzle.SolveValue)
+                SolveValue
             </th>
             <th>
                 Puzzle
@@ -131,10 +131,10 @@
                     @ServerCore.Helpers.RawHtmlHelper.Display(item.Puzzle.Group, Model.Event.ID, Html)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Puzzle.OrderInGroup)
+                    @item.Puzzle.OrderInGroup)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Puzzle.SolveValue)
+                    @item.Puzzle.SolveValue)
                 </td>
                 <td>
                     @if (item.Puzzle.IsPuzzle)
@@ -161,10 +161,10 @@
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Puzzle.MinPrerequisiteCount)
+                    @item.Puzzle.MinPrerequisiteCount
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Puzzle.SupportEmailAlias)
+                    @item.Puzzle.SupportEmailAlias
                 </td>
                 <td>
                     <div class="shortcut-menu-dropdown">

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -131,10 +131,10 @@
                     @ServerCore.Helpers.RawHtmlHelper.Display(item.Puzzle.Group, Model.Event.ID, Html)
                 </td>
                 <td>
-                    @item.Puzzle.OrderInGroup)
+                    @item.Puzzle.OrderInGroup
                 </td>
                 <td>
-                    @item.Puzzle.SolveValue)
+                    @item.Puzzle.SolveValue
                 </td>
                 <td>
                     @if (item.Puzzle.IsPuzzle)

--- a/ServerCore/Pages/Puzzles/Status.cshtml
+++ b/ServerCore/Pages/Puzzles/Status.cshtml
@@ -17,27 +17,27 @@
         <tr>
             <th>
                 <a asp-page="./Status" asp-route-puzzleId="@Model.Puzzle.ID" asp-route-sort="@(Model.SortForColumnLink(StatusModel.SortOrder.TeamAscending, StatusModel.SortOrder.TeamDescending))">
-                    @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Team) @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Team.Name)
+                    Team Name
                 </a>
             </th>
             <th>
                 <a asp-page="./Status" asp-route-puzzleId="@Model.Puzzle.ID" asp-route-sort="@(Model.SortForColumnLink(StatusModel.SortOrder.UnlockAscending, StatusModel.SortOrder.UnlockDescending))">
-                    @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].UnlockedTime)
+                    UnlockedTime
                 </a>
             </th>
             <th>
                 <a asp-page="./Status" asp-route-puzzleId="@Model.Puzzle.ID" asp-route-sort="@(Model.SortForColumnLink(StatusModel.SortOrder.SolveAscending, StatusModel.SortOrder.SolveDescending))">
-                    @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].SolvedTime)
+                    SolvedTime
                 </a>
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Printed)
+                Printed
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Notes)
+                Notes
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].IsEmailOnlyMode)
+                IsEmailOnlyMode
             </th>
         </tr>
     </thead>
@@ -46,7 +46,7 @@
         {
             <tr>
                 <td>
-                    <a asp-page="../Teams/Status" asp-route-teamId="@item.Team.ID">@Html.DisplayFor(modelItem => item.Team.Name)</a>
+                    <a asp-page="../Teams/Status" asp-route-teamId="@item.Team.ID">@item.Team.Name</a>
                 </td>
                 <td>
                     @if (item.UnlockedTime == null)
@@ -71,10 +71,10 @@
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Printed)
+                    item.Printed
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Notes)
+                    @item.Notes
                 </td>
                 <td>
                     @if (item.IsEmailOnlyMode == true)

--- a/ServerCore/Pages/Puzzles/Status.cshtml
+++ b/ServerCore/Pages/Puzzles/Status.cshtml
@@ -71,7 +71,7 @@
                     }
                 </td>
                 <td>
-                    item.Printed
+                    @item.Printed
                 </td>
                 <td>
                     @item.Notes

--- a/ServerCore/Pages/Puzzles/SubmitFeedback.cshtml
+++ b/ServerCore/Pages/Puzzles/SubmitFeedback.cshtml
@@ -10,7 +10,7 @@
     var id = ViewContext.RouteData.Values["puzzleId"];
 }
 
-<h2>Submit feedback for @Html.DisplayFor(model => model.Puzzle.Name)</h2> 
+<h2>Submit feedback for @(Model.Puzzle.Name)</h2> 
 <div>
     <a asp-page="/Teams/Play" asp-route-teamId="@Model.GetTeamId().Result">Back to puzzle list</a>
 </div>

--- a/ServerCore/Pages/Responses/Create.cshtml
+++ b/ServerCore/Pages/Responses/Create.cshtml
@@ -22,7 +22,7 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="PuzzleResponse.IsSolution" /> @Html.DisplayNameFor(model => model.PuzzleResponse.IsSolution)
+                        <input asp-for="PuzzleResponse.IsSolution" /> IsSolution
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Responses/CreateBulk.cshtml
+++ b/ServerCore/Pages/Responses/CreateBulk.cshtml
@@ -57,7 +57,7 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="DeleteExisting" /> @Html.DisplayNameFor(model => model.DeleteExisting)
+                        <input asp-for="DeleteExisting" /> DeleteExisting
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Responses/CreateBulkMulti.cshtml
+++ b/ServerCore/Pages/Responses/CreateBulkMulti.cshtml
@@ -61,7 +61,7 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="DeleteExisting" /> @Html.DisplayNameFor(model => model.DeleteExisting)
+                        <input asp-for="DeleteExisting" /> DeleteExisting
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Responses/Delete.cshtml
+++ b/ServerCore/Pages/Responses/Delete.cshtml
@@ -19,28 +19,28 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.IsSolution)
+            IsSolution
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.IsSolution)
+            @Model.PuzzleResponse.IsSolution
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.SubmittedText)
+            SubmittedText
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.SubmittedText)
+            @Model.PuzzleResponse.SubmittedText
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.ResponseText)
+            ResponseText
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.ResponseText)
+            @Model.PuzzleResponse.ResponseText
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.Note)
+            Note
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.Note)
+            @Model.PuzzleResponse.Note
         </dd>
     </dl>
 

--- a/ServerCore/Pages/Responses/Details.cshtml
+++ b/ServerCore/Pages/Responses/Details.cshtml
@@ -19,28 +19,28 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.IsSolution)
+            IsSolution
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.IsSolution)
+            @Model.PuzzleResponse.IsSolution
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.SubmittedText)
+            SubmittedText
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.SubmittedText)
+            @Model.PuzzleResponse.SubmittedText
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.ResponseText)
+            ResponseText
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.ResponseText)
+            @Model.PuzzleResponse.ResponseText
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.PuzzleResponse.Note)
+            Note
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.PuzzleResponse.Note)
+            @Model.PuzzleResponse.Note
         </dd>
     </dl>
 </div>

--- a/ServerCore/Pages/Responses/Edit.cshtml
+++ b/ServerCore/Pages/Responses/Edit.cshtml
@@ -23,7 +23,7 @@
             <div class="form-group">
                 <div class="checkbox">
                     <label>
-                        <input asp-for="PuzzleResponse.IsSolution" /> @Html.DisplayNameFor(model => model.PuzzleResponse.IsSolution)
+                        <input asp-for="PuzzleResponse.IsSolution" /> IsSolution
                     </label>
                 </div>
             </div>

--- a/ServerCore/Pages/Responses/Index.cshtml
+++ b/ServerCore/Pages/Responses/Index.cshtml
@@ -22,16 +22,16 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Responses[0].IsSolution)
+                IsSolution
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Responses[0].SubmittedText)
+                SubmittedText
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Responses[0].ResponseText)
+                ResponseText
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Responses[0].Note)
+                Note
             </th>
             <th>
                 Actions
@@ -49,13 +49,13 @@
                 }
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.SubmittedText)
+                @item.SubmittedText
             </td>
             <td>
                 @ServerCore.Helpers.RawHtmlHelper.Display(item.ResponseText, Model.Event.ID, Html)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Note)
+                @item.Note
             </td>
             <td>
                 <div class="shortcut-menu-dropdown">

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml
@@ -90,16 +90,16 @@
             {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.SubmitterName)
+                    @(item.SubmitterName)
                 </td>
                 <td>
-                    <a asp-page="AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@item.TeamID">@Html.DisplayFor(modelItem => item.TeamName)</a>
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@Model.Puzzle?.ID" asp-route-teamId="@item.TeamID">@(item.TeamName)</a>
                 </td>
                 <td>
-                    <a asp-page="AuthorIndex" asp-route-puzzleId="@item.PuzzleID" asp-route-teamId="@Model.Team?.ID">@Html.DisplayFor(modelItem => item.PuzzleName)</a>
+                    <a asp-page="AuthorIndex" asp-route-puzzleId="@item.PuzzleID" asp-route-teamId="@Model.Team?.ID">@(item.PuzzleName)</a>
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.ResponseText)
+                    @(item.ResponseText)
                 </td>
                 <td style="max-width: 500px; word-wrap: break-word">
                     @if (item.Linkify)
@@ -108,7 +108,7 @@
                     }
                     else
                     {
-                        @Html.DisplayFor(modelItem => item.SubmissionText)
+                        @(item.SubmissionText)
                     }
                 </td>
                 <td>

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -194,10 +194,10 @@
                             @Html.Raw(Model.LocalTime(Model.SubmissionViews[i].Submission.TimeSubmitted))
                         </td>
                         <td>
-                            @Html.DisplayFor(modelItem => Model.SubmissionViews[i].SubmitterName)
+                            @(Model.SubmissionViews[i].SubmitterName)
                         </td>
                         <td>
-                            @Html.DisplayFor(modelItem => Model.SubmissionViews[i].Submission.SubmissionText)
+                            @(Model.SubmissionViews[i].Submission.SubmissionText)
                         </td>
                         <td>
                             @{
@@ -209,7 +209,7 @@
                                     {
                                         if (Model.SubmissionViews[i].Submission.FreeformAccepted != null)
                                         {
-                                            @Html.DisplayFor(modelItem => Model.SubmissionViews[i].FreeformReponse);
+                                            @(Model.SubmissionViews[i].FreeformReponse);
                                         }
                                         else if (Model.PuzzleState.SolvedTime == null)
                                         {

--- a/ServerCore/Pages/Swag/Register.cshtml
+++ b/ServerCore/Pages/Swag/Register.cshtml
@@ -15,7 +15,7 @@
     }
 </style>
 
-<h2>Order Lunch for @Html.DisplayFor(model => model.Event.Name)</h2>
+<h2>Order Lunch for @(Model.Event.Name)</h2>
 
 @if (isEditable)
 {

--- a/ServerCore/Pages/Swag/Report.cshtml
+++ b/ServerCore/Pages/Swag/Report.cshtml
@@ -16,13 +16,13 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.SwagViews[0].TeamName)
+                TeamName
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.SwagViews[0].PlayerName)
+                PlayerName
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.SwagViews[0].PlayerEmail)
+                PlayerEmail
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.SwagViews[0].Lunch)
@@ -37,19 +37,19 @@
         {
         <tr>
             <td>
-                @Html.DisplayFor(model => item.TeamName)
+                @item.TeamName
             </td>
             <td>
-                @Html.DisplayFor(model => item.PlayerName)
+                @item.PlayerName
             </td>
             <td>
-                @Html.DisplayFor(model => item.PlayerEmail)
+                @item.PlayerEmail
             </td>
             <td>
-                @Html.DisplayFor(model => item.Lunch)
+                @item.Lunch
             </td>
             <td>
-                @Html.DisplayFor(model => item.LunchModifications)
+                @item.LunchModifications
             </td>
         </tr>
         }

--- a/ServerCore/Pages/Swag/Report.cshtml
+++ b/ServerCore/Pages/Swag/Report.cshtml
@@ -25,10 +25,10 @@
                 PlayerEmail
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.SwagViews[0].Lunch)
+                Lunch Selection
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.SwagViews[0].LunchModifications)
+                Dietary Modifications (e.g. no cheese)
             </th>
         </tr>
     </thead>

--- a/ServerCore/Pages/Teams/AddMember.cshtml
+++ b/ServerCore/Pages/Teams/AddMember.cshtml
@@ -21,13 +21,13 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Users[0].Item1.ID)
+                ID
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Users[0].Item1.Name)
+                Name
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Users[0].Item1.Email)
+                Email
             </th>
             <th></th>
         </tr>
@@ -37,13 +37,13 @@
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Item1.ID)
+                    @item.Item1.ID
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Item1.Name)
+                    @item.Item1.Name
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Item1.Email)
+                    @item.Item1.Email
                 </td>
                 <td>
                     <a asp-page-handler="AddMember" asp-route-teamId="@Model.Team.ID" asp-route-userId="@item.Item1.ID" asp-route-applicationId="@item.Item2">Add</a>

--- a/ServerCore/Pages/Teams/AddMember.cshtml
+++ b/ServerCore/Pages/Teams/AddMember.cshtml
@@ -9,7 +9,7 @@
     Layout = "_teamLayout.cshtml";
 }
 
-<h2>@Html.DisplayFor(model => model.Team.Name): Add member</h2>
+<h2>@(Model.Team.Name): Add member</h2>
 
 <div>
     <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Cancel</a>

--- a/ServerCore/Pages/Teams/AllTeams.cshtml
+++ b/ServerCore/Pages/Teams/AllTeams.cshtml
@@ -39,10 +39,10 @@ Registered Teams: <b>@Model.Teams.Count/@Model.Event.MaxNumberOfTeams</b>, Regis
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Name)
+                    @(item.Name)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => @Model.PlayerCountByTeamID[item.ID])
+                    @(Model.PlayerCountByTeamID[item.ID])
                 </td>
                 @if (Model.EventRole == ModelBases.EventRole.admin ||
                      Model.EventRole == ModelBases.EventRole.author)

--- a/ServerCore/Pages/Teams/Create.cshtml
+++ b/ServerCore/Pages/Teams/Create.cshtml
@@ -44,7 +44,7 @@ else
             {
                 <div class="form-group">
                     <label asp-for="Team.CustomRoom" class="control-label">Team room (selected by organizers)</label>
-                    <p>@Html.DisplayFor(model => model.Team.CustomRoom)</p>
+                    <p>@(Model.Team.CustomRoom)</p>
                 </div>
             }
             else

--- a/ServerCore/Pages/Teams/Delete.cshtml
+++ b/ServerCore/Pages/Teams/Delete.cshtml
@@ -23,7 +23,7 @@
             Team name
         </dt>
         <dd>
-            @Model.Team.Name)
+            @Model.Team.Name
         </dd>
         <!-- TODO: Conditionally show/hide based on event property (not needed for PuzzleHunt)
     <dt>

--- a/ServerCore/Pages/Teams/Delete.cshtml
+++ b/ServerCore/Pages/Teams/Delete.cshtml
@@ -9,7 +9,7 @@
     Layout = "_teamLayout.cshtml";
 }
 
-<h2>@Html.DisplayFor(model => model.Team.Name): Delete</h2>
+<h2>@(Model.Team.Name): Delete</h2>
 <div>
     <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Cancel</a>
 </div>
@@ -23,14 +23,14 @@
             Team name
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Team.Name)
+            @Model.Team.Name)
         </dd>
         <!-- TODO: Conditionally show/hide based on event property (not needed for PuzzleHunt)
     <dt>
-        @Html.DisplayNameFor(model => model.Team.RoomID)
+        RoomID
     </dt>
     <dd>
-        @Html.DisplayFor(model => model.Team.RoomID)
+        @Model.Team.RoomID
     </dd>
     -->
         <dt>
@@ -43,7 +43,7 @@
             }
             else
             {
-                @Html.DisplayFor(model => model.Team.CustomRoom)
+                @Model.Team.CustomRoom
             }
         </dd>
         <dt>
@@ -56,7 +56,7 @@
             }
             else
             {
-                @Html.DisplayFor(model => model.Team.PrimaryPhoneNumber)
+                @Model.Team.PrimaryPhoneNumber
             }
         </dd>
         <dt>
@@ -69,7 +69,7 @@
             }
             else
             {
-                @Html.DisplayFor(model => model.Team.SecondaryPhoneNumber)
+                @Model.Team.SecondaryPhoneNumber
             }
         </dd>
         <dt>
@@ -82,7 +82,7 @@
             }
             else
             {
-                @Html.DisplayFor(model => model.Team.PrimaryContactEmail)
+                @Model.Team.PrimaryContactEmail
             }
         </dd>
         <dt>

--- a/ServerCore/Pages/Teams/Details.cshtml
+++ b/ServerCore/Pages/Teams/Details.cshtml
@@ -231,7 +231,7 @@
                             <td>
                                 @if (Model.LoggedInUser.IsGlobalAdmin)
                                 {
-                                    <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@item.Member.Name)</a>
+                                    <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@item.Member.Name</a>
                                 }
                                 else
                                 {

--- a/ServerCore/Pages/Teams/Details.cshtml
+++ b/ServerCore/Pages/Teams/Details.cshtml
@@ -57,7 +57,7 @@
     }
 </style>
 
-<h2>@Model.Team.Name Team</h2>
+<h2>@(Model.Team.Name) Team</h2>
 
 @if (Model.Team.IsDisqualified)
 {

--- a/ServerCore/Pages/Teams/Details.cshtml
+++ b/ServerCore/Pages/Teams/Details.cshtml
@@ -57,7 +57,7 @@
     }
 </style>
 
-<h2>@Html.DisplayFor(model => model.Team.Name) Team</h2>
+<h2>@Model.Team.Name Team</h2>
 
 @if (Model.Team.IsDisqualified)
 {
@@ -104,14 +104,14 @@
                     Team name
                 </dt>
                 <dd>
-                    @Html.DisplayFor(model => model.Team.Name)
+                    @Model.Team.Name
                 </dd>
                 <!-- TODO: Conditionally show/hide based on event property (not needed for PuzzleHunt)
     <dt>
-        @Html.DisplayNameFor(model => model.Team.RoomID)
+        RoomID
     </dt>
     <dd>
-        @Html.DisplayFor(model => model.Team.RoomID)
+        @Model.Team.RoomID
     </dd>
     -->
                 
@@ -132,7 +132,7 @@
                     }
                     else
                     {
-                    @Html.DisplayFor(model => model.Team.CustomRoom)
+                    @Model.Team.CustomRoom
                     }
                 </dd>
                 
@@ -146,7 +146,7 @@
                     }
                     else
                     {
-                    @Html.DisplayFor(model => model.Team.PrimaryPhoneNumber)
+                    @Model.Team.PrimaryPhoneNumber
                     }
                 </dd>
                 <dt>
@@ -159,7 +159,7 @@
                     }
                     else
                     {
-                    @Html.DisplayFor(model => model.Team.SecondaryPhoneNumber)
+                    @Model.Team.SecondaryPhoneNumber
                     }
                 </dd>
                 <dt>
@@ -172,7 +172,7 @@
                     }
                     else
                     {
-                    @Html.DisplayFor(model => model.Team.PrimaryContactEmail)
+                    @Model.Team.PrimaryContactEmail
                     }
                 </dd>
                 <dt>
@@ -198,7 +198,7 @@
                     }
                     else
                     {
-                    @Html.DisplayFor(model => model.Team.Bio)
+                    @Model.Team.Bio
                     }
                 </dd>
             </dl>
@@ -213,13 +213,13 @@
                 <thead>
                     <tr>
                         <th>
-                            @Html.DisplayNameFor(model => model.Members[0].Member.Name)
+                            Name
                         </th>
                         <th>
-                            @Html.DisplayNameFor(model => model.Members[0].Member.Email)
+                            Email
                         </th>
                         <th>
-                            @Html.DisplayNameFor(model => model.Members[0].Member.EmployeeAlias)
+                            EmployeeAlias
                         </th>
                         <th></th>
                     </tr>
@@ -231,15 +231,15 @@
                             <td>
                                 @if (Model.LoggedInUser.IsGlobalAdmin)
                                 {
-                                    <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@Html.DisplayFor(modelItem => item.Member.Name)</a>
+                                    <a asp-area="Identity" asp-page="/Account/Edit" asp-route-userId="@item.Member.ID" asp-route-returnUrl="@Request.GetEncodedUrl()">@item.Member.Name)</a>
                                 }
                                 else
                                 {
-                                    @Html.DisplayFor(modelItem => item.Member.Name)
+                                    @item.Member.Name
                                 }
                             </td>
                             <td>
-                                @Html.DisplayFor(modelItem => item.Member.Email)
+                                @item.Member.Email
                             </td>
                             <td>
                                 @if (item.Member.EmployeeAlias == null)
@@ -248,7 +248,7 @@
                                 }
                                 else
                                 {
-                                    @Html.DisplayFor(modelItem => item.Member.EmployeeAlias);
+                                    @item.Member.EmployeeAlias
                                 }
                             </td>
                             @if (Model.EventRole == ModelBases.EventRole.admin || Model.Event.IsTeamMembershipChangeActive)
@@ -320,13 +320,13 @@
                     <thead>
                         <tr>
                             <th>
-                                @Html.DisplayNameFor(model => model.Users[0].Item1.Name)
+                                Name
                             </th>
                             <th>
-                                @Html.DisplayNameFor(model => model.Users[0].Item1.Email)
+                                Email
                             </th>
                             <th>
-                                @Html.DisplayNameFor(model => model.Users[0].Item1.EmployeeAlias)
+                                EmployeeAlias
                             </th>
                             <th>
                                 Approve application
@@ -341,10 +341,10 @@
                         {
                             <tr>
                                 <td>
-                                    @Html.DisplayFor(modelItem => item.Item1.Name)
+                                    @item.Item1.Name
                                 </td>
                                 <td>
-                                    @Html.DisplayFor(modelItem => item.Item1.Email)
+                                    @item.Item1.Email
                                 </td>
                                 <td>
                                     @if (item.Item1.EmployeeAlias == null)
@@ -353,7 +353,7 @@
                                     }
                                     else
                                     {
-                                        @Html.DisplayFor(modelItem => item.Item1.EmployeeAlias);
+                                        @item.Item1.EmployeeAlias
                                     }
                                 </td>
                                 <td>

--- a/ServerCore/Pages/Teams/Disqualify.cshtml
+++ b/ServerCore/Pages/Teams/Disqualify.cshtml
@@ -5,7 +5,7 @@
     Layout = "_teamLayout.cshtml";
 }
 
-<h2>@Html.DisplayFor(model => model.Team.Name): Disqualify</h2>
+<h2>@(Model.Team.Name): Disqualify</h2>
 <div>
     <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Cancel</a>
 </div>
@@ -27,7 +27,7 @@ else
             Team name
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Team.Name)
+            @(Model.Team.Name)
         </dd>
     </dl>
     

--- a/ServerCore/Pages/Teams/Edit.cshtml
+++ b/ServerCore/Pages/Teams/Edit.cshtml
@@ -10,7 +10,7 @@
     bool canChangeTeamName = Model.CanChangeTeamName();
 }
 
-<h2>@Html.DisplayFor(model => model.Team.Name): Edit</h2>
+<h2>@(Model.Team.Name): Edit</h2>
 <div>
     <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Cancel</a>
 </div>
@@ -44,7 +44,7 @@
             {
                 <div class="form-group">
                     <label asp-for="Team.CustomRoom" class="control-label">Team room (selected by organizers)</label>
-                    <p>@Html.DisplayFor(model => model.Team.CustomRoom)</p>
+                    <p>@(Model.Team.CustomRoom)</p>
                 </div>
             }
             else

--- a/ServerCore/Pages/Teams/Hints.cshtml
+++ b/ServerCore/Pages/Teams/Hints.cshtml
@@ -80,7 +80,7 @@ You have <b>
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Hints[0].Hint.Description)
+                Description
             </th>
             <th>
                 <text>Hint</text>
@@ -94,12 +94,12 @@ You have <b>
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => hint.Hint.Description)
+                    @hint.Hint.Description
                 </td>
                 <td>
                     @if (hint.IsUnlocked)
                     {
-                        @Html.DisplayFor(modelItem => hint.Hint.Content)
+                        @hint.Hint.Content
                     }
                     else
                     {

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -75,31 +75,31 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Name)
+                Name
             </th>
             <th>
                 Size
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().RoomID)
+                RoomID
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().CustomRoom)
+                CustomRoom
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().PrimaryContactEmail)
+                PrimaryContactEmail
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().PrimaryPhoneNumber)
+                PrimaryPhoneNumber
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().SecondaryPhoneNumber)
+                SecondaryPhoneNumber
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().IsDisqualified)
+                IsDisqualified
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Teams.FirstOrDefault().Bio)
+                Bio
             </th>
             <th>
                 Shortcuts
@@ -111,25 +111,25 @@
         {
             <tr>
                 <td>
-                    <a asp-page="./Status" asp-route-teamId="@item.ID">@Html.DisplayFor(modelItem => item.Name)</a>
+                    <a asp-page="./Status" asp-route-teamId="@item.ID">@item.Name)</a>
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => @Model.PlayerCountByTeamID[item.ID])
+                    @Model.PlayerCountByTeamID[item.ID]
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.RoomID)
+                    @item.RoomID
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.CustomRoom)
+                    @item.CustomRoom
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.PrimaryContactEmail)
+                    @item.PrimaryContactEmail
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.PrimaryPhoneNumber)
+                    @item.PrimaryPhoneNumber
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.SecondaryPhoneNumber)
+                    @item.SecondaryPhoneNumber
                 </td>
                 <td>
                     @if(item.IsDisqualified)
@@ -138,7 +138,7 @@
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Bio)
+                    @item.Bio
                 </td>
                 <td>
                     @if (Model.EventRole == ModelBases.EventRole.admin)

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -111,7 +111,7 @@
         {
             <tr>
                 <td>
-                    <a asp-page="./Status" asp-route-teamId="@item.ID">@item.Name)</a>
+                    <a asp-page="./Status" asp-route-teamId="@item.ID">@item.Name</a>
                 </td>
                 <td>
                     @Model.PlayerCountByTeamID[item.ID]

--- a/ServerCore/Pages/Teams/List.cshtml
+++ b/ServerCore/Pages/Teams/List.cshtml
@@ -91,13 +91,13 @@
 
                 <tr>
                     <td>
-                        @Html.DisplayFor(modelItem => item.Name)
+                        @(item.Name)
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => item.Bio)
+                        @(item.Bio)
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => @Model.PlayerCountByTeamID[item.ID])
+                        @(Model.PlayerCountByTeamID[item.ID])
                     </td>
                     @if (canRegister)
                     {

--- a/ServerCore/Pages/Teams/MergeInto.cshtml
+++ b/ServerCore/Pages/Teams/MergeInto.cshtml
@@ -9,7 +9,7 @@
     Layout = "_teamLayout.cshtml";
 }
 
-<h2>@Html.DisplayFor(model => model.Team.Name): Merge Into Another Team</h2>
+<h2>@(Model.Team.Name): Merge Into Another Team</h2>
 <div>
     <a asp-page="./Details" asp-route-teamId="@Model.Team.ID">Cancel</a>
 </div>
@@ -24,7 +24,7 @@
                 Team name
             </dt>
             <dd>
-                @Html.DisplayFor(model => model.Team.Name)
+                @(Model.Team.Name)
             </dd>
             <dt>
                 Primary contact e-mail
@@ -36,7 +36,7 @@
                 }
                 else
                 {
-                    @Html.DisplayFor(model => model.Team.PrimaryContactEmail)
+                    @(Model.Team.PrimaryContactEmail)
                 }
             </dd>
             <dt>

--- a/ServerCore/Pages/Teams/Status.cshtml
+++ b/ServerCore/Pages/Teams/Status.cshtml
@@ -9,34 +9,34 @@
     Layout = "_teamLayout.cshtml";
 }
 
-<h2>@Html.DisplayFor(model => model.Team.Name): Status</h2>
+<h2>@(Model.Team.Name): Status</h2>
 
 <table class="table">
     <thead>
         <tr>
             <th>
                 <a asp-page="./Status" asp-route-teamId="@Model.Team.ID" asp-route-sort="@(Model.SortForColumnLink(StatusModel.SortOrder.PuzzleAscending, StatusModel.SortOrder.PuzzleDescending))">
-                    @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Puzzle) @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Puzzle.Name)
+                    Puzzle Name
                 </a>
             </th>
             <th>
                 <a asp-page="./Status" asp-route-teamId="@Model.Team.ID" asp-route-sort="@(Model.SortForColumnLink(StatusModel.SortOrder.UnlockAscending, StatusModel.SortOrder.UnlockDescending))">
-                    @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].UnlockedTime)
+                    UnlockedTime
                 </a>
             </th>
             <th>
                 <a asp-page="./Status" asp-route-teamId="@Model.Team.ID" asp-route-sort="@(Model.SortForColumnLink(StatusModel.SortOrder.SolveAscending, StatusModel.SortOrder.SolveDescending))">
-                    @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].SolvedTime)
+                    SolvedTime
                 </a>
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Printed)
+                Printed
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].Notes)
+                Notes
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PuzzleStatePerTeam[0].IsEmailOnlyMode)
+                IsEmailOnlyMode
             </th>
         </tr>
     </thead>
@@ -45,7 +45,7 @@
         {
             <tr>
                 <td>
-                    <a asp-page="../Puzzles/Status" asp-route-puzzleid="@item.Puzzle.ID">@Html.DisplayFor(modelItem => item.Puzzle.Name)</a>
+                    <a asp-page="../Puzzles/Status" asp-route-puzzleid="@item.Puzzle.ID">@item.Puzzle.Name</a>
                 </td>
                 <td>
                     @if (item.UnlockedTime == null)
@@ -70,10 +70,10 @@
                     }
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Printed)
+                    @item.Printed
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Notes)
+                    @item.Notes
                 </td>
                 <td>
                     @if (item.IsEmailOnlyMode == true)


### PR DESCRIPTION
Remove usage of Html.DisplayNameFor and Html.DisplayFor except for items with [Display(...)] or [DisplayFormat(...)]

Addresses issue
#769 

Also fixed delete page
Before fix
![image](https://user-images.githubusercontent.com/4121745/225552411-835d0070-27ff-4c9a-95f0-2250b3aa2861.png)

After fix
![image](https://user-images.githubusercontent.com/4121745/225552157-9fa64582-eae3-45d0-b5ab-31cf04607e5f.png)
