### PR TITLE
Make sure non-puzzles are not shown in answers page

### DIFF
--- a/ServerCore/Pages/Teams/Answers.cshtml.cs
+++ b/ServerCore/Pages/Teams/Answers.cshtml.cs
@@ -36,10 +36,10 @@ namespace ServerCore.Pages.Teams
             TeamID = teamId;
 
             IQueryable<PuzzleStatePerTeam> puzzleStates = _context.PuzzleStatePerTeam
-                .Where((state) => state.TeamID == teamId && state.SolvedTime != null);
+                .Where((state) => state.TeamID == teamId && state.SolvedTime != null && state.Puzzle.IsPuzzle);
 
             IQueryable<Submission> correctSubmissions = _context.Submissions
-                .Where((s) => s.Puzzle.IsPuzzle && s.TeamID == teamId && s.Response.IsSolution);
+                .Where((s) => s.TeamID == teamId && s.Response.IsSolution);
 
             IQueryable<SubmissionView> finalSubmissions = 
                 from state in puzzleStates

--- a/ServerCore/Pages/Teams/Answers.cshtml.cs
+++ b/ServerCore/Pages/Teams/Answers.cshtml.cs
@@ -39,7 +39,7 @@ namespace ServerCore.Pages.Teams
                 .Where((state) => state.TeamID == teamId && state.SolvedTime != null);
 
             IQueryable<Submission> correctSubmissions = _context.Submissions
-                .Where((s) => s.TeamID == teamId && s.Response.IsSolution);
+                .Where((s) => s.Puzzle.IsPuzzle && s.TeamID == teamId && s.Response.IsSolution);
 
             IQueryable<SubmissionView> finalSubmissions = 
                 from state in puzzleStates


### PR DESCRIPTION
Fixes #754 

We shouldn't be showing invisible puzzles on the puzzle page 
Before change
![image](https://user-images.githubusercontent.com/4121745/225562886-0dc2e3e5-8146-4afc-a3a4-10c663c75d5d.png)

After change
![image](https://user-images.githubusercontent.com/4121745/225563912-edc92e81-ed8e-4662-9aa0-3e87955c4430.png)
