### PR TITLE
Remove puzzles for you while beta testing

### DIFF
--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -213,7 +213,7 @@
                                 Puzzles
                                 <span class="caret"></span>
                             </a>
-                            <li><a asp-page="/Teams/Play" asp-route-teamId="@teamId">Team Puzzles</a></li>
+                            <li><a asp-page="/Teams/Play" asp-route-teamId="@teamId">Puzzles</a></li>
                         </li>
                     }
                     @if (Event.HasSwag)

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -204,7 +204,6 @@
                     </li>
                     @if(!isOnTeam)
                     {
-                        <li><a asp-page="/Puzzles/SinglePlayerPuzzles">Puzzles</a></li>
                         <li><a style="color:yellow" asp-page="/Teams/List"> Join or Create a Team!</a></li>
                     }
                     else
@@ -214,11 +213,7 @@
                                 Puzzles
                                 <span class="caret"></span>
                             </a>
-                            <ul class="dropdown-menu">
-                                <li><a asp-page="/Teams/Play" asp-route-teamId="@teamId">Team Puzzles</a></li>
-                                <li class="divider"></li>
-                                <li><a asp-page="/Puzzles/SinglePlayerPuzzles">Puzzles for you</a></li>
-                            </ul>
+                            <li><a asp-page="/Teams/Play" asp-route-teamId="@teamId">Team Puzzles</a></li>
                         </li>
                     }
                     @if (Event.HasSwag)
@@ -315,7 +310,6 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a asp-page="/EventSpecific/Index">Event</a></li>
-                    <li><a asp-page="/Puzzles/SinglePlayerPuzzles">Puzzles</a></li>
                     @if(isOnTeam && Event.IsTeamMembershipChangeActive && !Event.EventHasStarted) // Exclude previous events from this registration prompt
                     {
                         <li><a style="color:yellow" asp-page="/Player/Create">Complete Your Registration</a></li>


### PR DESCRIPTION
Right now, we are testing pregame puzzles in the beta and the "puzzles for you" dropdown is very confusing.
For now, removing ability for players to get to those puzzles.