### PR TITLE
Usability tweaks for puzzle embedding

### DIFF
--- a/ServerCore/Helpers/SubmissionEvaluator.cs
+++ b/ServerCore/Helpers/SubmissionEvaluator.cs
@@ -112,7 +112,7 @@ namespace ServerCore.Helpers
             }
 
             // The user or team isn't known
-            if (loggedInUser == null || team == null)
+            if (loggedInUser == null || (!puzzle.IsForSinglePlayer && team == null))
             {
                 return new SubmissionResponse() { ResponseCode = SubmissionResponseCode.Unauthorized };
             }

--- a/ServerCore/Helpers/SubmissionEvaluator.cs
+++ b/ServerCore/Helpers/SubmissionEvaluator.cs
@@ -421,7 +421,7 @@ namespace ServerCore.Helpers
         {
             uint wrongSubmissions = 0;
 
-            foreach (Submission s in submissions)
+            foreach (SubmissionBase s in submissions)
             {
                 if (s.Response == null)
                 {

--- a/ServerCore/Pages/Resources/ToolsPartial.cshtml
+++ b/ServerCore/Pages/Resources/ToolsPartial.cshtml
@@ -2,70 +2,40 @@
 <div class="container">
     <h1>Puzzle Solving Tools</h1>
 
-    <p>
-        If you're wondering how the top teams are able to solve so many puzzles so
-        quickly, part of the answer is that they're probably not relying solely on
-        their brainpower. Puzzles in the Puzzlehunt often involve anagramming,
-        deleting, or otherwise manipulating letters and words to discover new words.
-        This is a task well-suited to computers. Since we can't effectively ban the
-        use of such tools, the least we can do is share the locations of some of them
-        to help level the playing field.
-    </p>
+    <p>If you're wondering how the top teams are able to solve so many puzzles so quickly, part of the answer is that they're probably not relying solely on their brainpower. Puzzles in the Puzzlehunt often involve anagramming, deleting, or otherwise manipulating letters and words to discover new words. This is a task well-suited to computers. Since we can't effectively ban the use of such tools, the least we can do is share the locations of some of them to help level the playing field.</p>
+
+    <h3>Built-in tools</h3>
+    <p>If you're using the browser to look something up, don't forget that there are multiple search engines to try, and all have the possibility of giving different results.  Don't like what you find on Google or Bing?  Try <a href="https://www.seekr.com/" target="_blank">Seekr</a>, <a href="https://www.mojeek.com/" target="_blank">Mojeek</a>, or <a href="https://www.qwant.com/" target="_blank">Qwant</a>.  You also don't have to search with just words; you can use reverse image search to upload an image and look for ones just like it.  Even the browser itself has tools to help you.  For example, Microsoft Edge has built-in screenshotting tools that allow you to draw directly on the screenshot, or web selection tools to only select the relevant parts of a page. Just right-click and look for Web Capture!</p>
 
     <h3><a href="http://web.archive.org/web/20171224203122/http://www.crosswordman.com/teadown.html">The Electronic Alveary (TEA)</a></h3>
-    <p>
-        TEA (The Electronic Alveary) allows you to search word lists for words
-        that match a pattern. TEA's pattern language supports simple template and
-        anagram searches, but also has the flexibility to perform many more
-        complicated queries.  Check the Quick Reference page on the help menu to see
-        the kinds of things TEA can do for you. Typing ;STIN for example will product
-        all anagrams of the letters STIN (ISN'T, NITS, TINS, SNIT).
-    </p>
+    <p>TEA (The Electronic Alveary) allows you to search word lists for words that match a pattern. TEA's pattern language supports simple template and anagram searches, but also has the flexibility to perform many more complicated queries.  Check the Quick Reference page on the help menu to see the kinds of things TEA can do for you. Typing ;STIN for example will product all anagrams of the letters STIN (ISN'T, NITS, TINS, SNIT).</p>
+
+    <h3><a href="https://nutrimatic.org/">Nutrimatic</a></h3>
+    <p>Nutrimatic is another powerful anagram solver that's backed by Wikipedia's database, so modern words are likely to be found.</p>
 
     <h3><a href="https://www.quinapalus.com/qat.html">Qat</a></h3>
-    <p>
-        Qat is a more modern analog of TEA.
-    </p>
+    <p>Qat is a more modern analog of TEA.</p>
 
     <h3><a href="https://web.archive.org/web/20110723054953/http://www.valuecube.com/lexpert/LXP321.exe">LeXpert</a></h3>
-    <p>
-        LeXpert is a software program designed to assist word game enthusiasts in
-        expanding their knowledge of words. It offers more than 3500 word lists and
-        different ways of viewing these lists. Customized lists can be created based on
-        patterns, cryptograms, anagrams, number of vowels, etc. It offers similar
-        functionality to TEA.
-    </p>
+    <p>LeXpert is a software program designed to assist word game enthusiasts in expanding their knowledge of words. It offers more than 3500 word lists and different ways of viewing these lists. Customized lists can be created based on patterns, cryptograms, anagrams, number of vowels, etc. It offers similar functionality to TEA.</p>
 
     <h3><a href="http://www.ics.uci.edu/~eppstein/cryptogram/">Cryptogram Helper</a></h3>
-    <p>
-        Cryptogram solver which not only provides a helpful interface for
-        replacing letters in a cryptogram, but can also solve the cryptogram for you.
-        You don't really think we'd give you any cryptograms that can be solved this
-        way, do you?
-    </p>
+    <p>Cryptogram solver which not only provides a helpful interface for replacing letters in a cryptogram, but can also solve the cryptogram for you. You don't really think we'd give you any cryptograms that can be solved this way, do you?</p>
 
     <h3><a href="http://www.oneacross.com">One Across</a></h3>
     <p>Database of crossword clues.</p>
 
     <h3><a href="http://en.wikipedia.org/wiki/Cryptic_crosswords#Clues">Cryptic Crossword Solving Hints</a></h3>
-    <p>
-        Detailed hints for solving cryptic crossword, including explanations and
-        samples of all the major clue types.
-    </p>
+    <p>Detailed hints for solving cryptic crossword, including explanations and samples of all the major clue types.</p>
 
-    <h3>
-        <a href="http://wiki.puzzlers.org/dokuwiki/doku.php?id=solving:start">
-            National Puzzlers League Base Finding Tools for Flats
-        </a>
-    </h3>
+    <h3><a href="http://wiki.puzzlers.org/dokuwiki/doku.php?id=solving:start">National Puzzlers League Base Finding Tools for Flats</a></h3>
     <p>Search tools for all kinds of word forms, including many you never knew existed.</p>
 
-    <h3>
-        <a href="tools.qhex.org">
-            tools.qhex.org
-        </a>
-    </h3>
+    <h3><a href="tools.qhex.org">tools.qhex.org</a></h3>
     <p>A set of puzzle solving tools by Dany Qumsiyeh designed for puzzle hunts. Great for wordplay.</p>
+
+    <h3><a href="https://www.shazam.com/">Shazam</a></h3>
+    <p>Shazam is a search engine for music.  It will listen to a song that's currently playing using your microphone and tell you what it is.  In addition to its Android and iOS apps, it also has a browser extension for Chrome and Edge.</p>
 
     <h3><a href="http://www.imdb.com">Internet Movie Database</a></h3>
     <p>Did we really need to tell you about this one?</p>

--- a/ServerCore/Pages/Resources/pd2023/FAQPartial.cshtml
+++ b/ServerCore/Pages/Resources/pd2023/FAQPartial.cshtml
@@ -77,6 +77,13 @@ else
         </p>
 
         <h3>
+            What is Data Confirmation?
+        </h3>
+        <p>
+            Data Confirmation, or DC, is a feature that certain puzzles have.  When you see the DC logo next to the puzzle's title, that means the answer system will tell you if a particular piece of data is part of the puzzle or not.  For example, if a puzzle has crossword clues, you could type in the answer to a particular clue and system will tell you if you're correct about that clue. 
+        </p>
+
+        <h3>
             How do we solve puzzles that don't have instructions?
         </h3>
         <p>
@@ -146,7 +153,7 @@ else
             Absolutely. We endeavor to make our puzzles in general accessible to all audiences, although some specific puzzles may use mechanics that are less accessible to people of certain abilities than others.
         </p>
         <p>
-            If you think you will require alternate versions of puzzles or any other accommodation, please reach out to Puzzleday staff <a href="https://aka.ms/pdaccform22" target="_blank">by filling out this form</a> as soon as you can before the event so we can prepare the materials. By default, the puzzles we provide digitally are compatible with Windows' built-in accessibility tools like <strong>Narrator</strong>. For more customized accommodations, we will engage in a dialog with you to determine what will be most effective.
+            If you think you will require alternate versions of puzzles or any other accommodation, please reach out to Puzzleday staff <a href="https://aka.ms/pdaccform23" target="_blank">by filling out this form</a> as soon as you can before the event so we can prepare the materials. By default, the puzzles we provide digitally are compatible with Windows' built-in accessibility tools like <strong>Narrator</strong>. For more customized accommodations, we will engage in a dialog with you to determine what will be most effective.
         </p>
 
         <h3>

--- a/ServerCore/Pages/Resources/pd2023/HomePartial.cshtml
+++ b/ServerCore/Pages/Resources/pd2023/HomePartial.cshtml
@@ -34,8 +34,9 @@ else
             <div class="pd2023-container-card card-3">
                 <h3>FULL SCHEDULE (all times PDT)</h3>
 
-                <h4>July 3-7 (optional)</h4>
-                <p>A variety of pregame puzzles for fun and learning how to use our website. Log into the site, join a team, and then click "Puzzles" at the top of the page.</p>
+                <h4>June 29 - July 7 (optional)</h4>
+                <p>A variety of pregame puzzles for fun and learning how to use our website. You don't even need to be on a team to see them! If you are already on a team, click "Puzzles" at the top of the page, and then click "Pregame Puzzles".</p>
+                <p>The first 2 puzzles will release on June 29<sup>th</sup>, with 2 more following on June 30<sup>th</sup>, July 5<sup>th</sup>, and July 6<sup>th</sup>. One final puzzle will release on July 7<sup>th</sup>.</p>
 
                 <h4>July 8 - DAY OF EVENT</h4>
                 <ul>

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -61,6 +61,36 @@
         mailtoUrl.Append("&body=");
         mailtoUrl.Append(Uri.EscapeDataString("The more details you add here, the more helpful the responses you'll get will be! 😇" + Environment.NewLine + Environment.NewLine));
     }
+
+    string puzzleFilePath = "";
+    int embedType = 0; // Nothing
+    if (Model.Puzzle.CustomURL != null)
+    {
+        puzzleFilePath = @PuzzleHelper.GetFormattedUrl(Model.Puzzle, Model.Event.ID);
+    }
+    else if (Model.Puzzle.PuzzleFile != null)
+    {
+        puzzleFilePath = @Model.Puzzle.PuzzleFile.Url.AbsoluteUri;
+    }
+    if (puzzleFilePath.Length > 0)
+    {
+        if (puzzleFilePath.EndsWith(".pdf"))
+        {
+            embedType = 1;
+        }
+        else if ((puzzleFilePath.EndsWith(".htm")) || (puzzleFilePath.EndsWith(".html")))
+        {
+            embedType = 3;
+        }
+        else if ((puzzleFilePath.EndsWith(".jpg")) || (puzzleFilePath.EndsWith(".jpeg")) || (puzzleFilePath.EndsWith(".png")) || (puzzleFilePath.EndsWith(".bmp")) || (puzzleFilePath.EndsWith(".gif")))
+        {
+            embedType = 4;
+        }
+        else // Office files, etc.
+        {
+            embedType = 2;
+        }
+    }
 }
 
 <style>
@@ -69,7 +99,7 @@
         align-self: flex-end;
     }
     .flexwrapper img {
-        margin-top: 15px;
+        margin-top: 20px;
     }
     .inlinewrapper {
         display: inline;
@@ -118,10 +148,7 @@
     .panelcontents {
         width: inherit;
         display: none;
-        position: fixed;
-        top: 23px;
-        left: 0px;
-        z-index: 1060;
+        margin-left: -6px;
         border: 1px solid;
         border-color: rgb(51, 51, 51);
         background-color: rgba(255,255,255,1);
@@ -129,8 +156,7 @@
     .panelitem {
         padding: 3px;
         background-color: rgba(255,255,255,1);
-        z-index: 1090;
-        overflow: overlay;
+        overflow: auto;
     }
     iframe {
         border: 0px solid black;
@@ -142,6 +168,9 @@
     #pdf-frame {
         width: 100%;
         height: 100vh;
+    }
+    #img-frame {
+        width: 100%;
     }
 </style>
 
@@ -395,10 +424,10 @@ else
 {
     <div class="twocolumn">
         <div class="flexwrapper">
-            <div><h2>@RawHtmlHelper.Display(Model.Puzzle.Name, Model.Event.ID, Html)</h2></div>
+            <div><h2><b>@RawHtmlHelper.Display(Model.Puzzle.Name, Model.Event.ID, Html)</b></h2></div>&nbsp;&nbsp;
             @if (Model.Puzzle.HasDataConfirmation)
             {
-                <img src="~/images/DataConfirmationIcon.png" width="20" height="20" style="margin-bottom:3px" title="Reminder: This puzzle supports data confirmation" />
+                <img src="~/images/DataConfirmationIcon.png" width="30" height="30" style="margin-bottom:3px" title="Reminder: This puzzle supports data confirmation" />
             }
         </div>
         <div class="inlinewrapper">
@@ -437,13 +466,13 @@ else
                 <div><b>Have feedback?</b> <a asp-Page="/Puzzles/SubmitFeedback" asp-route-puzzleid="@Model.Puzzle.ID" target="_blank">Click this link</a> to open the feedback form.</div>
             }
 
-            @if (Model.Puzzle.CustomURL != null)
+            @if (embedType > 2) // HTML files or images
             {
-                <div><b>Want to print?</b> <a href="@PuzzleHelper.GetFormattedUrl(Model.Puzzle, Model.Event.ID)" target="_blank">Click this link</a> for a printable version.</div>
+                <div><b>Want to print?</b> <a href="@puzzleFilePath" target="_blank">Click this link</a> for a printable version.</div>
             }
-            else if (Model.Puzzle.PuzzleFile != null)
+            else if (embedType == 1) // PDFs
             {
-                <div><b>Want to print?</b> <a href="@Model.Puzzle.PuzzleFile.Url.AbsoluteUri" target="_blank">Click this link</a> for a printable version.</div>
+                <div><b>Want to print?</b> <a href="@puzzleFilePath" download>Click this link</a> to download the file.</div>
             }
         </div>
     </div>
@@ -522,7 +551,6 @@ else
             }
         }
     </div>
-    <br />
     <div class="centerwrapper">
         <div class="inlineblockwrapper">
             <div id="submissionHistory" style="display: @((Model.SubmissionViews.Count == 0) ? "none" : "block")" class="hideablepanel">
@@ -574,19 +602,23 @@ else
     </div>
     <br />
 
-    @if (Model.Puzzle.CustomURL != null)
+    @switch (embedType)
     {
-        <iframe id="puzzle-frame" title="@Model.Puzzle.Name" sandbox="allow-same-origin allow-scripts" src="@PuzzleHelper.GetFormattedUrl(Model.Puzzle, Model.Event.ID)"></iframe>
-    }
-    else if (Model.Puzzle.PuzzleFile != null)
-    {
-        // TODO: https://github.com/PuzzleServer/mainpuzzleserver/pull/817
-        // Explicitly check for PDF file type before embedding using this PDF frame
-        // Also check for other file types and embed them appropriately (single html files, images, office docs, etc.)
-        <object id="pdf-frame" title="@Model.Puzzle.Name" data="@Model.Puzzle.PuzzleFile.Url.AbsoluteUri" type="application/pdf">
-            <embed src="@Model.Puzzle.PuzzleFile.Url.AbsoluteUri" type="application/pdf" />
-        </object>
-        <div>Trouble viewing the PDF? <a download href="@Model.Puzzle.PuzzleFile.Url.AbsoluteUri">Click here</a> to download it!</div>
+        case 1: // PDF
+            <object id="pdf-frame" title="@Model.Puzzle.Name" data="@puzzleFilePath" type="application/pdf">
+                <embed src="@puzzleFilePath" type="application/pdf" />
+            </object>
+            break;
+        case 2: // Files that can't be embedded
+            <div><b>This puzzle can't be displayed here.</b> <a href="@puzzleFilePath" download>Click this link</a> to download the file.</div>
+            break;
+        case 3: // HTML
+            puzzleFilePath += "?embed=true";
+            <iframe id="puzzle-frame" title="@Model.Puzzle.Name" sandbox="allow-same-origin allow-scripts allow-popups" src="@puzzleFilePath"></iframe>
+            break;
+        case 4: // Images
+            <img id="img-frame" src="@puzzleFilePath" alt="An image containing a puzzle" />
+            break;
     }
 
     @section Scripts {
@@ -653,7 +685,7 @@ else
                         method: "POST", mode: "cors", headers: { "Content-Type": "application/json" }, body: JSON.stringify(submission), credentials: "include"});
                     const responseData = await response.json();
                     
-                    // When the response data is back, add it to the page and list of responses
+                    // When the response data is back, add it to the page
                     // Also clear the previous response from the page
                     // Response Code enum is in Helpers/SubmissionEvaluator
                     const messageArea = document.querySelector("#initialMessage");
@@ -665,37 +697,39 @@ else
                             updateVal += ((Date.now() > Date.parse(dateString).valueOf()) ? `<div class="alert alert-warning" role="alert"><span>You solved this after the event ended and it did not count toward your ranking.</span></div>` : ``);
                             break;
                         case 1: // Incorrect
-                            updateVal = `<div class="panelitem">` + cleanedText + ": " + `@IndexModel.IncorrectResponseText</div>`;
+                            updateVal = `<div class="alert alert-danger" role="alert">` + cleanedText + ": " + `@IndexModel.IncorrectResponseText</div>`;
                             break;
                         case 2: // Freeform
-                            updateVal = `<div class="panelitem">` + cleanedText + ": " + responseData.freeformResponse + `</div>`;
+                            updateVal = `<div class="alert alert-warning" role="alert">` + cleanedText + ": " + responseData.freeformResponse + `</div>`;
                             break;
                         case 3: // Partial
-                            updateVal = `<div class="panelitem">` + cleanedText + ": " + responseData.completeResponse + `</div>`;
+                            updateVal = `<div class="alert alert-warning" role="alert">` + cleanedText + ": " + responseData.completeResponse + `</div>`;
                             break;
                         case 4: // Unauthorized
-                            updateVal = `<div class="panelitem">You don't appear to have access to this puzzle, so your answer has not been recorded.</div>`;
+                            updateVal = `<div class="alert alert-danger" role="alert">You don't appear to have access to this puzzle, so your answer has not been recorded.</div>`;
                             break;
                         case 5: // Puzzle not found
-                            updateVal = `<div class="panelitem">This puzzle can't be found in the system, so your answer has not been recorded.</div>`;
+                            updateVal = `<div class="alert alert-danger" role="alert">This puzzle can't be found in the system, so your answer has not been recorded.</div>`;
                             break;
                         case 6: // Puzzle Locked
                             updateVal = `<div class="alert alert-danger" role="alert"><h4>Answer Submission Locked</h4><span>This puzzle is currently locked! Please <a href="@mailtoUrl">use this link to email us if you think this is a mistake</a>.</span></div>`;
                             break;
                         case 7: // Empty
-                            updateVal = `<div class="panelitem">No valid characters were found in this submission. Please try something else.</div>`;
+                            updateVal = `<div class="alert alert-danger" role="alert">No valid characters were found in this submission. Please try something else.</div>`;
                             break;
                         case 8: // Team locked out
                             updateVal = `<div class="alert alert-danger" role="alert"><h4>Answer Submission Locked</h4><span>You're locked out. Please wait a while before attempting another submission.</span></div>`;
                             break;
                         case 9: // Already solved
-                            updateVal = `<div class="panelitem">This puzzle has already been solved.</div>`;
+                            updateVal = `<div class="alert alert-warning" role="alert">This puzzle has already been solved.</div>`;
                             break;
                         case 10: // Duplicate submission
-                            updateVal = `<div class="panelitem">You've already submitted ` + cleanedText + `.</div>`;
+                            updateVal = `<div class="alert alert-warning" role="alert">You've already submitted ` + cleanedText + `.</div>`;
                             break;
                     }
                     messageArea.innerHTML = updateVal;
+
+                    // Also add the submission to the list of submissions
                     if (responseData.responseCode < 4) { // Correct, Incorrect, Freeform, Partial
                         const wrapper = document.createElement("div");
                         wrapper.classList.add("gridwrapper");
@@ -725,6 +759,15 @@ else
                 }
                 submit.addEventListener("click", submitClickHandler);
 
+                // Make hitting enter in the answer box trigger a submission
+                const submitBox = document.querySelector("#submitBox");
+                submitBox.addEventListener("keydown", (e) => {
+                    if (e.key === "Enter") {
+                        e.preventDefault();
+                        document.querySelector("#submitButton").click();
+                    }
+                });
+
                 // Resize iframe so the frame has no scrollbars
                 // By the time the window has loaded, the iframe contents should have as well, thus no iframe load listener
                 // Note that when the puzzle receives the message, it should remove any extraneous wrapping before reporting its size
@@ -736,13 +779,13 @@ else
 
             // When the iframe response comes, use it to set the iframe's size
             // Removing the iframe's id removes the hard-coded css size
-            // The extra 20px added to the size undoes the widths of the scrollbars themselves
+            // The extra 25px added to the size undoes the widths of the scrollbars themselves
             window.addEventListener("message", (e) => {
                 if ((e.data.width > 0) && (e.data.height > 0)) {
                     const iframe = document.querySelector("iframe");
                     iframe.id = ""; 
-                    iframe.width = e.data.width + 20;
-                    iframe.height = e.data.height + 20;
+                    iframe.width = e.data.width + 25;
+                    iframe.height = e.data.height + 25;
                 }
             });
         </script>

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -346,11 +346,14 @@ namespace ServerCore.Pages.Submissions
             IQueryable<PuzzleUser> currentAuthorsQ = _context.PuzzleAuthors.Where(m => m.Puzzle == Puzzle).Select(m => m.Author);
             List<PuzzleUser> CurrentAuthors = await currentAuthorsQ.OrderBy(p => p.Name).ToListAsync();
             for (int i = 0; i < CurrentAuthors.Count; i++) {
-                if (i > 0)
+                if (CurrentAuthors[i].Name.Trim().Length > 0)
                 {
-                    PuzzleAuthor += ", ";
+                    if ((PuzzleAuthor != null) && (PuzzleAuthor.Length > 0))
+                    {
+                        PuzzleAuthor += ", ";
+                    }
+                    PuzzleAuthor += CurrentAuthors[i].Name.Trim();
                 }
-                PuzzleAuthor += CurrentAuthors[i].Name;
             }
 
             Submissions = new List<SubmissionBase>(SubmissionViews.Count);

--- a/ServerCore/wwwroot/js/pd2023/resize.js
+++ b/ServerCore/wwwroot/js/pd2023/resize.js
@@ -1,16 +1,23 @@
 window.addEventListener("message", (e) => {
     if ((e.origin.includes("puzzlehunt.azurewebsites.net")) || (e.origin.includes("localhost"))) {
+        e.source.postMessage({ width: document.body.scrollWidth, height: document.body.scrollHeight }, e.origin);
+    }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("embed") && (params.get("embed").length > 0) && (params.get("embed") === "true")) {
         const contents = document.querySelector(".content-div");
-        contents.style.padding = "0px";
-        contents.style.margin = "0px";
-        contents.style.borderWidth = "0px";
+        if ((contents !== null) && (contents !== undefined)) {
+            contents.style.padding = "0px";
+            contents.style.margin = "0px";
+            contents.style.borderWidth = "0px";
+            contents.parentElement.style.padding = "0px";
+            contents.parentElement.style.margin = "0px";
+        }
         const header = document.querySelector(".header-div");
         if ((header !== null) && (header !== undefined)) {
             header.parentElement.removeChild(header);
         }
-        contents.parentElement.style.padding = "0px";
-        contents.parentElement.style.margin = "0px";
-        const windowSize = { width: document.body.scrollWidth, height: document.body.scrollHeight };
-        e.source.postMessage(windowSize, e.origin);
     }
 });


### PR DESCRIPTION
Resolves #818 and #819. Does not fix the issue where the page's nav header expands to two lines when the contents gets too wide since that width is defined in library that's pulled down from the web via bootstrap and I didn't feel like figuring out how to override that locally.  

Note that some of the fixes mentioned in those issues are also to get puzzleday 2023 page updated for pregame.  