### PR TITLE
Update hidden properties for PuzzleUser editing pages

### DIFF
--- a/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml
+++ b/ServerCore/Areas/Identity/Pages/Account/Edit.cshtml
@@ -20,6 +20,8 @@
             <input type="hidden" asp-for="PuzzleUser.ID" />
             <input type="hidden" asp-for="PuzzleUser.IdentityUserId" />
             <input type="hidden" asp-for="PuzzleUser.IsGlobalAdmin" />
+            <input type="hidden" asp-for="PuzzleUser.TShirtSize" />
+            <input type="hidden" asp-for="PuzzleUser.MayBeAdminOrAuthor" />
             <div class="form-group">
                 <label asp-for="PuzzleUser.Email"></label>
                 <input asp-for="PuzzleUser.Email" class="form-control" />

--- a/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -48,6 +48,8 @@
             </div>
             <input type="hidden" asp-for="Input.IdentityUserId" />
             <input type="hidden" asp-for="Input.IsGlobalAdmin" />
+            <input type="hidden" asp-for="Input.TShirtSize" />
+            <input type="hidden" asp-for="Input.MayBeAdminOrAuthor" />
 
             <button type="submit" class="btn btn-default">Save</button>
         </form>

--- a/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -71,11 +71,12 @@ namespace ServerCore.Areas.Identity.Pages.Account.Manage
 
             var thisPuzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(_context, User, _userManager);
 
-            // enforce access rights, do not let these change!
+            // enforce hidden values, do not let these change!
             Input.ID = thisPuzzleUser.ID;
             Input.IsGlobalAdmin = thisPuzzleUser.IsGlobalAdmin;
             Input.IdentityUserId = thisPuzzleUser.IdentityUserId;
             Input.MayBeAdminOrAuthor = thisPuzzleUser.MayBeAdminOrAuthor;
+            Input.TShirtSize= thisPuzzleUser.TShirtSize;
 
             _context.Entry(thisPuzzleUser).State = EntityState.Detached;
             _context.Attach(Input).State = EntityState.Modified;

--- a/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/ServerCore/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -75,6 +75,7 @@ namespace ServerCore.Areas.Identity.Pages.Account.Manage
             Input.ID = thisPuzzleUser.ID;
             Input.IsGlobalAdmin = thisPuzzleUser.IsGlobalAdmin;
             Input.IdentityUserId = thisPuzzleUser.IdentityUserId;
+            Input.MayBeAdminOrAuthor = thisPuzzleUser.MayBeAdminOrAuthor;
 
             _context.Entry(thisPuzzleUser).State = EntityState.Detached;
             _context.Attach(Input).State = EntityState.Modified;


### PR DESCRIPTION
PuzzleUser editing pages weren't updated when the AdminOrAuthor bool was added so it was getting overwritten whenever the PuzzleUser was updated.