### PR TITLE
Re-enable metas

### DIFF
--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -86,9 +86,13 @@
         {
             embedType = 4;
         }
-        else // Office files, etc.
+        else if (puzzleFilePath.EndsWith(".doc") || puzzleFilePath.EndsWith(".docx") || puzzleFilePath.EndsWith(".xls") || puzzleFilePath.EndsWith(".xlsx") || puzzleFilePath.EndsWith(".ppt") || puzzleFilePath.EndsWith(".pptx") || puzzleFilePath.EndsWith(".pub")) // Office files, etc.
         {
             embedType = 2;
+        }
+        else
+        {
+            embedType = 3; // probably a web endpoint of some kind, e.g. a piece-driven meta or a remote site
         }
     }
 }


### PR DESCRIPTION
Since the CustonURL for metas doesn't include the "htm" extension, the embedType was coming up as 2.