### PR TITLE
Move Puzzle Safari 23 into past events on index page

### DIFF
--- a/ServerCore/Pages/Index.cshtml
+++ b/ServerCore/Pages/Index.cshtml
@@ -6,19 +6,18 @@
 
 <h3>Upcoming events</h3>
 
-<h4>Puzzle Safari 2023</h4>
-<img src="~/images/ps23/NopePS23_300.png" height="300" width="300" title="Puzzle Safari 23 logo" alt="Puzzle Safari 23" />
-<p>A one-day event for employees and friends that combines solving, running, and searching. Puzzle solvers at all levels are welcome!</p>
-<a href="http://badideas.solutions">Go to the Puzzle Safari event</a>
-
-<hr />
-
 <h4>Microsoft Non-Intern Puzzleday 2023</h4>
 <img src="~/images/pd2023/nipd2023logo.png" height="256" width="256" title="Puzzleday 2023 logo" alt="Puzzleday 2023" />
 <p>A one-day rebroadcast for employees and friends that happens every summer. Puzzle solvers of all levels of experience are welcome!</p>
 <a href="https://puzzlehunt.azurewebsites.net/nipd2023/play">Go to the Non-Intern Puzzleday event</a>
 
 <h3>Past events</h3>
+
+<h4>Puzzle Safari 2023</h4>
+<p>A one-day event for employees and friends that combines solving, running, and searching. Puzzle solvers at all levels are welcome!</p>
+<a href="http://badideas.solutions">Go to the Puzzle Safari event</a>
+
+<hr />
 
 <h4>Microsoft Intern Puzzleday 2023</h4>
 <p>A one-day event for interns and friends that happens every summer. Puzzle solvers of all levels of experience are welcome!</p>


### PR DESCRIPTION
PS23 is no longer an upcoming event.