### PR TITLE
Remove single player puzzles from tab when title not there

### DIFF
--- a/Data/DataModel/Event.cs
+++ b/Data/DataModel/Event.cs
@@ -285,6 +285,6 @@ namespace ServerCore.DataModel
         /// True if the single player puzzles should be shown.
         /// </summary>
         [NotMapped]
-        public bool ShouldShowSinglePlayerPuzzles => string.IsNullOrEmpty(SinglePlayerPuzzleTitle);
+        public bool ShouldShowSinglePlayerPuzzles => !string.IsNullOrEmpty(SinglePlayerPuzzleTitle);
     }
 }

--- a/ServerCore/Pages/Events/Details.cshtml
+++ b/ServerCore/Pages/Events/Details.cshtml
@@ -35,6 +35,12 @@
             @Model.Event.HomePartial
         </dd>
         <dt>
+            SinglePlayerPuzzleTitle
+        </dt>
+        <dd>
+            @Model.Event.SinglePlayerPuzzleTitle
+        </dd>
+        <dt>
             ContactEmail
         </dt>
         <dd>

--- a/ServerCore/Pages/Events/Edit.cshtml
+++ b/ServerCore/Pages/Events/Edit.cshtml
@@ -36,6 +36,11 @@
                 <span asp-validation-for="EditableEvent.HomePartial" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="EditableEvent.SinglePlayerPuzzleTitle" class="control-label"></label>
+                <input asp-for="EditableEvent.SinglePlayerPuzzleTitle" class="form-control" />
+                <span asp-validation-for="EditableEvent.SinglePlayerPuzzleTitle" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="EditableEvent.ContactEmail" class="control-label"></label>
                 <input asp-for="EditableEvent.ContactEmail" class="form-control" />
                 <span asp-validation-for="EditableEvent.ContactEmail" class="text-danger"></span>

--- a/ServerCore/Pages/Puzzles/SinglePlayerPuzzles.cshtml
+++ b/ServerCore/Pages/Puzzles/SinglePlayerPuzzles.cshtml
@@ -25,7 +25,7 @@
         }
 </style>
 
-<h2>Pregame puzzles</h2>
+<h2>@Model.Event.SinglePlayerPuzzleTitle</h2>
 @if (DateTime.UtcNow > @Model.Event.AnswerSubmissionEnd)
 {
     <div class="alert alert-warning" role="alert">

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -204,7 +204,10 @@
                     </li>
                     @if (!isOnTeam)
                     {
-                        <li><a asp-page="/Puzzles/SinglePlayerPuzzles">Pregame puzzles</a></li>
+                        @if (Event.ShouldShowSinglePlayerPuzzles)
+                        {
+                            <li><a asp-page="/Puzzles/SinglePlayerPuzzles">@Event.SinglePlayerPuzzleTitle</a></li>
+                        }
                         @if (Event.IsTeamMembershipChangeActive)
                         {
                             <li><a style="color:yellow" asp-page="/Teams/List"> Join or Create a Team!</a></li>
@@ -212,17 +215,24 @@
                     }
                     else
                     {
-                        <li class="dropdown">
-                            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-                                Puzzles
-                                <span class="caret"></span>
-                            </a>
-                            <ul class="dropdown-menu">
-                                <li><a asp-page="/Teams/Play" asp-route-teamId="@teamId">Team puzzles</a></li>
-                                <li class="divider"></li>
-                                <li><a asp-page="/Puzzles/SinglePlayerPuzzles">Pregame puzzles</a></li>
-                            </ul>
-                        </li>
+                            @if (Event.ShouldShowSinglePlayerPuzzles)
+                            {
+                                <li class="dropdown">
+                                    <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                                        Puzzles
+                                        <span class="caret"></span>
+                                    </a>
+                                    <ul class="dropdown-menu">
+                                        <li><a asp-page="/Teams/Play" asp-route-teamId="@teamId">Team puzzles</a></li>
+                                        <li class="divider"></li>
+                                        <li><a asp-page="/Puzzles/SinglePlayerPuzzles">@Event.SinglePlayerPuzzleTitle</a></li>
+                                    </ul>
+                                </li>
+                            }
+                            else
+                            {
+                                <li><a asp-page="/Teams/Play" asp-route-teamId="@teamId">Puzzles</a></li>
+                            }
                     }
                     @if (Event.HasSwag)
                     {
@@ -318,7 +328,10 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a asp-page="/EventSpecific/Index">Event</a></li>
-                    <li><a asp-page="/Puzzles/SinglePlayerPuzzles">Pregame puzzles</a></li>
+                    @if (Event.ShouldShowSinglePlayerPuzzles)
+                    {
+                        <li><a asp-page="/Puzzles/SinglePlayerPuzzles">@Event.SinglePlayerPuzzleTitle</a></li>
+                    }
                     @if (Event.IsTeamMembershipChangeActive)
                     {
                         if (isOnTeam)


### PR DESCRIPTION
Part of #829 
Updates navigation bar to not show pregame puzzles if they were not set in the event details.
Will also use the title proposed in the event details

Here is what it looks like when I set event details 
<img width="523" alt="image" src="https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/29706a6f-8116-40d4-b745-86026e3d1f12">

<img width="824" alt="image" src="https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/d3883749-ebe4-47bd-85c9-04a60e2d4066">
