### PR TITLE
Allow unlock single player puzzles for any registered player

### DIFF
--- a/ServerCore/Pages/Puzzles/SinglePlayerPuzzleStatus.cshtml
+++ b/ServerCore/Pages/Puzzles/SinglePlayerPuzzleStatus.cshtml
@@ -56,16 +56,7 @@ else
         <tr>
             <td></td>
             <td>
-                <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-playerId="@Model.LoggedInUser.ID" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark unlock this puzzle for yourself?')">Unlock for me</a>
-            </td>
-            <td></td>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td></td>
-            <td>
-                <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-playerId="@Model.LoggedInUser.ID" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to lock the puzzle for yourself?')"> Lock for me</a>
+                <a asp-page-handler="UnlockSinglePlayerPuzzleForPlayer" asp-route-puzzleId="@Model.Puzzle.ID">Unlock for player</a>
             </td>
             <td></td>
             <td></td>

--- a/ServerCore/Pages/Puzzles/SinglePlayerPuzzleStatus.cshtml
+++ b/ServerCore/Pages/Puzzles/SinglePlayerPuzzleStatus.cshtml
@@ -56,7 +56,25 @@ else
         <tr>
             <td></td>
             <td>
-                <a asp-page-handler="UnlockSinglePlayerPuzzleForPlayer" asp-route-puzzleId="@Model.Puzzle.ID">Unlock for player</a>
+                <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-playerId="@Model.LoggedInUser.ID" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark unlock this puzzle for yourself?')">Unlock for me</a>
+            </td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td>
+                <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-playerId="@Model.LoggedInUser.ID" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to lock the puzzle for yourself?')"> Lock for me</a>
+            </td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td>
+                <a asp-page="./UnlockSinglePlayerPuzzleForPlayer" asp-route-puzzleId="@Model.Puzzle.ID">Unlock for player</a>
             </td>
             <td></td>
             <td></td>

--- a/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml
+++ b/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml
@@ -35,7 +35,7 @@
                     @player.Email
                 </td>
                 <td>
-                    <a asp-page-handler="UnlockPlayer" asp-route-userId=@player.ID>Unlock</a>
+                    <a asp-page-handler="UnlockPlayer" asp-route-puzzleId=@Model.Puzzle.ID asp-route-userId=@player.ID>Unlock</a>
                 </td>
             </tr>
         }

--- a/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml
+++ b/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml
@@ -1,0 +1,43 @@
+﻿@page "/{eventId}/{eventRole}/Puzzles/UnlockSinglePlayerPuzzleForPlayer/{puzzleId}"
+@model ServerCore.Pages.Puzzles.UnlockSinglePlayerPuzzleForPlayerModel
+
+@{
+    ViewData["Title"] = "Unlock single player puzzle for player";
+}
+
+<h2>Unlock @Model.Puzzle.Name for a player</h2>
+
+<div>
+    <a asp-page="/Puzzles/SinglePlayerPuzzleStatus" asp-route-puzzleid=@Model.Puzzle.ID>Cancel</a>
+</div>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                Name
+            </th>
+            <th>
+                Email
+            </th>
+            <th>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var player in Model.Users)
+        {
+            <tr>
+                <td>
+                    @player.Name
+                </td>
+                <td>
+                    @player.Email
+                </td>
+                <td>
+                    <a asp-page-handler="UnlockPlayer" asp-route-userId=@player.ID>Unlock</a>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml.cs
@@ -34,7 +34,7 @@ namespace ServerCore.Pages.Puzzles
             }
 
             HashSet<int> playerIdsAlreadyUnlocked = (await (from puzzleState in _context.SinglePlayerPuzzleStatePerPlayer
-                                                 where !puzzleState.UnlockedTime.HasValue && puzzleState.PuzzleID == puzzleId
+                                                 where puzzleState.UnlockedTime.HasValue && puzzleState.PuzzleID == puzzleId
                                                  select puzzleState.PlayerID).ToListAsync()).ToHashSet();
 
             Users = await (from user in _context.PlayerInEvent
@@ -44,7 +44,7 @@ namespace ServerCore.Pages.Puzzles
             return Page();
         }
 
-        public async Task<IActionResult> OnGetUnlockPlayerAsync(int userId)
+        public async Task<IActionResult> OnGetUnlockPlayerAsync(int userId, int puzzleId)
         {
             PuzzleUser user = await _context.PuzzleUsers.FirstOrDefaultAsync(m => m.ID == userId);
             if (user == null)
@@ -53,7 +53,7 @@ namespace ServerCore.Pages.Puzzles
             }
 
             var userPuzzleState = (await (from puzzleState in _context.SinglePlayerPuzzleStatePerPlayer
-                                         where puzzleState.PlayerID == userId && puzzleState.PuzzleID == Puzzle.ID
+                                         where puzzleState.PlayerID == userId && puzzleState.PuzzleID == puzzleId
                                          select puzzleState)
                                          .ToListAsync()).FirstOrDefault();
 
@@ -69,18 +69,18 @@ namespace ServerCore.Pages.Puzzles
                 _context.SinglePlayerPuzzleStatePerPlayer.Add(
                     new SinglePlayerPuzzleStatePerPlayer
                     { 
-                        Puzzle = Puzzle,
+                        PuzzleID = puzzleId,
                         PlayerID = userId,
                         UnlockedTime = DateTime.UtcNow
                     });
             }
             else
             {
-
+                userPuzzleState.UnlockedTime = DateTime.UtcNow;
             }
 
             await _context.SaveChangesAsync();
-            return RedirectToPage("/Puzzles/SinglePlayerPuzzleStatus", new { puzzleId = Puzzle.ID });
+            return RedirectToPage("/Puzzles/SinglePlayerPuzzleStatus", new { puzzleId = puzzleId });
         }
     }
 }

--- a/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Puzzles
+{
+    [Authorize(Policy = "IsEventAdminOrAuthorOfPuzzle")]
+    public class UnlockSinglePlayerPuzzleForPlayerModel : EventSpecificPageModel
+    {
+        public Puzzle Puzzle { get; set; }
+
+        public IList<PuzzleUser> Users { get; set; }
+
+        public UnlockSinglePlayerPuzzleForPlayerModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
+        {
+        }
+
+        public async Task<IActionResult> OnGetAsync(int puzzleId)
+        {
+            Puzzle = (await (from puzzle in _context.Puzzles
+                                 where puzzle.ID == puzzleId
+                                 select puzzle).ToListAsync()).SingleOrDefault();
+
+            if (Puzzle == null)
+            {
+                return NotFound();
+            }
+
+            HashSet<int> playerIdsAlreadyUnlocked = (await (from puzzleState in _context.SinglePlayerPuzzleStatePerPlayer
+                                                 where !puzzleState.UnlockedTime.HasValue && puzzleState.PuzzleID == puzzleId
+                                                 select puzzleState.PlayerID).ToListAsync()).ToHashSet();
+
+            Users = await (from user in _context.PlayerInEvent
+                           where !playerIdsAlreadyUnlocked.Contains(user.PlayerId)
+                           select user.Player).ToListAsync();
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnGetUnlockPlayerAsync(int userId)
+        {
+            PuzzleUser user = await _context.PuzzleUsers.FirstOrDefaultAsync(m => m.ID == userId);
+            if (user == null)
+            {
+                return NotFound("Could not find user with ID '" + userId + "'. Check to make sure the user hasn't been removed.");
+            }
+
+            var userPuzzleState = (await (from puzzleState in _context.SinglePlayerPuzzleStatePerPlayer
+                                         where puzzleState.PlayerID == userId && puzzleState.PuzzleID == Puzzle.ID
+                                         select puzzleState)
+                                         .ToListAsync()).FirstOrDefault();
+
+            // Check that the user isn't already unlocked
+            if (userPuzzleState != null && userPuzzleState.UnlockedTime.HasValue)
+            {
+                return NotFound("User is already unlocked for this puzzle.");
+            }
+
+            // Set user unlock state
+            if (userPuzzleState == null)
+            {
+                _context.SinglePlayerPuzzleStatePerPlayer.Add(
+                    new SinglePlayerPuzzleStatePerPlayer
+                    { 
+                        Puzzle = Puzzle,
+                        PlayerID = userId,
+                        UnlockedTime = DateTime.UtcNow
+                    });
+            }
+            else
+            {
+
+            }
+
+            await _context.SaveChangesAsync();
+            return RedirectToPage("/Puzzles/SinglePlayerPuzzleStatus", new { puzzleId = Puzzle.ID });
+        }
+    }
+}


### PR DESCRIPTION
#829  Allows the unlock of single player puzzles for any registered player.
Before you could only unlock all or unlock users that already tried to submit an answer

![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/e81c94a5-6b9b-4c98-ad6f-6ebea95c440c)
