### PR TITLE
Allow admins and authors to see fastest solves when not registered

### DIFF
--- a/ServerCore/Pages/Events/FastestSolves.cshtml.cs
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml.cs
@@ -52,7 +52,7 @@ namespace ServerCore.Pages.Events
         private async Task updateTeamPuzzleStats()
         {
             bool isRegisteredUser = await this.IsRegisteredUser();
-            if (!isRegisteredUser)
+            if (EventRole == EventRole.play && !isRegisteredUser)
             {
                 this.TeamSectionNotShowMessage = "Please register for the event to see team standings.";
                 this.TeamPuzzles = new List<TeamPuzzleStats>();


### PR DESCRIPTION
Allow admins and authors to see fastest solves even when they are not registered for the event