### PR TITLE
Remove phone number fields if event is remote

### DIFF
--- a/ServerCore/Pages/Teams/Create.cshtml
+++ b/ServerCore/Pages/Teams/Create.cshtml
@@ -56,16 +56,19 @@ else
                 <input asp-for="Team.PrimaryContactEmail" class="form-control" />
                 <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="Team.PrimaryPhoneNumber" class="control-label">Primary phone number</label>
-                <input asp-for="Team.PrimaryPhoneNumber" class="form-control" />
-                <span asp-validation-for="Team.PrimaryPhoneNumber" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Team.SecondaryPhoneNumber" class="control-label">Secondary phone number (optional)</label>
-                <input asp-for="Team.SecondaryPhoneNumber" class="form-control" />
-                <span asp-validation-for="Team.SecondaryPhoneNumber" class="text-danger"></span>
-            </div>
+            @if (!Model.Event.IsRemote)
+            {
+                <div class="form-group">
+                    <label asp-for="Team.PrimaryPhoneNumber" class="control-label">Primary phone number</label>
+                    <input asp-for="Team.PrimaryPhoneNumber" class="form-control" />
+                    <span asp-validation-for="Team.PrimaryPhoneNumber" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Team.SecondaryPhoneNumber" class="control-label">Secondary phone number (optional)</label>
+                    <input asp-for="Team.SecondaryPhoneNumber" class="form-control" />
+                    <span asp-validation-for="Team.SecondaryPhoneNumber" class="text-danger"></span>
+                </div>
+            }
             <div class="form-group">
                 <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow unsolicited applications</label>
                 <table>

--- a/ServerCore/Pages/Teams/Delete.cshtml
+++ b/ServerCore/Pages/Teams/Delete.cshtml
@@ -25,45 +25,48 @@
         <dd>
             @Model.Team.Name
         </dd>        
-        <dt>
-            Team room
-        </dt>
-        <dd>
-            @if (Model.Team.CustomRoom == null)
-            {
-                <div>(none)</div>
-            }
-            else
-            {
-                @Model.Team.CustomRoom
-            }
-        </dd>
-        <dt>
-            Primary phone number
-        </dt>
-        <dd>
-            @if (Model.Team.PrimaryPhoneNumber == null)
-            {
-                <div>(none)</div>
-            }
-            else
-            {
-                @Model.Team.PrimaryPhoneNumber
-            }
-        </dd>
-        <dt>
-            Secondary phone number
-        </dt>
-        <dd>
-            @if (Model.Team.SecondaryPhoneNumber == null)
-            {
-                <div>(none)</div>
-            }
-            else
-            {
-                @Model.Team.SecondaryPhoneNumber
-            }
-        </dd>
+        @if (!Model.Event.IsRemote)
+        {
+            <dt>
+                Team room
+            </dt>
+            <dd>
+                @if (Model.Team.CustomRoom == null)
+                {
+                    <div>(none)</div>
+                }
+                else
+                {
+                    @Model.Team.CustomRoom
+                }
+            </dd>
+            <dt>
+                Primary phone number
+            </dt>
+            <dd>
+                @if (Model.Team.PrimaryPhoneNumber == null)
+                {
+                    <div>(none)</div>
+                }
+                else
+                {
+                    @Model.Team.PrimaryPhoneNumber
+                }
+            </dd>
+            <dt>
+                Secondary phone number
+            </dt>
+            <dd>
+                @if (Model.Team.SecondaryPhoneNumber == null)
+                {
+                    <div>(none)</div>
+                }
+                else
+                {
+                    @Model.Team.SecondaryPhoneNumber
+                }
+            </dd>
+        }
         <dt>
             Primary contact e-mail
         </dt>

--- a/ServerCore/Pages/Teams/Details.cshtml
+++ b/ServerCore/Pages/Teams/Details.cshtml
@@ -110,53 +110,56 @@
                     @Model.Team.Name
                 </dd>
                 <!-- TODO: Add new room dropdown here and clean up custom room-->
-                <dt>
-                    Team room
-                </dt>
-                <dd>
-                    @if (Model.Team.CustomRoom == null)
-                    {
-                    @if (Model.Event.IsInternEvent)
-                    {
-                    <div>@Model.TeamRoom</div>
-                    }
-                    else
-                    {
-                    <div>(none - please enter this before the start of the event)</div>
-                    }
-                    }
-                    else
-                    {
-                    @Model.Team.CustomRoom
-                    }
-                </dd>
+                @if (!Model.Event.IsRemote)
+                {
+                    <dt>
+                        Team room
+                    </dt>
+                    <dd>
+                        @if (Model.Team.CustomRoom == null)
+                        {
+                            @if (Model.Event.IsInternEvent)
+                            {
+                                <div>@Model.TeamRoom</div>
+                            }
+                            else
+                            {
+                                <div>(none - please enter this before the start of the event)</div>
+                            }
+                        }
+                        else
+                        {
+                            @Model.Team.CustomRoom
+                        }
+                    </dd>
 
-                <dt>
-                    Primary phone number
-                </dt>
-                <dd>
-                    @if (Model.Team.PrimaryPhoneNumber == null)
-                    {
-                    <div>(none - please enter this before the start of the event)</div>
-                    }
-                    else
-                    {
-                    @Model.Team.PrimaryPhoneNumber
-                    }
-                </dd>
-                <dt>
-                    Secondary phone number (optional)
-                </dt>
-                <dd>
-                    @if (Model.Team.SecondaryPhoneNumber == null)
-                    {
-                    <div>(none)</div>
-                    }
-                    else
-                    {
-                    @Model.Team.SecondaryPhoneNumber
-                    }
-                </dd>
+                    <dt>
+                        Primary phone number
+                    </dt>
+                    <dd>
+                        @if (Model.Team.PrimaryPhoneNumber == null)
+                        {
+                            <div>(none - please enter this before the start of the event)</div>
+                        }
+                        else
+                        {
+                            @Model.Team.PrimaryPhoneNumber
+                        }
+                    </dd>
+                    <dt>
+                        Secondary phone number (optional)
+                    </dt>
+                    <dd>
+                        @if (Model.Team.SecondaryPhoneNumber == null)
+                        {
+                            <div>(none)</div>
+                        }
+                        else
+                        {
+                            @Model.Team.SecondaryPhoneNumber
+                        }
+                    </dd>
+                }
                 <dt>
                     Primary contact e-mail (optional)
                 </dt>

--- a/ServerCore/Pages/Teams/Edit.cshtml
+++ b/ServerCore/Pages/Teams/Edit.cshtml
@@ -40,36 +40,42 @@
                 <input asp-for="Team.RoomID" class="form-control" />
                 <span asp-validation-for="Team.RoomID" class="text-danger"></span>
             </div>*@
-            @if (Model.Event.IsInternEvent && Model.EventRole == ModelBases.EventRole.play)
+            @if (!Model.Event.IsRemote)
             {
-                <div class="form-group">
-                    <label asp-for="Team.CustomRoom" class="control-label">Team room (selected by organizers)</label>
-                    <p>@(Model.Team.CustomRoom)</p>
-                </div>
-            }
-            else
-            {
-                <div class="form-group">
-                    <label asp-for="Team.CustomRoom" class="control-label">Team room (please enter 'virtual' if playing remotely)</label>
-                    <input asp-for="Team.CustomRoom" class="form-control" />
-                    <span asp-validation-for="Team.CustomRoom" class="text-danger"></span>
-                </div>
+                @if (Model.Event.IsInternEvent && Model.EventRole == ModelBases.EventRole.play)
+                {
+                    <div class="form-group">
+                        <label asp-for="Team.CustomRoom" class="control-label">Team room (selected by organizers)</label>
+                        <p>@(Model.Team.CustomRoom)</p>
+                    </div>
+                }
+                else
+                {
+                    <div class="form-group">
+                        <label asp-for="Team.CustomRoom" class="control-label">Team room (please enter 'virtual' if playing remotely)</label>
+                        <input asp-for="Team.CustomRoom" class="form-control" />
+                        <span asp-validation-for="Team.CustomRoom" class="text-danger"></span>
+                    </div>
+                }
             }
             <div class="form-group">
                 <label asp-for="Team.PrimaryContactEmail" class="control-label">Primary contact e-mail(s) separated by , or ;</label>
                 <input asp-for="Team.PrimaryContactEmail" class="form-control" />
                 <span asp-validation-for="Team.PrimaryContactEmail" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="Team.PrimaryPhoneNumber" class="control-label">Primary phone number</label>
-                <input asp-for="Team.PrimaryPhoneNumber" class="form-control" />
-                <span asp-validation-for="Team.PrimaryPhoneNumber" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Team.SecondaryPhoneNumber" class="control-label">Secondary phone number (optional)</label>
+            @if (!Model.Event.IsRemote)
+            {
+                <div class="form-group">
+                    <label asp-for="Team.PrimaryPhoneNumber" class="control-label">Primary phone number</label>
+                    <input asp-for="Team.PrimaryPhoneNumber" class="form-control" />
+                    <span asp-validation-for="Team.PrimaryPhoneNumber" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Team.SecondaryPhoneNumber" class="control-label">Secondary phone number (optional)</label>
                 <input asp-for="Team.SecondaryPhoneNumber" class="form-control" />
                 <span asp-validation-for="Team.SecondaryPhoneNumber" class="text-danger"></span>
-            </div>
+                </div>
+            }
             <div class="form-group">
                 <label asp-for="Team.IsLookingForTeammates" class="control-label">Allow unsolicited applications</label>
                 <table>


### PR DESCRIPTION
If the event is remote, the phone numbers could be anywhere in the world and we aren't going to call them. Let's not even bother to collect.

Also hiding the team room from all pages when the event is remote, not just the team creation page.