### PR TITLE
Autostarting Event support

### DIFF
--- a/ServerCore/Helpers/SubmissionEvaluator.cs
+++ b/ServerCore/Helpers/SubmissionEvaluator.cs
@@ -118,7 +118,7 @@ namespace ServerCore.Helpers
             }
 
             // The event hasn't started yet
-            if (DateTime.UtcNow < thisEvent.EventBegin)
+            if (DateTime.UtcNow < thisEvent.EventBegin && team?.IsDisqualified != true)
             {
                 return new SubmissionResponse() { ResponseCode = SubmissionResponseCode.Unauthorized };
             }

--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -9,7 +9,7 @@
     ViewData["AuthorRoute"] = "/Puzzles/Index";
 
     bool unsolvedFilter = Model.StateFilter == PlayModel.PuzzleStateFilter.Unsolved;
-    bool canSubmit = DateTime.UtcNow >= Model.Event.EventBegin;
+    bool canSubmit = DateTime.UtcNow >= Model.Event.EventBegin || Model.Team?.IsDisqualified == true;
 }
 <style>
     .radioButton {

--- a/ServerCore/Pages/Puzzles/Play.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Play.cshtml.cs
@@ -131,6 +131,12 @@ namespace ServerCore.Pages.Puzzles
 
         private async Task<IEnumerable<PuzzleView>> GetVisibleTeamPlayerPuzzleViews(SortOrder? sortOrder, Team team)
         {
+            // If the event has not yet begun, no puzzles yet
+            if (DateTime.UtcNow < Event.EventBegin && !team.IsDisqualified)
+            {
+                return Enumerable.Empty<PuzzleView>();
+            }
+
             // all puzzles for this event that are real puzzles
             var puzzlesInEventQ = _context.Puzzles.Where(puzzle => puzzle.Event.ID == this.Event.ID && puzzle.IsPuzzle && !puzzle.IsForSinglePlayer);
 

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -220,7 +220,7 @@
             </div>
         }
     }
-    else if (DateTime.UtcNow < Model.Event.EventBegin)
+    else if (DateTime.UtcNow < Model.Event.EventBegin && Model.Team?.IsDisqualified != true)
     {
         <div class="col-md-12" style="padding-bottom: 15px;">
             <h3>This event is not yet in session. No submissions will be accepted at this time.</h3>
@@ -493,7 +493,7 @@ else
                 </div>
             }
         }
-        else if (DateTime.UtcNow < Model.Event.EventBegin)
+        else if (DateTime.UtcNow < Model.Event.EventBegin && Model.Team?.IsDisqualified != true)
         {
             <div class="col-md-12" style="padding-bottom: 15px;">
                 <h3>This event is not yet in session. No submissions will be accepted at this time.</h3>

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -66,12 +66,12 @@ namespace ServerCore.Pages.Submissions
             }
 
             SubmissionText = submissionText;
-            if (DateTime.UtcNow < Event.EventBegin)
+            await SetupContext(puzzleId);
+
+            if (DateTime.UtcNow < Event.EventBegin && Team?.IsDisqualified != true)
             {
                 return NotFound("The event hasn't started yet!");
             }
-
-            await SetupContext(puzzleId);
 
             if (!ModelState.IsValid)
             {


### PR DESCRIPTION
Support events that begin at specific start times, e.g. 12/31/23 at 12:31:23PM.

- auto-unlock all puzzles with MinPrerequisiteCount = 0.
- hide all puzzles if the event is not yet started.
- let DQ'ed teams work before the event start time (so DQ'ed teams can beta test). DQ'ed teams are still bound by all unlocking rules, since the only barrier they are empowered to break through is the EventBegin check.

Note that this approach will also allow teams to be created at any point after EventBegin and get instant access to puzzles without someone needing to continually monitor puzzle status and manually unlock.