### PR TITLE
Shared Resource UX

### DIFF
--- a/ServerCore/FileManager.cs
+++ b/ServerCore/FileManager.cs
@@ -24,10 +24,11 @@ namespace ServerCore
         /// <param name="fileName">Name of the file to upload. The caller should ensure it is safe to use in a URL</param>
         /// <param name="eventId">Event the file will be used in</param>
         /// <param name="contents">Contents of the file</param>
+        /// <param name="specificDirectory">A directory name to upload the file to. If null, a randomized directory will be used.</param>
         /// <returns>Url of the file in blob storage</returns>
-        public static async Task<Uri> UploadBlobAsync(string fileName, int eventId, Stream contents)
+        public static async Task<Uri> UploadBlobAsync(string fileName, int eventId, Stream contents, string specificDirectory = null)
         {
-            CloudBlockBlob blob = await CreateNewBlob(fileName, eventId, GetRandomDirectoryName());
+            CloudBlockBlob blob = await CreateNewBlob(fileName, eventId, specificDirectory ?? GetRandomDirectoryName());
 
             await blob.UploadFromStreamAsync(contents);
             return blob.Uri;
@@ -52,6 +53,34 @@ namespace ServerCore
             return blob.Uri;
         }
 
+        /// <summary>
+        /// Enumerates all the files in a directory subtree.
+        /// </summary>
+        /// <param name="eventId">Event to find the directory in</param>
+        /// <param name="directoryName">The name of the directory</param>
+        /// <returns>The names and URIs of all the files in the directory.</returns>
+        public static async Task<List<DirectoryFileResult>> GetDirectoryContents(int eventId, string directoryName)
+        {
+            CloudBlobDirectory directory = await GetPuzzleDirectoryAsync(eventId, directoryName);
+
+            BlobContinuationToken continuationToken = null;
+            List<DirectoryFileResult> results = new List<DirectoryFileResult>();
+            do
+            {
+                bool useFlatBlobListing = true;
+                BlobListingDetails blobListingDetails = BlobListingDetails.None;
+                int maxBlobsPerRequest = 500;
+                var response = await directory.ListBlobsSegmentedAsync(useFlatBlobListing, blobListingDetails, maxBlobsPerRequest, continuationToken, null, null);
+                continuationToken = response.ContinuationToken;
+                foreach (var result in response.Results)
+                {
+                    results.Add(new DirectoryFileResult() {  Name = (result as CloudBlockBlob)?.Name, Uri = result.Uri });
+                }
+            }
+            while (continuationToken != null);
+            return results;
+        }
+
         private static async Task<CloudBlockBlob> CreateNewBlob(string fileName, int eventId, string puzzleDirectoryName)
         {
             CloudBlobDirectory puzzleDirectory = await GetPuzzleDirectoryAsync(eventId, puzzleDirectoryName);
@@ -71,10 +100,11 @@ namespace ServerCore
         /// <param name="files">A dictionary of files. Keys are file names. The caller should ensure they are safe to use in a URL.
         /// The values are streams with the contents of the files</param>
         /// <param name="eventId">Event the files will be used in</param>
+        /// <param name="specificDirectory">A directory name to upload the files to. If null, a randomized directory will be used.</param>
         /// <returns>A dictionary with key of the file names and value of the urls of the files in blob storage</returns>
-        public static async Task<Dictionary<string, Uri>> UploadBlobsAsync(Dictionary<string, Stream> files, int eventId)
+        public static async Task<Dictionary<string, Uri>> UploadBlobsAsync(Dictionary<string, Stream> files, int eventId, string specificDirectory = null)
         {
-            CloudBlobDirectory puzzleDirectory = await GetPuzzleDirectoryAsync(eventId, GetRandomDirectoryName());
+            CloudBlobDirectory puzzleDirectory = await GetPuzzleDirectoryAsync(eventId, specificDirectory ?? GetRandomDirectoryName());
             Dictionary<string, Uri> fileUrls = new Dictionary<string, Uri>(files.Count);
 
             foreach (KeyValuePair<string, Stream> file in files)
@@ -147,6 +177,15 @@ namespace ServerCore
                 return CloudStorageAccount.Parse(ConnectionString);
             }
         }
+    }
+
+    /// <summary>
+    /// One file in the result of a call to GetDirectoryContents.
+    /// </summary>
+    public class DirectoryFileResult
+    {
+        public string Name { get; set; }
+        public Uri Uri { get; set; }
     }
 
     /// <summary>

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -44,7 +44,8 @@
         <a asp-page="/Hints/CreateBulkMulti">Bulk hint create</a> @(" |")
         <a asp-page="/Hints/Responses">View all hint responses</a> @(" |")
     }
-    <a asp-page="/Puzzles/Checklist">View puzzle checklist</a>
+    <a asp-page="/Puzzles/Checklist">View puzzle checklist</a> |
+    <a asp-page="/Puzzles/ResourceManagement">Manage shared resources</a>
 </p>
 <p>
     Support:

--- a/ServerCore/Pages/Puzzles/ResourceManagement.cshtml
+++ b/ServerCore/Pages/Puzzles/ResourceManagement.cshtml
@@ -1,0 +1,63 @@
+﻿@page  "/{eventId}/{eventRole}/Puzzles/ResourceManagement/{handler?}"
+@model ServerCore.Pages.Puzzles.ResourceManagementModel
+
+@{
+    ViewData["Title"] = "Puzzle resource management";
+    ViewData["AdminRoute"] = "../Puzzles/ResourceManagement";
+    ViewData["AuthorRoute"] = "../Puzzles/ResourceManagement";
+    ViewData["PlayRoute"] = "/Puzzles/Play";
+}
+
+<script type="text/javascript">
+    window.addEventListener("load", () => {
+        const button = document.querySelector("#buttonSelectAllResources");
+        const checkboxes = document.querySelectorAll(".resourceFileCheckbox");
+        if (checkboxes.length == 0) {
+            button.disabled = true;
+        }
+        button.addEventListener("click", selectAllResources);
+    });
+
+    function selectAllResources () {
+        const checkboxes = document.querySelectorAll(".resourceFileCheckbox");
+        for (const checkbox of checkboxes) { 
+            checkbox.checked = true;
+        }
+    }
+</script>
+
+<h2>@Model.Event.Name: Resource management</h2>
+
+<div>
+    <hr />
+    <div class="form-group">
+        <form method="post" enctype="multipart/form-data">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <p>
+                <input type="checkbox" asp-for="ExpandZipFiles" />
+                &lt;- Check this box to automatically extract the contents of zip files in materials or solve tokens into the same directory.
+            </p>
+            <p>
+                <button type="submit" asp-page-handler="DeleteSelected">Delete Selected</button>
+
+                <button type="submit" asp-page-handler="DeleteAll" onclick="return confirm('Are you sure you want to delete all shared resources for this event?')">Delete All</button>
+            </p>
+            <button id="buttonSelectAllResources" type="button">Select All</button>
+            @foreach (var resource in Model.Resources)
+            {
+                <p>
+                    <input class="resourceFileCheckbox" type="checkbox" name="SelectedFiles" value="@resource.Uri" />
+                    <span>@resource.Name</span>
+                    <a href="@resource.Uri">[Raw]</a>
+                    <button type="submit" asp-route-url="@resource.Uri" asp-page-handler="Delete">Delete</button>
+                </p>
+            }
+            <input asp-for="NewResourceFiles" class="form-control" style="height:auto" />
+            <span asp-validation-for="NewResourceFiles" class="text-danger"></span>
+
+            <div class="form-group">
+                <input type="submit" value="Upload" class="btn btn-default" />
+            </div>
+        </form>
+    </div>
+</div>

--- a/ServerCore/Pages/Puzzles/ResourceManagement.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/ResourceManagement.cshtml.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Security.Policy;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Puzzles
+{
+    /// <summary>
+    /// Page for managing the files associated with a puzzle
+    /// </summary>
+    [Authorize(Policy = "IsEventAdminOrAuthorOfPuzzle")]
+    public class ResourceManagementModel : EventSpecificPageModel
+    {
+        public ResourceManagementModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
+        {
+        }
+
+        [BindProperty]
+        public List<IFormFile> NewResourceFiles { get; set; }
+
+        [BindProperty]
+        public bool ExpandZipFiles { get; set; }
+
+        [BindProperty]
+        public List<Uri> SelectedFiles { get; set; }
+
+        public List<DirectoryFileResult> Resources { get; private set; }
+
+        const string SharedResourceDirectoryName = "resources";
+
+        /// <summary>
+        /// Handler for listing files
+        /// </summary>
+        public async Task<IActionResult> OnGetAsync(int puzzleId)
+        {
+            this.Resources = await FileManager.GetDirectoryContents(this.Event.ID, SharedResourceDirectoryName);
+            return Page();
+        }
+
+        /// <summary>
+        /// Handler for uploading files
+        /// </summary>
+        public async Task<IActionResult> OnPostAsync(int puzzleId)
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            if (NewResourceFiles != null)
+            {
+                foreach (IFormFile resourceFile in NewResourceFiles)
+                {
+                    await UploadFileAsync(resourceFile);
+                }
+            }
+
+            return RedirectToPage("ResourceManagement");
+        }
+
+        /// <summary>
+        /// Handler for deleting an uploaded file
+        /// </summary>
+        public async Task<IActionResult> OnPostDeleteAsync(Uri url)
+        {
+            await FileManager.DeleteBlobAsync(url);
+
+            return RedirectToPage("ResourceManagement");
+        }
+
+        /// <summary>
+        /// Deletes files selected by checkboxes
+        /// </summary>
+        public async Task<IActionResult> OnPostDeleteSelectedAsync()
+        {
+            foreach (Uri resource in SelectedFiles)
+            {
+                await FileManager.DeleteBlobAsync(resource);
+            }
+
+            return RedirectToPage("ResourceManagement");
+        }
+
+        /// <summary>
+        /// Deletes all files from this puzzle
+        /// </summary>
+        public async Task<IActionResult> OnPostDeleteAllAsync()
+        {
+            foreach (var file in await FileManager.GetDirectoryContents(Event.ID, SharedResourceDirectoryName))
+            {
+                await FileManager.DeleteBlobAsync(file.Uri);
+            }
+
+            return RedirectToPage("ResourceManagement");
+        }
+
+        /// <summary>
+        /// Helper for taking an uploaded form file, uploading it, and tracking it in the database
+        /// </summary>
+        private async Task UploadFileAsync(IFormFile uploadedFile)
+        {
+            if (Path.GetExtension(uploadedFile.FileName).Equals(".zip", StringComparison.OrdinalIgnoreCase) && ExpandZipFiles)
+            {
+                await UploadZipAsync(uploadedFile);
+                return;
+            }
+
+            await FileManager.UploadBlobAsync(uploadedFile.FileName, Event.ID, uploadedFile.OpenReadStream(), SharedResourceDirectoryName);
+        }
+
+        /// <summary>
+        /// Extracts the contents of a zip file and uploads the contents into a single directory
+        /// </summary>
+        private async Task UploadZipAsync(IFormFile uploadedFile)
+        {
+            ZipArchive archive = new ZipArchive(uploadedFile.OpenReadStream(), ZipArchiveMode.Read);
+            Dictionary<string, Stream> contents = new Dictionary<string, Stream>();
+            foreach(ZipArchiveEntry entry in archive.Entries)
+            {
+                if (entry.FullName.EndsWith("/"))
+                {
+                    continue;
+                }
+
+                if (entry.FullName.StartsWith("/") || entry.FullName.StartsWith("\\") || entry.FullName.Contains(".."))
+                {
+                    throw new ArgumentException();
+                }
+
+                string fileName = entry.FullName;
+                contents[fileName] = entry.Open();
+            }
+
+            Dictionary<string, Uri> fileUrls = await FileManager.UploadBlobsAsync(contents, Event.ID, SharedResourceDirectoryName);
+        }
+    }
+}


### PR DESCRIPTION
Allow an event to manage its shared resources in a folder on the Azure storage explicitly named "resources". This means that an event can drop any number of dependencies in that folder (CSS files, event logos, puzzle.js, etc) while keeping the URLs stable and not needing to use Azure Storage Explorer.