### PR TITLE
Fix messages not appearing

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -157,6 +157,7 @@ namespace ServerCore.Pages.Threads
                 ModelState.AddModelError("NewMessage.Text", "Your message should not be longer than 3000 characters.");
             }
 
+            ModelState.Remove("EventId");
             if (!ModelState.IsValid)
             {
                 return await this.OnGetAsync(NewMessage.PuzzleID, NewMessage.TeamID, NewMessage.PlayerID);


### PR DESCRIPTION
This issue only occurs when the URL string is set.

The fix is to remove the offending eventId from the modelState.