### PR TITLE
Create links to help message page

### DIFF
--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -43,7 +43,8 @@
        asp-route-teamPuzzleSort="@Model.TeamPuzzleSort"
        asp-route-stateFilter=@(unsolvedFilter ? PlayModel.PuzzleStateFilter.All : PlayModel.PuzzleStateFilter.Unsolved)>
         Show @(unsolvedFilter ? "All" : "only unsolved") puzzles
-    </a>
+    </a> |
+    <a asp-page="/Threads/PuzzleThreads">View current help messages</a>
 </div>
 
 <h2>Team puzzles</h2>
@@ -66,8 +67,7 @@ else if (!Model.VisibleTeamPuzzleViews.Any())
 else
 {
     <div>
-        <a asp-page="/Teams/Answers" asp-route-teamId="@Model.Team.ID">View all correct team answers</a> |
-        <a asp-page="/Threads/PuzzleThreads">View current help messages</a>
+        <a asp-page="/Teams/Answers" asp-route-teamId="@Model.Team.ID">View all correct team answers</a>
     </div>
     <br />
     <a asp-page="/Events/FastestSolves"

--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -66,7 +66,8 @@ else if (!Model.VisibleTeamPuzzleViews.Any())
 else
 {
     <div>
-        <a asp-page="/Teams/Answers" asp-route-teamId="@Model.Team.ID">View all correct team answers</a>
+        <a asp-page="/Teams/Answers" asp-route-teamId="@Model.Team.ID">View all correct team answers</a> |
+        <a asp-page="/Threads/PuzzleThreads">View current help messages</a>
     </div>
     <br />
     <a asp-page="/Events/FastestSolves"

--- a/ServerCore/Pages/Puzzles/_puzzleManagementLayout.cshtml
+++ b/ServerCore/Pages/Puzzles/_puzzleManagementLayout.cshtml
@@ -14,17 +14,15 @@
     <a asp-page="/Puzzles/Edit" asp-route-puzzleId="@puzzleId">Details</a> |
     <a asp-page="/Puzzles/FileManagement" asp-route-puzzleId="@puzzleId">Files</a> |
     <a asp-page="/Responses/Index" asp-route-puzzleId="@puzzleId">Responses</a> |
-    @if (shouldShowHints)
-    {
-        <a asp-page="/Hints/Index" asp-route-puzzleId="@puzzleId">Hints</a>@(" |")
-    }
     <a asp-page="/Puzzles/Status" asp-route-puzzleId="@puzzleId">Status</a> |
     <a asp-page="/Submissions/AuthorIndex" asp-route-puzzleId="@puzzleId">Submissions</a> |
     <a asp-page="/Submissions/FreeformQueue" asp-route-puzzleId="@puzzleId">Freeform Queue</a> |
     @if (shouldShowHints)
     {
+        <a asp-page="/Hints/Index" asp-route-puzzleId="@puzzleId">Hints</a>@(" |")
         <a asp-page="/Hints/AuthorIndex" asp-route-puzzleId="@puzzleId">Hints Taken</a>@(" |")
     }
+    <a asp-page="/Threads/PuzzleThreads" asp-route-puzzleId="@puzzleId">Threads</a> |
     @if (isAdmin)
     {
         <a asp-page="/Events/Mailer" asp-route-group="NonSolvers" asp-route-puzzleId="@puzzleId">Mail non-solvers</a>@(" |")

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -157,6 +157,7 @@
                                 {
                                     <a asp-page="/Hints/AuthorIndex" asp-route-teamId="@item.ID">Hints Taken</a><br />
                                 }
+                                <a asp-page="/Threads/PuzzleThreads" asp-route-teamId="@item.ID">Threads</a><br />
                                 ------<br />
                                 <a asp-page="./MergeInto" asp-route-teamId="@item.ID">Merge Into...</a><br/>
                                 <a asp-page="./Delete" asp-route-teamId="@item.ID">Delete</a>
@@ -175,6 +176,7 @@
                                     <a asp-page="/Hints/AuthorIndex" asp-route-teamId="@item.ID">Hints Taken</a><br />
 
                                 }
+                                <a asp-page="/Threads/PuzzleThreads" asp-route-teamId="@item.ID">Threads</a><br />
                             </div>
                         </div>
                     }

--- a/ServerCore/Pages/Teams/_teamLayout.cshtml
+++ b/ServerCore/Pages/Teams/_teamLayout.cshtml
@@ -18,6 +18,7 @@
         <a asp-page="/Hints/AuthorIndex" asp-route-teamId="@Model.Team.ID">Hints Taken</a>@(" |")
     }
     <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a> |
+    <a asp-page="/Threads/PuzzleThreads" asp-route-teamId="@Model.Team.ID">Threads</a> |
     <a asp-page="/Teams/MergeInto" asp-route-teamId="@Model.Team.ID">Merge Into...</a>
 </div>
 }
@@ -30,7 +31,8 @@
     {
         <a asp-page="/Hints/AuthorIndex" asp-route-teamId="@Model.Team.ID">Hints Taken</a>@(" |")
     }
-    <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a>
+    <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a> |
+    <a asp-page="/Threads/PuzzleThreads" asp-route-teamId="@Model.Team.ID">Threads</a> |
 </div>
 }
 <!--Players don't have other options so they don't need any links-->

--- a/ServerCore/Pages/Teams/_teamLayout.cshtml
+++ b/ServerCore/Pages/Teams/_teamLayout.cshtml
@@ -32,7 +32,7 @@
         <a asp-page="/Hints/AuthorIndex" asp-route-teamId="@Model.Team.ID">Hints Taken</a>@(" |")
     }
     <a asp-page="/Teams/Status" asp-route-teamId="@Model.Team.ID">Status</a> |
-    <a asp-page="/Threads/PuzzleThreads" asp-route-teamId="@Model.Team.ID">Threads</a> |
+    <a asp-page="/Threads/PuzzleThreads" asp-route-teamId="@Model.Team.ID">Threads</a>
 </div>
 }
 <!--Players don't have other options so they don't need any links-->

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml
@@ -30,19 +30,21 @@
         originalText.classList.remove("hidden");
     }
 </script>
-<h2>Help thread</h2>
 <div>
-    @if (Model.EventRole == ServerCore.ModelBases.EventRole.play)
-    {
-        <a asp-page="/Submissions/Index" asp-route-puzzleId="@Model.Puzzle.ID">Back to puzzle</a>
-    }
-    else
-    {
-        <a asp-page="/Threads/PuzzleThreads">Back to thread list</a>
-    }
+    <span>
+        @if (Model.EventRole == ServerCore.ModelBases.EventRole.play)
+        {
+            <a asp-page="/Submissions/Index" asp-route-puzzleId="@Model.Puzzle.ID">Go to puzzle</a>@(" |")
+        }
+        else
+        {
+            <a asp-page="/Puzzles/Edit" asp-route-puzzleId="@Model.Puzzle.ID">Go to puzzle</a>@(" |")
+        }
+        <a asp-page="/Threads/PuzzleThreads">See all threads</a>
+    </span>
 </div>
 
-<h4>Thread for puzzle @Model.Puzzle.Name</h4>
+<h3>Thread for puzzle @Model.Puzzle.Name</h3>
 <hr />
 @foreach (var message in Model.Messages)
 {

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -92,6 +92,7 @@ namespace ServerCore.Pages.Threads
 
                 subject = $"[{singlePlayerPuzzlePlayer.Name}]{Puzzle.Name}";
                 threadId = MessageHelper.GetSinglePlayerPuzzleThreadId(Puzzle.ID, playerId.Value);
+                teamId = null;
                 PuzzleState = await SinglePlayerPuzzleStateHelper.GetOrAddStateIfNotThere(
                     _context,
                     Event,
@@ -115,6 +116,7 @@ namespace ServerCore.Pages.Threads
 
                 subject = $"[{team.Name}]{Puzzle.Name}";
                 threadId = MessageHelper.GetTeamPuzzleThreadId(Puzzle.ID, teamId.Value);
+                playerId = null;
                 PuzzleState = await PuzzleStateHelper
                     .GetFullReadOnlyQuery(
                         _context,

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -17,16 +17,22 @@
         <a asp-page="/Puzzles/Index">Puzzle list</a>@(" |")
     }
     <a asp-page="/Threads/PuzzleThreads">All threads</a> |
-    <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true">Unclaimed only</a>
+    @if (Model.IsGameControlRole())
+    {
+        <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true">Unclaimed only</a>
+    }
 </div>
 <h3>@Model.Title</h3>
 
 <table class="table">
     <thead>
         <tr>
-            <th>
-                Is handled
-            </th>
+            @if (Model.IsGameControlRole())
+            {
+                <th>
+                    Is handled
+                </th>
+            }
             <th>
                 Thread
             </th>
@@ -36,9 +42,12 @@
             <th>
                 Puzzle
             </th>
-            <th>
-                Team
-            </th>
+            @if (Model.IsGameControlRole())
+            {
+                <th>
+                    Team
+                </th>
+            }
             <th>
                 Last message
             </th>
@@ -51,12 +60,15 @@
         @foreach (var item in Model.LatestMessagesFromEachThread)
         {
             <tr>
-                <td>
-                    @if (Model.IsLatestMessageUnclaimed(item))
-                    {
-                        <p>&#x26A0; Has unanswered question!</p>
-                    }
-                </td>
+                @if (Model.IsGameControlRole())
+                {
+                    <td>
+                        @if (Model.IsLatestMessageUnclaimed(item))
+                        {
+                            <p>&#x26A0; Has unanswered question!</p>
+                        }
+                    </td>
+                }
                 <td>
                     <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID">@item.Subject</a>
                 </td>
@@ -73,16 +85,19 @@
                         <a asp-page="/Submissions/Index" asp-route-puzzleId="@item.Puzzle.ID">@item.Puzzle.Name</a>
                     }
                 </td>
-                <td>
-                    @if (item.TeamID.HasValue)
-                    {
-                        <a asp-page="/Teams/Status" asp-route-teamId="@item.TeamID.Value">@item.Team.Name</a>
-                    }
-                    else
-                    {
-                        <span>N/A</span>
-                    }
-                </td>
+                @if (Model.IsGameControlRole())
+                {
+                            <td>
+                                @if (item.TeamID.HasValue)
+                                {
+                                    <a asp-page="/Teams/Status" asp-route-teamId="@item.TeamID.Value">@item.Team.Name</a>
+                                }
+                                else
+                                {
+                                    <span>N/A</span>
+                                }
+                            </td>
+                }
                 <td>
                     @(item.Text.Length > 93 ? $"{item.Text.Substring(0, 90)}..." : item.Text)
                 </td>

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -7,37 +7,43 @@
     ViewData["PlayRoute"] = "/Threads/PuzzleThreads";
 }
 
-<h2>Help thread</h2>
 <div>
-    @if (Model.EventRole == ServerCore.ModelBases.EventRole.play) {
-        <a asp-page="/Puzzles/Play">Back to puzzle list</a>
+    @if (Model.EventRole == ServerCore.ModelBases.EventRole.play) 
+    {
+        <a asp-page="/Puzzles/Play">Puzzle list</a>@(" |")
     }
     else
     {
-        <a asp-page="/Puzzles/Index">Back to puzzle list</a>
+        <a asp-page="/Puzzles/Index">Puzzle list</a>@(" |")
     }
+    <a asp-page="/Threads/PuzzleThreads">All threads</a> |
+    <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true">Unclaimed only</a>
 </div>
+<h3>@Model.Title</h3>
 
 <table class="table">
     <thead>
         <tr>
             <th>
-                Puzzle
+                Is handled
+            </th>
+            <th>
+                Thread
             </th>
             <th>
                 Timestamp
             </th>
             <th>
-                Subject
+                Puzzle
+            </th>
+            <th>
+                Team
             </th>
             <th>
                 Last message
             </th>
             <th>
                 Last message sender
-            </th>
-            <th>
-                Is handled
             </th>
         </tr>
     </thead>
@@ -46,9 +52,21 @@
         {
             <tr>
                 <td>
+                    @if (Model.IsLatestMessageUnclaimed(item))
+                    {
+                        <p>&#x26A0; Has unanswered question!</p>
+                    }
+                </td>
+                <td>
+                    <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID">@item.Subject</a>
+                </td>
+                <td>
+                    @Html.Raw(Model.LocalTime(@item.CreatedDateTimeInUtc))
+                </td>
+                <td>
                     @if (Model.EventRole == ModelBases.EventRole.admin || Model.EventRole == ModelBases.EventRole.author)
                     {
-                        <a asp-Page="/Puzzles/Edit" asp-route-puzzleid=@item.Puzzle.ID>@item.Puzzle.Name</a>
+                        <a asp-Page="/Puzzles/Edit" asp-route-puzzleId=@item.Puzzle.ID>@item.Puzzle.Name</a>
                     }
                     else
                     {
@@ -56,22 +74,20 @@
                     }
                 </td>
                 <td>
-                    @Html.Raw(Model.LocalTime(@item.CreatedDateTimeInUtc))
-                </td>
-                <td>
-                    <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID">@item.Subject</a>
+                    @if (item.TeamID.HasValue)
+                    {
+                        <a asp-page="/Teams/Status" asp-route-teamId="@item.TeamID.Value">@item.Team.Name</a>
+                    }
+                    else
+                    {
+                        <span>N/A</span>
+                    }
                 </td>
                 <td>
                     @(item.Text.Length > 93 ? $"{item.Text.Substring(0, 90)}..." : item.Text)
                 </td>
                 <td>
                     @item.Sender.Name
-                </td>
-                <td>
-                    @if (!item.ClaimerID.HasValue && !item.IsFromGameControl)
-                    {
-                        <p>&#x26A0; Has unanswered question!</p>
-                    }
                 </td>
             </tr>
         }

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -10,16 +10,16 @@
 <div>
     @if (Model.EventRole == ServerCore.ModelBases.EventRole.play) 
     {
-        <a asp-page="/Puzzles/Play">Puzzle list</a>@(" |")
+        <a asp-page="/Puzzles/Play">Puzzle list</a>
     }
     else
     {
-        <a asp-page="/Puzzles/Index">Puzzle list</a>@(" |")
+        <a asp-page="/Puzzles/Index">Puzzle list</a>
     }
-    <a asp-page="/Threads/PuzzleThreads">All threads</a> |
+    @(" | ")<a asp-page="/Threads/PuzzleThreads">All threads</a>
     @if (Model.IsGameControlRole())
     {
-        <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true">Unclaimed only</a>
+        @(" | ")<a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true">Unclaimed only</a>
     }
 </div>
 <h3>@Model.Title</h3>

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
@@ -9,6 +9,7 @@ using ServerCore.ModelBases;
 using System.Collections.Generic;
 using System;
 using Microsoft.EntityFrameworkCore;
+using System.Numerics;
 
 namespace ServerCore.Pages.Threads
 {
@@ -22,17 +23,28 @@ namespace ServerCore.Pages.Threads
         }
 
         /// <summary>
-        /// The team of the current user. 
-        /// This value will only be filled in the play route and if the player actually has a team.
+        /// The title of the page.
         /// </summary>
-        public Team Team { get; set; }
+        public string Title { get; set; }
 
         /// <summary>
         /// Gets or sets the list of thread views.
         /// </summary>
         public List<Message> LatestMessagesFromEachThread { get; set; }
 
-        public async Task<IActionResult> OnGetAsync()
+        /// <summary>
+        /// Gets the view for list of all applicable puzzle threads.
+        /// 
+        /// Note: the puzzleId, teamId, and playerId are only used for admina and author views and only one will ever be set at one time.
+        /// Players will always see all messages they are allowed to see.
+        /// </summary>
+        /// <param name="puzzleId">The puzzle id to filter to if applicable.</param>
+        /// <param name="teamId">The team id to filter to if applicable.</param>
+        /// <param name="playerId">The player id to filter to if applicable.</param>
+        /// <param name="showUnclaimedOnly">True if we want to filter only to unclaimed messages.</param>
+        /// <returns>The Puzzle threads page view.</returns>
+        /// <exception cref="NotSupportedException">Thrown when we receive an unexpected event role.</exception>
+        public async Task<IActionResult> OnGetAsync(int? puzzleId, int? teamId, int? playerId, bool? showUnclaimedOnly)
         {
             if (LoggedInUser == null)
             {
@@ -41,21 +53,56 @@ namespace ServerCore.Pages.Threads
 
             IQueryable<Message> messages = this._context.Messages.Where(message => message.Puzzle != null
                     && message.Puzzle.EventID == Event.ID);
+            this.Title = "All help threads";
 
             // Based on the event role, filter the messages further.
             if (EventRole == EventRole.play)
             {
-                Team = await GetTeamAsync();
+                Team team = await GetTeamAsync();
                 messages = messages.Where(message => 
-                    (Team != null && message.TeamID.Value == Team.ID) 
+                    (team != null && message.TeamID.Value == team.ID) 
                     || message.SenderID == LoggedInUser.ID);
+            }
+            else if (puzzleId.HasValue)
+            {
+                Puzzle puzzle = this._context.Puzzles.Where(puzzle => puzzle.EventID == this.Event.ID && puzzle.ID == puzzleId.Value).FirstOrDefault();
+                if (puzzle == null)
+                {
+                    return NotFound();
+                }
+
+                messages = messages.Where(message => message.PuzzleID == puzzleId.Value);
+                this.Title = $"Help threads for puzzle {puzzle.Name}";
+            }
+            else if (teamId.HasValue)
+            {
+                Team team = this._context.Teams.Where(team => team.EventID == this.Event.ID && team.ID == teamId.Value).FirstOrDefault();
+                if (team == null)
+                {
+                    return NotFound();
+                }
+
+                messages = messages.Where(message => message.TeamID == teamId.Value);
+                this.Title = $"Help threads for team {team.Name}";
+            }
+            else if (playerId.HasValue)
+            {
+                PuzzleUser player = this._context.PuzzleUsers.Where(user => user.ID == playerId.Value).FirstOrDefault();
+                if (player == null)
+                {
+                    return NotFound();
+                }
+
+                messages = messages.Where(message => message.PlayerID == playerId.Value);
+                this.Title = $"Help threads for player {player.Name}";
             }
             else if (EventRole == EventRole.author)
             {
-                HashSet<int> authorPuzzleIds = UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
+                // TODO 969: For things like puzzlehunt, we don't want authors seeing each other's threads. We need to add an event level flag for this.
+                /*HashSet<int> authorPuzzleIds = UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
                     .Select(puzzle => puzzle.ID)
                     .ToHashSet();
-                messages = messages.Where(message => authorPuzzleIds.Contains(message.Puzzle.ID));
+                messages = messages.Where(message => authorPuzzleIds.Contains(message.Puzzle.ID));*/
             }
             else if (EventRole == EventRole.admin)
             {
@@ -67,12 +114,25 @@ namespace ServerCore.Pages.Threads
                 throw new NotSupportedException($"EventRole [{EventRole}] is not supported in PuzzleThreads");
             }
 
-            LatestMessagesFromEachThread = await messages
+            // Filter down to only latest messages
+            IEnumerable<Message> latestMessages = messages
                 .GroupBy(message => message.ThreadId)
                 .Select(group => group.OrderByDescending(message => message.CreatedDateTimeInUtc).First())
-                .ToListAsync();
+                .AsEnumerable();
 
+            if (showUnclaimedOnly.HasValue && showUnclaimedOnly.Value)
+            {
+                this.Title += " (unclaimed only)";
+                latestMessages = latestMessages.Where(this.IsLatestMessageUnclaimed);
+            }
+
+            LatestMessagesFromEachThread = latestMessages.ToList();
             return Page();
+        }
+
+        public bool IsLatestMessageUnclaimed(Message message)
+        {
+            return !message.IsFromGameControl && !message.ClaimerID.HasValue;
         }
     }
 }


### PR DESCRIPTION
#969 
Partial implementation

This PR does the following:
- Creates link to the puzzle thread page from 
    - Player puzzle index
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/dcec491e-85cf-4f54-8317-a814ea861c01)
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/621bf026-6ce4-492a-bbc8-438e875f2ddf)
    - GC teams status page
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/bf60a838-ed21-4820-96f5-95f69ded6170)
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/5dcbb929-816f-4179-89db-09ef38a5c4c9)
    - GC puzzle page
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/03fb58d0-79e7-414d-9803-97630e3d4bf9)
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/4e3019b0-9810-4dfa-b3cb-a45ab64bdf30)
- Allows filtering to only unclaimed messages

Next PR will add sorting and auto-refresh for game control

