### PR TITLE
Add refresh

### DIFF
--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -180,6 +180,7 @@
                             {
                                 <a asp-page="/Hints/AuthorIndex" asp-route-puzzleid=@item.Puzzle.ID>Hints Taken</a><br />
                             }
+                            <a asp-Page="/Threads/PuzzleThreads" asp-route-puzzleid=@item.Puzzle.ID>Help threads</a><br />
                             <a asp-Page="./Feedback" asp-route-puzzleid=@item.Puzzle.ID>Feedback</a><br />
                             ------<br />
                             <a asp-Page="./Delete" asp-route-puzzleid="@item.Puzzle.ID">Delete</a>

--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -44,7 +44,7 @@
        asp-route-stateFilter=@(unsolvedFilter ? PlayModel.PuzzleStateFilter.All : PlayModel.PuzzleStateFilter.Unsolved)>
         Show @(unsolvedFilter ? "All" : "only unsolved") puzzles
     </a> |
-    <a asp-page="/Threads/PuzzleThreads">View current help messages</a>
+    <a asp-page="/Threads/PuzzleThreads">View help threads</a>
 </div>
 
 <h2>Team puzzles</h2>

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml
@@ -1,5 +1,6 @@
 ﻿@page "/{eventId}/{eventRole}/Threads/PuzzleThread/{puzzleId}"
 @using ServerCore.DataModel
+@using ServerCore.Pages.Threads;
 @model ServerCore.Pages.Threads.PuzzleThreadModel
 
 @{
@@ -74,7 +75,7 @@
                 <form asp-page-handler="EditMessage" method="post">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group">
-                        <textarea asp-for="EditMessage.Text" class="form-control" rows="4" placeholder="@message.Text" autocomplete="off">@message.Text</textarea>
+                        <textarea asp-for="EditMessage.Text" class="form-control" rows="4" placeholder="@message.Text" autocomplete="off" maxlength="@PuzzleThreadModel.MessageCharacterLimit">@message.Text</textarea>
                         <span asp-validation-for="EditMessage.Text" class="text-danger"></span>
                         <input type="hidden" asp-for="EditMessage.ID" value="@message.ID" />
                         <input type="hidden" asp-for="EditMessage.PuzzleID" value="@message.PuzzleID" />
@@ -125,7 +126,7 @@ else
                     {
                         <p>The more details you add here, the more helpful the responses you'll get will be!</p>
                     }
-                    <textarea asp-for="NewMessage.Text" class="form-control" rows="4" placeholder="Type message here" autocomplete="off"></textarea>
+                    <textarea asp-for="NewMessage.Text" class="form-control" rows="4" placeholder="Type message here" autocomplete="off" maxlength="@PuzzleThreadModel.MessageCharacterLimit"></textarea>
                     <span asp-validation-for="NewMessage.Text" class="text-danger"></span>
                     <input type="hidden" asp-for="NewMessage.ThreadId" value="@Model.NewMessage.ThreadId" />
                     <input type="hidden" asp-for="NewMessage.EventID" value="@Model.NewMessage.EventID" />

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml
@@ -54,6 +54,9 @@
         classString += " message-game-control";
     }
 
+    bool isAllowedToEditMessage = Model.IsAllowedToEditMessage(message);
+    bool isAllowedToDeleteMessage = Model.IsAllowedToDeleteMessage(message);
+
     <div class="@classString">
         @{
             string senderName = message.Sender.Name;
@@ -65,29 +68,28 @@
             }
         }
         <p>[@Html.Raw(Model.LocalTime(@message.CreatedDateTimeInUtc))] @senderName</p>
-        <div id="TextAreaEdit_@message.ID" class="hidden">
-            <form asp-page-handler="EditMessage" method="post">
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                <div class="form-group">
-                    <textarea asp-for="EditMessage.Text" class="form-control" rows="4" placeholder="@message.Text" autocomplete="off">@message.Text</textarea>
-                    <span asp-validation-for="EditMessage.Text" class="text-danger"></span>
-                    <input type="hidden" asp-for="EditMessage.ID" value="@message.ID" />
-                    <input type="hidden" asp-for="EditMessage.PuzzleID" value="@message.PuzzleID" />
-                    <input type="hidden" asp-for="EditMessage.TeamID" value="@message.TeamID" />
-                    <input type="hidden" asp-for="EditMessage.PlayerID" value="@message.PlayerID" />
-                </div>
-                <div class="form-group">
-                    <input type="submit" value="Update" class="btn btn-default" /> | <a role="button" style="text-decoration:underline;color:blue" onclick="CancelEdit(@message.ID)">Cancel</a>
-                </div>
-            </form>
-        </div>
+        @if (isAllowedToEditMessage)
+        {
+            <div id="TextAreaEdit_@message.ID" class="hidden">
+                <form asp-page-handler="EditMessage" method="post">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div class="form-group">
+                        <textarea asp-for="EditMessage.Text" class="form-control" rows="4" placeholder="@message.Text" autocomplete="off">@message.Text</textarea>
+                        <span asp-validation-for="EditMessage.Text" class="text-danger"></span>
+                        <input type="hidden" asp-for="EditMessage.ID" value="@message.ID" />
+                        <input type="hidden" asp-for="EditMessage.PuzzleID" value="@message.PuzzleID" />
+                        <input type="hidden" asp-for="EditMessage.TeamID" value="@message.TeamID" />
+                        <input type="hidden" asp-for="EditMessage.PlayerID" value="@message.PlayerID" />
+                    </div>
+                    <div class="form-group">
+                        <input type="submit" value="Update" class="btn btn-default" /> | <a role="button" style="text-decoration:underline;color:blue" onclick="CancelEdit(@message.ID)">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        }
         <div id="MessageText_@message.ID">
             <p style="white-space: pre-wrap;">@message.Text</p>
             <span>
-                @{
-                    bool isAllowedToEditMessage = Model.IsAllowedToEditMessage(message);
-                    bool isAllowedToDeleteMessage = Model.IsAllowedToDeleteMessage(message);
-                }
                 @if (isAllowedToEditMessage)
                 {
                     <a role="button" style="text-decoration:underline;color:blue" onclick="EditText(@message.ID)">Edit</a>
@@ -104,36 +106,44 @@
         </div>
     </div>
 }
-<div class="row">
-    <div class="col-md-4">
-        <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                @if (Model.PuzzleState.IsEmailOnlyMode)
-                {
-                    <p>Use this message to fully explain your thought process so we know you're not randomly spamming attempts!</p>
-                }
-                else
-                {
-                    <p>The more details you add here, the more helpful the responses you'll get will be!</p>
-                }
-                <textarea asp-for="NewMessage.Text" class="form-control" rows="4" placeholder="Type message here" autocomplete="off"></textarea>
-                <span asp-validation-for="NewMessage.Text" class="text-danger"></span>
-                <input type="hidden" asp-for="NewMessage.ThreadId" value="@Model.NewMessage.ThreadId" />
-                <input type="hidden" asp-for="NewMessage.EventID" value="@Model.NewMessage.EventID" />
-                <input type="hidden" asp-for="NewMessage.Subject" value="@Model.NewMessage.Subject" />
-                <input type="hidden" asp-for="NewMessage.PuzzleID" value="@Model.NewMessage.PuzzleID" />
-                <input type="hidden" asp-for="NewMessage.TeamID" value="@Model.NewMessage.TeamID" />
-                <input type="hidden" asp-for="NewMessage.IsFromGameControl" value="@Model.NewMessage.IsFromGameControl" />
-                <input type="hidden" asp-for="NewMessage.SenderID" value="@Model.NewMessage.SenderID" />
-                <input type="hidden" asp-for="NewMessage.PlayerID" value="@Model.NewMessage.PlayerID" />
-            </div>
-            <div class="form-group">
-                <input type="submit" value="Send" class="btn btn-default" />
-            </div>
-        </form>
+@if (Model.Event.AreAnswersAvailableNow)
+{
+    <div>No help is needed because answers are now available!</div>
+}
+else
+{
+    <div class="row">
+        <div class="col-md-4">
+            <form method="post">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group">
+                    @if (Model.PuzzleState.IsEmailOnlyMode)
+                    {
+                        <p>Use this message to fully explain your thought process so we know you're not randomly spamming attempts!</p>
+                    }
+                    else
+                    {
+                        <p>The more details you add here, the more helpful the responses you'll get will be!</p>
+                    }
+                    <textarea asp-for="NewMessage.Text" class="form-control" rows="4" placeholder="Type message here" autocomplete="off"></textarea>
+                    <span asp-validation-for="NewMessage.Text" class="text-danger"></span>
+                    <input type="hidden" asp-for="NewMessage.ThreadId" value="@Model.NewMessage.ThreadId" />
+                    <input type="hidden" asp-for="NewMessage.EventID" value="@Model.NewMessage.EventID" />
+                    <input type="hidden" asp-for="NewMessage.Subject" value="@Model.NewMessage.Subject" />
+                    <input type="hidden" asp-for="NewMessage.PuzzleID" value="@Model.NewMessage.PuzzleID" />
+                    <input type="hidden" asp-for="NewMessage.TeamID" value="@Model.NewMessage.TeamID" />
+                    <input type="hidden" asp-for="NewMessage.IsFromGameControl" value="@Model.NewMessage.IsFromGameControl" />
+                    <input type="hidden" asp-for="NewMessage.SenderID" value="@Model.NewMessage.SenderID" />
+                    <input type="hidden" asp-for="NewMessage.PlayerID" value="@Model.NewMessage.PlayerID" />
+                </div>
+                <div class="form-group">
+                    <input type="submit" value="Send" class="btn btn-default" />
+                </div>
+            </form>
+        </div>
     </div>
-</div>
+}
+
 @if (Model.IsAllowedToClaimMessage() && Model.Messages.Count > 0)
 {
     Message lastMessage = Model.Messages.Last();

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -379,7 +379,7 @@ namespace ServerCore.Pages.Threads
             }
             else if (messageText.Length > MessageCharacterLimit)
             {
-                return ValidationResult.CreateFailure("Your message should not be longer than 3000 characters.");
+                return ValidationResult.CreateFailure($"Your message should not be longer than {MessageCharacterLimit} characters.");
             }
             else
             {

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -155,13 +155,15 @@ namespace ServerCore.Pages.Threads
 
         public async Task<IActionResult> OnPostAsync()
         {
-            if (string.IsNullOrWhiteSpace(NewMessage.Text))
+            if (Event.AreAnswersAvailableNow)
             {
-                ModelState.AddModelError("NewMessage.Text", "Your message cannot be empty.");
+                ModelState.AddModelError("NewMessage.Text", "Answers are already available.");
             }
-            else if (NewMessage.Text.Length > MessageCharacterLimit)
+
+            ValidationResult validationResult = IsMessageTextValid(NewMessage.Text);
+            if (!validationResult.IsValid)
             {
-                ModelState.AddModelError("NewMessage.Text", "Your message should not be longer than 3000 characters.");
+                ModelState.AddModelError("NewMessage.Text", validationResult.FailureReason);
             }
 
             ModelState.Remove("EventId");
@@ -215,6 +217,23 @@ namespace ServerCore.Pages.Threads
 
         public async Task<IActionResult> OnPostEditMessageAsync()
         {
+            if (Event.AreAnswersAvailableNow)
+            {
+                ModelState.AddModelError("EditMessage.Text", $"Edit failed because no updates can be made after answers are available");
+            }
+
+            ValidationResult validationResult = IsMessageTextValid(EditMessage.Text);
+            if (!validationResult.IsValid)
+            {
+                ModelState.AddModelError("EditMessage.Text", $"Edit failed because {validationResult.FailureReason}");
+            }
+
+            ModelState.Remove("EventId");
+            if (!ModelState.IsValid)
+            {
+                return await this.OnGetAsync(EditMessage.PuzzleID, EditMessage.TeamID, EditMessage.PlayerID);
+            }
+
             var message = await _context.Messages.Where(m => m.ID == EditMessage.ID).FirstOrDefaultAsync();
             if (message != null && IsAllowedToEditMessage(message))
             {
@@ -280,14 +299,13 @@ namespace ServerCore.Pages.Threads
 
         public bool IsAllowedToEditMessage(Message message)
         {
-            return message.SenderID == LoggedInUser.ID;
+            return !Event.AreAnswersAvailableNow && message.SenderID == LoggedInUser.ID;
         }
 
         public bool IsAllowedToDeleteMessage(Message message)
         {
-            return EventRole == EventRole.admin
-                || EventRole == EventRole.author
-                || message.SenderID == LoggedInUser.ID;
+            return !Event.AreAnswersAvailableNow 
+                && (IsGameControlRole() || message.SenderID == LoggedInUser.ID);
         }
 
         private async Task SendEmailNotifications(Message newMessage, Puzzle puzzle)
@@ -350,6 +368,39 @@ namespace ServerCore.Pages.Threads
             if (recipients.Any())
             {
                 MailHelper.Singleton.SendPlaintextWithoutBcc(recipients.Select(r => r.Email), emailTitle, emailContent);
+            }
+        }
+
+        private ValidationResult IsMessageTextValid(string messageText)
+        {
+            if (string.IsNullOrWhiteSpace(messageText))
+            {
+                return ValidationResult.CreateFailure("Your message cannot be empty.");
+            }
+            else if (messageText.Length > MessageCharacterLimit)
+            {
+                return ValidationResult.CreateFailure("Your message should not be longer than 3000 characters.");
+            }
+            else
+            {
+                return ValidationResult.CreateSuccess();
+            }
+        }
+
+        private class ValidationResult
+        {
+            public bool IsValid { get; set; }
+
+            public string FailureReason { get; set; }
+
+            public static ValidationResult CreateSuccess()
+            {
+                return new ValidationResult { IsValid = true };
+            }
+
+            public static ValidationResult CreateFailure(string failureReason)
+            {
+                return new ValidationResult { IsValid = false, FailureReason = failureReason };
             }
         }
     }

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -56,6 +56,7 @@
             <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="60" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">1 min</a>
         }
 
+        @(" | ")
         @if (Model.InputParameters.RefreshInterval == 120)
         {
             <span>2 min</span>

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -5,6 +5,8 @@
     ViewData["AdminRoute"] = "/Threads/PuzzleThreads";
     ViewData["AuthorRoute"] = "/Threads/PuzzleThreads";
     ViewData["PlayRoute"] = "/Threads/PuzzleThreads";
+
+    bool isGameControlRole = Model.IsGameControlRole();
 }
 
 <div>
@@ -16,13 +18,75 @@
     {
         <a asp-page="/Puzzles/Index">Puzzle list</a>
     }
-    @(" | ")<a asp-page="/Threads/PuzzleThreads">All threads</a>
-    @if (Model.IsGameControlRole())
+
+    @if (isGameControlRole)
     {
-        @(" | ")<a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true">Unclaimed only</a>
+        @(" | ")
+        @if (Model.InputParameters.HasFilterApplied())
+        {
+            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="@Model.InputParameters.RefreshInterval">All threads</a>
+        }
+        else
+        {
+            <span>All threads</span>
+        }
+
+        @(" | ")
+        @if (Model.InputParameters.ShowUnclaimedOnly.HasValue && Model.InputParameters.ShowUnclaimedOnly.Value)
+        {
+            <span>Unclaimed only</span>
+        }
+        else
+        {
+            <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-refreshInterval="@Model.InputParameters.RefreshInterval">Unclaimed only</a>
+        }
     }
 </div>
 <h3>@Model.Title</h3>
+@if (isGameControlRole)
+{
+    <div>
+        Refresh every:
+        @if (Model.InputParameters.RefreshInterval == 60)
+        {
+            <span>1 min</span>
+        }
+        else
+        {
+            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="60" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">1 min</a>
+        }
+
+        @if (Model.InputParameters.RefreshInterval == 120)
+        {
+            <span>2 min</span>
+        }
+        else
+        {
+            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="120" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">2 min</a>
+        }
+
+        @(" | ")
+        @if (Model.InputParameters.RefreshInterval == 300)
+        {
+            <span>5 min</span>
+        }
+        else
+        {
+            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="300" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">5 min</a>
+        }
+
+        @(" | ")
+        @if (Model.InputParameters.RefreshInterval.HasValue)
+        {
+            <a asp-page="/Threads/PuzzleThreads" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">off</a>
+        }
+        else
+        {
+            <span>off</span>
+        }
+
+    </div>
+}
 
 <table class="table">
     <thead>


### PR DESCRIPTION
#969 

This PR adds the following
- Adds shortcut to Puzzle help thread from "Jump to..."
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/5f802014-bacd-4b11-bf2f-4ad289754107)
- Make sure you can't edit or post new messages after answers have been released
- Introduce the ability to refresh the threads page for GCs
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/e7752e54-332f-40a1-86a2-b7e40064dee9)

