### PR TITLE
Respect ShouldShowHelpMessageOnlyToAuthor and 

### DIFF
--- a/ServerCore/Pages/Events/Create.cshtml
+++ b/ServerCore/Pages/Events/Create.cshtml
@@ -123,6 +123,13 @@
                 </div>
             </div>
             <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <input asp-for="Event.ShouldShowHelpMessageOnlyToAuthor" /> ShouldShowHelpMessageOnlyToAuthor
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
                 <label asp-for="Event.TeamRegistrationBegin" class="control-label"></label>
                 <input asp-for="Event.TeamRegistrationBegin" class="form-control" />
                 <span asp-validation-for="Event.TeamRegistrationBegin" class="text-danger"></span>

--- a/ServerCore/Pages/Events/Delete.cshtml
+++ b/ServerCore/Pages/Events/Delete.cshtml
@@ -78,9 +78,6 @@
             @Model.Event.HasSwag
         </dd>
         <dt>
-            HideHints
-        </dt>
-        <dt>
             HasTShirts
         </dt>
         <dd>
@@ -92,8 +89,17 @@
         <dd>
             @Model.Event.HasIndividualLunch
         </dd>
+        <dt>
+            HideHints
+        </dt>
         <dd>
             @Model.Event.HideHints
+        </dd>
+        <dt>
+            ShouldShowHelpMessageOnlyToAuthor
+        </dt>
+        <dd>
+            @Model.Event.ShouldShowHelpMessageOnlyToAuthor
         </dd>
         <dt>
             TeamRegistrationBegin

--- a/ServerCore/Pages/Events/Details.cshtml
+++ b/ServerCore/Pages/Events/Details.cshtml
@@ -140,6 +140,12 @@
             @Model.Event.HideHints
         </dd>
         <dt>
+            ShouldShowHelpMessageOnlyToAuthor
+        </dt>
+        <dd>
+            @Model.Event.ShouldShowHelpMessageOnlyToAuthor
+        </dd>
+        <dt>
             TeamRegistrationBegin
         </dt>
         <dd>

--- a/ServerCore/Pages/Events/Edit.cshtml
+++ b/ServerCore/Pages/Events/Edit.cshtml
@@ -135,6 +135,13 @@
                 </div>
             </div>
             <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <input asp-for="EditableEvent.ShouldShowHelpMessageOnlyToAuthor" /> ShouldShowHelpMessageOnlyToAuthor
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
                 <label asp-for="EditableEvent.TeamRegistrationBegin" class="control-label"></label>
                 <input asp-for="EditableEvent.TeamRegistrationBegin" class="form-control" />
                 <span asp-validation-for="EditableEvent.TeamRegistrationBegin" class="text-danger"></span>

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml
@@ -75,7 +75,7 @@
                 <form asp-page-handler="EditMessage" method="post">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group">
-                        <textarea asp-for="EditMessage.Text" class="form-control" rows="4" placeholder="@message.Text" autocomplete="off" maxlength="@PuzzleThreadModel.MessageCharacterLimit">@message.Text</textarea>
+                        <textarea id="@Html.IdFor(model => model.EditMessage.Text)" name="@Html.NameFor(model => model.EditMessage.Text)" class="form-control" rows="4" autocomplete="off" maxlength="@PuzzleThreadModel.MessageCharacterLimit">@message.Text</textarea>
                         <span asp-validation-for="EditMessage.Text" class="text-danger"></span>
                         <input type="hidden" asp-for="EditMessage.ID" value="@message.ID" />
                         <input type="hidden" asp-for="EditMessage.PuzzleID" value="@message.PuzzleID" />

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -81,6 +81,15 @@ namespace ServerCore.Pages.Threads
             string subject = null;
             string threadId = null;
             bool isGameControl = IsGameControlRole();
+            if (Event.ShouldShowHelpMessageOnlyToAuthor && EventRole == EventRole.author)
+            {
+                PuzzleAuthors author = _context.PuzzleAuthors.Where(puzzleAuthor => puzzleAuthor.PuzzleID == puzzleId && puzzleAuthor.AuthorID == LoggedInUser.ID).FirstOrDefault();
+                if (author == null)
+                {
+                    throw new InvalidOperationException("You are not an author of this puzzle.");
+                }
+            }
+
             if (Puzzle.IsForSinglePlayer)
             {
                 singlePlayerPuzzlePlayer = _context.PuzzleUsers.Where(user => user.ID == playerId).FirstOrDefault();

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -12,11 +12,11 @@
 <div>
     @if (Model.EventRole == ServerCore.ModelBases.EventRole.play) 
     {
-        <a asp-page="/Puzzles/Play">Puzzle list</a>
+        <a asp-page="/Puzzles/Play">Go to puzzle list</a>
     }
     else
     {
-        <a asp-page="/Puzzles/Index">Puzzle list</a>
+        <a asp-page="/Puzzles/Index">Go to puzzle list</a>
     }
 
     @if (isGameControlRole)
@@ -38,7 +38,20 @@
         }
         else
         {
-            <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-refreshInterval="@Model.InputParameters.RefreshInterval">Unclaimed only</a>
+            <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="true" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-refreshInterval="@Model.InputParameters.RefreshInterval" asp-route-filterToSupportingPuzzlesOnly="@Model.InputParameters.FilterToSupportingPuzzlesOnly">Unclaimed only</a>
+        }
+
+        @if (!Model.Event.ShouldShowHelpMessageOnlyToAuthor)
+        {
+            @(" | ")
+            @if (Model.InputParameters.FilterToSupportingPuzzlesOnly.HasValue && Model.InputParameters.FilterToSupportingPuzzlesOnly.Value)
+            {
+                <span>Your puzzles only</span>
+            }
+            else
+            {
+                <a asp-page="/Threads/PuzzleThreads" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-refreshInterval="@Model.InputParameters.RefreshInterval" asp-route-filterToSupportingPuzzlesOnly="true">Your puzzles only</a>
+            }
         }
     }
 </div>
@@ -53,7 +66,7 @@
         }
         else
         {
-            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="60" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">1 min</a>
+            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="60" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly" asp-route-filterToSupportingPuzzlesOnly="@Model.InputParameters.FilterToSupportingPuzzlesOnly">1 min</a>
         }
 
         @(" | ")
@@ -63,7 +76,7 @@
         }
         else
         {
-            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="120" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">2 min</a>
+            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="120" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly" asp-route-filterToSupportingPuzzlesOnly="@Model.InputParameters.FilterToSupportingPuzzlesOnly">2 min</a>
         }
 
         @(" | ")
@@ -73,13 +86,13 @@
         }
         else
         {
-            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="300" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">5 min</a>
+            <a asp-page="/Threads/PuzzleThreads" asp-route-refreshInterval="300" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly" asp-route-filterToSupportingPuzzlesOnly="@Model.InputParameters.FilterToSupportingPuzzlesOnly">5 min</a>
         }
 
         @(" | ")
         @if (Model.InputParameters.RefreshInterval.HasValue)
         {
-            <a asp-page="/Threads/PuzzleThreads" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly">off</a>
+            <a asp-page="/Threads/PuzzleThreads" asp-route-puzzleId="@Model.InputParameters.PuzzleId" asp-route-playerId="@Model.InputParameters.PlayerId" asp-route-teamId="@Model.InputParameters.TeamId" asp-route-showUnclaimedOnly="@Model.InputParameters.ShowUnclaimedOnly" asp-route-filterToSupportingPuzzlesOnly="@Model.InputParameters.FilterToSupportingPuzzlesOnly">off</a>
         }
         else
         {


### PR DESCRIPTION
#969 

This PR does the following:
- Respects the ShouldShowHelpMessageOnlyToAuthor flag and allows editing the flag
- Fixes the text area only showing placeholder text when editing (see https://github.com/dotnet/aspnetcore/issues/4824 for more details)
- Create new filter for seeing only puzzles you support/author 
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/a94dd992-44df-4d25-aa50-fcab5145b3cd)
