### PR TITLE
hide lunch

### DIFF
--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -205,7 +205,7 @@
                             <li class="nav-item"><a style="color:yellow" asp-page="/Swag/Register" title="Lunch">Pick Lunch by @(Event.TeamMiscDataChangeEnd.ToString("M/dd"))!</a></li>
                         }
                     }
-                    else if (Event.EventHasTeamSwag)
+                    else if (Event.EventHasTeamSwag && isOnTeam)
                     {
                         if (!Event.CanChangeLunch)
                         {


### PR DESCRIPTION
As Morgan pointed out, lunch for teams in the navbar is showing even if they're not on a team yet.  