### PR TITLE
Fix lunch for formerly remote players

### DIFF
--- a/ServerCore/Pages/Player/Index.cshtml.cs
+++ b/ServerCore/Pages/Player/Index.cshtml.cs
@@ -24,6 +24,7 @@ namespace ServerCore.Pages.Player
                                    where t.EventID == Event.ID
                                    join tm in _context.TeamMembers on t.ID equals tm.Team.ID
                                    join p in _context.PlayerInEvent on tm.Member.ID equals p.Player.ID
+                                   where p.Event.ID == Event.ID
                                    orderby p.Player.Name
                                    select new PlayerWithTeamInEvent { Player = p, Team = tm.Team }
                 ).ToListAsync();

--- a/ServerCore/Pages/Teams/Details.cshtml.cs
+++ b/ServerCore/Pages/Teams/Details.cshtml.cs
@@ -130,6 +130,7 @@ namespace ServerCore.Pages.Teams
                 int remoteMembers = await (from player in _context.PlayerInEvent
                                            join member in _context.TeamMembers on player.PlayerId equals member.Member.ID
                                            where member.Team.ID == Team.ID &&
+                                           player.EventId == Event.ID &&
                                            player.IsRemote
                                            select player).CountAsync();
                 EligibleForLunch = totalMembers - remoteMembers;


### PR DESCRIPTION
Fix lunch incorrectly including remote status from all events and a similar bug in the Players in Event report