### PR TITLE
TLDR section for tools page

### DIFF
--- a/ServerCore/Pages/Resources/ToolsPartial.cshtml
+++ b/ServerCore/Pages/Resources/ToolsPartial.cshtml
@@ -4,6 +4,40 @@
     <p>If you're wondering how the top teams are able to solve so many puzzles so quickly, part of the answer is that they're probably using computer power to help them. Many puzzle mechanics like anagramming, deleting, or otherwise manipulating letters and words to discover new words are well-suited to computers. Since we can't effectively ban the use of such tools, the least we can do is share the locations of some of them to help level the playing field.</p>
 
     <br />
+    <h2>TL;DR</h2>
+    <p>All of these links are elaborated on in depth below, and there are even more tools below as well.</p>
+    <div style="display: flex; gap: 40px">
+        <div>
+            <h6 style="margin-top: 9px">General</h6>
+            <div><a asp-page="/EventSpecific/Encodings" target="_blank">All types of encodings (Braille, Morse, etc.)</a></div>
+            <div><a href="https://www.quinapalus.com/qat.html" target="_blank">&lsquo;Qat&rsquo; word finder</a></div>
+            <div><a href="https://nutrimatic.org/2024/" target="_blank">&lsquo;Nutrimatic&rsquo; word finder</a></div>
+            <div><a href="https://www.dcode.fr/caesar-cipher" target="_blank">Letter Shift ciphers (Caesar, ROT-13, etc.)</a></div>
+            <div><a href="https://www.boxentriq.com/code-breaking/cryptogram" target="_blank">Cryptogram helper</a></div>
+            <div><a href="https://www.bing.com/translator" target="_blank">Foreign language translation</a></div>
+        </div>
+        <div>
+            <h6 style="margin-top: 9px">Wordplay</h6>
+            <div><a href="https://www.oneacross.com" target="_blank">Crossword clue helper</a></div>
+            <div><a href="https://en.wikipedia.org/wiki/Cryptic_crossword#Types_of_cryptic_clues" target="_blank">Cryptic crossword primer</a></div>
+            <div><a href="http://wiki.puzzlers.org/dokuwiki/doku.php?id=solving:start" target="_blank">Word finder for &lsquo;Flats&rsquo;</a></div>
+            <h6 style="margin-top: 9px">Audio</h6>
+            <div><a href="https://www.musicca.com/piano" target="_blank">Online playable piano</a></div>
+            <div><a href="https://www.shazam.com" target="_blank">Song identification</a></div>
+            <div><a href="https://www.audacityteam.org/download/" target="_blank">Audio file manipulation</a></div>
+        </div>
+        <div>
+            <h6 style="margin-top: 9px">Pop Culture</h6>
+            <div><a href="https://www.imdb.com" target="_blank">IMDB (movie database)</a></div>
+            <div><a href="https://www.tvtropes.org" target="_blank">TV Tropes</a></div>
+            <div><a href="https://www.knowyourmeme.com" target="_blank">Know Your Meme</a></div>
+            <h6 style="margin-top: 9px">Practice Puzzles</h6>
+            <div><a href="https://www.puzzazz.com/how-to-solve" target="_blank">Ways to solve word puzzles</a></div>
+            <div><a href="https://www.nikoli.co.jp/en/puzzles/" target="_blank">Ways to solve visual logic puzzles</a></div>
+            <div><a href="https://www.chiark.greenend.org.uk/~sgtatham/puzzles/" target="_blank">Many playable logic puzzles</a></div>
+        </div>
+    </div>
+    <br/>
     <h2>General Techniques</h2>
     <h3>Observation</h3>
     <p>The first thing you might notice is that some puzzles have no instructions!  In that case, part of the puzzle is figuring out what to do. Sometimes you'll be looking for differences or similarities between things.  For example, if there are just a number of pictures, perhaps a set of them have some theme or root word in common.</p>

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -82,7 +82,7 @@
                             <ul class="dropdown-menu admin-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Getting Started</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>
@@ -138,7 +138,7 @@
                             <ul class="dropdown-menu author-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Getting Started</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>
@@ -259,7 +259,7 @@
                             <ul class="dropdown-menu player-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Getting Started</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>
@@ -320,7 +320,7 @@
                             <ul class="dropdown-menu player-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Getting Started</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>


### PR DESCRIPTION
There's a lot of good info on the tools page but it's also a lot to slog through when you're in the middle of an event and just want that one thing. Copying some of the links up to a TLDR section at the top.

<img width="545" alt="image" src="https://github.com/PuzzleServer/mainpuzzleserver/assets/42425095/de527f73-19ef-4cbd-a263-f84b9802e2e6">
