### PR TITLE
Fix puzzle css path

### DIFF
--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -116,16 +116,15 @@
                             <div class="form-group">
                                 <label asp-for="Puzzle.CustomCSSFile" class="control-label"></label>
                                 <div class="text-danger" style="font-size: 10px">The name of a CSS file to customize the appearance of the Submission 
-                                    page when embedding is enabled. If only a filepath is provided (i.e. not a full url beginning with https...), the 
+                                    page when embedding is enabled. If only a filepath is provided (i.e. not a full url beginning with http...), the 
                                     relative path of the file will start in the shared resources folder. The path on local development environments 
                                     may differ, but in production, the shared resources folder (and any subfolder uploaded to it as a zip file) is at 
                                     https://puzzleserverteststore.blob.core.windows.net/evt{eventId}/resources/{optionalFolderName}/{filename}
                                     <br /><br />
-                                    A full url will be used as-is.  To address files outside of the shared resources, a single set of .. dots at the
-                                    beginning of the relative path can be used to access a file from the puzzle's resources, for example. To prevent
-                                    the need for future puzzle updates, shared resources are preferred; use caution with puzzle resources instead of 
-                                    shared ones! Puzzle resource links change every time the puzzle is re-uploaded, but they do allow authors to do
-                                    their own submission page styling; shared resources require admins to upload them.
+                                    A full url will be used as-is.  Please note that in development, non-raw full urls to files uploaded to a specific
+                                    puzzle will fail to load. Use caution with full urls; puzzle files have links (both raw and non-) that change every
+                                    time the puzzle is re-uploaded. To address files outside of the shared resources, a dollar sign $ as the first 
+                                    character preceding the relative path can be used to access a file from that puzzle's files. 
                                     <br /><br />
                                 </div>
                                 <input asp-for="Puzzle.CustomCSSFile" class="form-control" />

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -115,21 +115,18 @@
                             </div>
                             <div class="form-group">
                                 <label asp-for="Puzzle.CustomCSSFile" class="control-label"></label>
-                                <div class="text-danger" style="font-size: 10px">The name of a CSS file to customize the appearance of the Submission page when embedding is enabled. 
-                                    If only a filename is provided, the file is assumed to be in the shared resources folder and addressable 
-                                    as https://puzzleserverteststore.blob.core.windows.net/evt{eventId}/resources/{filename} in production 
-                                    (development url will be different). Otherwise, a full or relative url will be used as-is, allowing for files 
-                                    to be uploaded to the puzzle's materials for example.<br />
-                                    Full urls are preferred; use caution with relative ones! If a relative url is provided, it is assumed to be 
-                                    relative to the puzzle file path, which can be useful if you want both the host page and the puzzle to be 
-                                    able to use the same file, but this will only be true if you upload the puzzle and the css file together at 
-                                    the same time as part of the same zip file! Otherwise, if you upload it separately, Azure storage will put 
-                                    it in a different randomly-named folder, which will break the link.<br />
-                                    Relative links will also assume that all files for a puzzle live at the same base directory level. For 
-                                    example, if the puzzle lives at /myPuzzleName/puzzle.html, then the css file will be assumed to live at 
-                                    /myPuzzleName/{filename}. Specifically, don't put them at different levels, for example putting the css file 
-                                    at only /{filename} via a relative link of ../{filename}. Instead, 
-                                    ./{optionalDeeperFolderInsideMyPuzzleNameFolder}/{filename} should be the only kind of relative link used.
+                                <div class="text-danger" style="font-size: 10px">The name of a CSS file to customize the appearance of the Submission 
+                                    page when embedding is enabled. If only a filepath is provided (i.e. not a full url beginning with https...), the 
+                                    relative path of the file will start in the shared resources folder. The path on local development environments 
+                                    may differ, but in production, the shared resources folder (and any subfolder uploaded to it as a zip file) is at 
+                                    https://puzzleserverteststore.blob.core.windows.net/evt{eventId}/resources/{optionalFolderName}/{filename}
+                                    <br /><br />
+                                    A full url will be used as-is.  To address files outside of the shared resources, a single set of .. dots at the
+                                    beginning of the relative path can be used to access a file from the puzzle's resources, for example. To prevent
+                                    the need for future puzzle updates, shared resources are preferred; use caution with puzzle resources instead of 
+                                    shared ones! Puzzle resource links change every time the puzzle is re-uploaded, but they do allow authors to do
+                                    their own submission page styling; shared resources require admins to upload them.
+                                    <br /><br />
                                 </div>
                                 <input asp-for="Puzzle.CustomCSSFile" class="form-control" />
                                 <span asp-validation-for="Puzzle.CustomCSSFile" class="text-danger"></span>

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -446,22 +446,22 @@ else
         }
         else
         {
-            if (cssFileName.StartsWith("../") && (embedType > 0))
+            if (cssFileName.StartsWith("$") && (embedType > 0))
             {
-                // Allow a single ../ at the beginning for relative links to puzzle files instead of shared resources
-                cssFileName = cssFileName.Substring(3);
-                <link rel="stylesheet" href="@(Model.FileStoragePrefix)/@cssFileName" />
+                // $ denotes a material file, where the Short Name of the file is expected to be in the box
+                // the full url has already been obtained in the cs file, so just use it here
+                <link rel="stylesheet" href="@(Model.PossibleMaterialFile)" />
             }
             else
             {
                 if (cssFileName.StartsWith("./") && (embedType > 0))
                 {
-                    // Strip relative links that start in the root folder
+                    // Strip relative links that start in the root shared resources folder
                     cssFileName = cssFileName.Substring(2);
                 }
                 else if (cssFileName.StartsWith("/") && (embedType > 0))
                 {
-                    // Strip relative links that start in the root folder
+                    // Strip relative links that start in the root shared resources folder
                     cssFileName = cssFileName.Substring(1);
                 }
                 <link rel="stylesheet" href="@(Model.FileStoragePrefix)/resources/@cssFileName" />

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -446,7 +446,7 @@ else
         }
         else
         {
-            if (cssFileName.StartsWith("$") && (embedType > 0))
+            if (cssFileName.StartsWith("$") && (embedType > 0) && !string.IsNullOrWhiteSpace(Model.PossibleMaterialFile))
             {
                 // $ denotes a material file, where the Short Name of the file is expected to be in the box
                 // the full url has already been obtained in the cs file, so just use it here

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -439,22 +439,33 @@ else
     {
         cssFileName += (!cssFileName.EndsWith(".css")) ? ".css" : "";
         cssFileName = cssFileName.Replace('\\', '/');
-        if (cssFileName.Contains('/'))
+        if (cssFileName.StartsWith("http"))
         {
-            if (cssFileName.StartsWith(".") && (embedType > 0))
-            {
-                // For relative urls, ASSUME THAT THE RULES DESCRIBED ON THE UPLOAD PAGE HAVE BEEN FOLLOWED
-                // This means that the leading . will be replaced with the puzzleFilePath variable above, minus the puzzle file itself
-                // If the file doesn't start with a ., it's assumed to be a full url that will be used as-is
-                cssFileName = puzzleFilePath.Substring(0, puzzleFilePath.LastIndexOf('/')) + cssFileName.Substring(1);
-            }
+            // Use full links as-is
             <link rel="stylesheet" href="@cssFileName" />
         }
         else
         {
-            // Otherwise, assume that bare file names are in the shared resources folder 
-            // (FileStoragePrefix used to account for different urls between development and production)
-            <link rel="stylesheet" href="@(Model.FileStoragePrefix)/resources/@cssFileName" />
+            if (cssFileName.StartsWith("../") && (embedType > 0))
+            {
+                // Allow a single ../ at the beginning for relative links to puzzle files instead of shared resources
+                cssFileName = cssFileName.Substring(3);
+                <link rel="stylesheet" href="@(Model.FileStoragePrefix)/@cssFileName" />
+            }
+            else
+            {
+                if (cssFileName.StartsWith("./") && (embedType > 0))
+                {
+                    // Strip relative links that start in the root folder
+                    cssFileName = cssFileName.Substring(2);
+                }
+                else if (cssFileName.StartsWith("/") && (embedType > 0))
+                {
+                    // Strip relative links that start in the root folder
+                    cssFileName = cssFileName.Substring(1);
+                }
+                <link rel="stylesheet" href="@(Model.FileStoragePrefix)/resources/@cssFileName" />
+            }
         }
     }
 

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -396,7 +396,10 @@ namespace ServerCore.Pages.Submissions
                                                  where contentFile.Event == Event &&
                                                  contentFile.ShortName == Puzzle.CustomCSSFile.Substring(1)
                                                  select contentFile).SingleOrDefaultAsync();
-                    PossibleMaterialFile = content.Url.AbsoluteUri;
+                    if (content != null)
+                    {
+                        PossibleMaterialFile = content.Url.AbsoluteUri;
+                    }
                 }
             }
         }

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Data.Migrations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -33,7 +32,7 @@ namespace ServerCore.Pages.Submissions
 
         public List<SubmissionView> SubmissionViews { get; set; }
 
-        public DataModel.Puzzle Puzzle { get; set; }
+        public Puzzle Puzzle { get; set; }
 
         public string PuzzleAuthor { get; set; }
 
@@ -41,7 +40,7 @@ namespace ServerCore.Pages.Submissions
 
         public string AnswerToken { get; set; }
 
-        public IList<DataModel.Puzzle> PuzzlesCausingGlobalLockout { get; set; }
+        public IList<Puzzle> PuzzlesCausingGlobalLockout { get; set; }
 
         public string AnswerRedAlertMessage { get; set; }
 


### PR DESCRIPTION
Partially addresses #1025. This update at least makes relative links work again, although not in the way they used to.  It also allows subfolders in the shared resources to be used.  

Accessing puzzle material files is now done by preceding the file name with a $