### PR TITLE
Make plaintext requirement more clear for responses

### DIFF
--- a/ServerCore/Pages/Responses/Create.cshtml
+++ b/ServerCore/Pages/Responses/Create.cshtml
@@ -10,6 +10,8 @@
 }
 
 <h2>@Model.Puzzle.Name: Create response</h2>
+<h5>Note: ResponseText can either be plaintext or Raw HTML.</h5>
+<h5>If you are using HTML, write it as "<i>&lt;Plaintext version&gt;</i> Html.Raw(<i>&lt;YOUR HTML&gt;</i>)" and <b>CHECK IT VERY CAREFULLY!</b><br />Example: You are correct Html.Raw(&lt;span&gt;You are &lt;b&gt;correct&lt;/b&gt;/&lt;span&gt;)<br />Failure to be careful may make responses uneditable, and you may have to delete your puzzle and start over.</h5>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>

--- a/ServerCore/Pages/Responses/Create.cshtml.cs
+++ b/ServerCore/Pages/Responses/Create.cshtml.cs
@@ -34,10 +34,16 @@ namespace ServerCore.Pages.Responses
         {
             if (!ModelState.IsValid)
             {
-                return Page();
+                return await OnGetAsync(puzzleId);
             }
 
             PuzzleResponse.PuzzleID = puzzleId;
+
+            if (PuzzleResponse.ResponseText != null && PuzzleResponse.ResponseText.StartsWith("Html.Raw("))
+            {
+                ModelState.AddModelError("PuzzleResponse.ResponseText", "Reponses using \"Html.Raw\" must start with a plain text version.");
+                return await OnGetAsync(puzzleId);
+            }
 
             // Ensure that the response text is unique across all responses for this puzzle.
             bool duplicateResponse = await (from Response r in _context.Responses

--- a/ServerCore/Pages/Responses/CreateBulk.cshtml
+++ b/ServerCore/Pages/Responses/CreateBulk.cshtml
@@ -10,6 +10,8 @@
 }
 
 <h2>@Model.Puzzle.Name: Create responses (bulk)</h2>
+<h5>Note: ResponseText can either be plaintext or Raw HTML.</h5>
+<h5>If you are using HTML, write it as "<i>&lt;Plaintext version&gt;</i> Html.Raw(<i>&lt;YOUR HTML&gt;</i>)" and <b>CHECK IT VERY CAREFULLY!</b><br />Example: You are correct Html.Raw(&lt;span&gt;You are &lt;b&gt;correct&lt;/b&gt;/&lt;span&gt;)<br />Failure to be careful may make responses uneditable, and you may have to delete your puzzle and start over.</h5>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>

--- a/ServerCore/Pages/Responses/Index.cshtml
+++ b/ServerCore/Pages/Responses/Index.cshtml
@@ -17,7 +17,8 @@
     <a asp-page="CreateBulk" asp-route-puzzleId="@Model.PuzzleId">Bulk Create</a>
 </p>
 
-<h4>Note: ResponseText can either be plain text or Raw HTML.<br/>If you are using HTML, write it as Html.Raw(<i>&lt;your html&gt;</i>) and <b>CHECK IT VERY CAREFULLY!</b><br/>Failure to be careful may make responses uneditable, and you may have to delete your puzzle and start over.</h4>
+<h5>Note: ResponseText can either be plaintext or Raw HTML.</h5>
+<h5>If you are using HTML, write it as "<i>&lt;Plaintext version&gt;</i> Html.Raw(<i>&lt;YOUR HTML&gt;</i>)" and <b>CHECK IT VERY CAREFULLY!</b><br />Example: You are correct Html.Raw(&lt;span&gt;You are &lt;b&gt;correct&lt;/b&gt;/&lt;span&gt;)<br />Failure to be careful may make responses uneditable, and you may have to delete your puzzle and start over.</h5>
 <table class="table">
     <thead>
         <tr>

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -570,12 +570,13 @@ namespace ServerCore
                     var teams = await (from sub in context.Submissions
                                              where sub.PuzzleID == response.PuzzleID && sub.SubmissionText == response.SubmittedText
                                              select sub.Team).ToListAsync();
+                    var plaintextResponseText = response.GetPlaintextResponseText(puzzle?.EventID ?? 0);
                     MailHelper.Singleton.SendPlaintextBcc(teamMembers,
                         $"{puzzle.Event.Name}: {puzzle.PlaintextName} Response updated for '{response.SubmittedText}'",
-                        $"The new response for this submission is: '{response.GetPlaintextResponseText(puzzle?.EventID ?? 0)}'.");
+                        $"The new response for this submission is: '{plaintextResponseText}'.");
                     foreach (Team team in teams)
                     {
-                        await ServiceProvider.GetRequiredService<IHubContext<ServerMessageHub>>().SendNotification(team, $"{puzzle.PlaintextName} Response updated for '{response.SubmittedText}'", $"The new response for this submission is: '{response.GetPlaintextResponseText(puzzle?.EventID ?? 0)}'.", $"/{puzzle.Event.EventID}/play/Submissions/{puzzle.ID}");
+                        await ServiceProvider.GetRequiredService<IHubContext<ServerMessageHub>>().SendNotification(team, $"{puzzle.PlaintextName} Response updated for '{response.SubmittedText}'", $"The new response for this submission is: '{plaintextResponseText}'.", $"/{puzzle.Event.EventID}/play/Submissions/{puzzle.ID}");
                     }
                 }
             }


### PR DESCRIPTION
#1020 

The original bug was because "Html.Raw(" was used without a plaintext version at the beginning.
When the Response is just an Html.Raw, we end up returning the entire response text
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/98b9da0d-d965-4f28-9126-360d4bc1bdbe)


This PR makes it more clear about this formatting requirement.

### Responses page
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/dd47265b-4d2a-44cd-b39c-de2b7ced5f55)

### Bulk creation page
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/d7e7ad53-27f8-4134-9c31-f147b411d3ef)

### Create page
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/26ceb43f-0c04-43ea-a095-36e77e8ebae8)

### What player sees
Notification for response "Here is plaintext Html.Raw(<span>Here is a <b>bolded</b> answer. </span>)"
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/fb5b4627-227f-4425-85e8-500780dcad80)

Submissions page
![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/4121745/91876f70-78c2-46c3-a89b-754ac391aabf)


