### PR TITLE
Revert "Add presense to puzzle page (#1037)"

### DIFF
--- a/ServerCore/Pages/Components/PresenceComponent.razor
+++ b/ServerCore/Pages/Components/PresenceComponent.razor
@@ -11,19 +11,7 @@
 
 <div>
     <span>
-        @if(!ShowPresenceOnly)
-        {
-            <b>Who&apos;s Here: </b>
-        }
-        @if (MaxUsers.HasValue && PresentUsers.Count > MaxUsers.Value)
-        {
-            int remainingUsers = PresentUsers.Count - MaxUsers.Value + 1;
-            string remainingUsersString = $"{remainingUsers}+";
-            @(string.Join(" | ", PresentUsers.Take(MaxUsers.Value - 1).Select(u => u.Name)) + " | " + remainingUsersString);
-        }
-        else
-        {
-            @string.Join(" | ", PresentUsers.Select(u => u.Name))
-        }
+        <b>Who&apos;s Here: </b>
+        @string.Join(" | ", PresentUsers.Select(u => u.Name))
     </span>
 </div>

--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -101,12 +101,6 @@ else
                         Answer
                     </th>
                 }
-                else if (Model.Event.AllowBlazor)
-                {
-                    <th>
-                        Who's here
-                    </th>
-                }
                 <th>
                     <a asp-page="./Play"
                         asp-route-singlePlayerPuzzleSort="@Model.SinglePlayerPuzzleSort" 
@@ -182,12 +176,6 @@ else
                             {
                                 @Html.ActionLink("View answer", "Index", "Files", new { eventId = Model.Event.ID, filename = item.Answer.ShortName }, new { target = "_blank" })
                             }
-                        </td>
-                    }
-                    else if (Model.Event.AllowBlazor)
-                    {
-                        <td>
-                            <component type="typeof(ServerCore.Pages.Components.PresenceComponent)" render-mode="Server" param-PuzzleUserId="@Model.LoggedInUser.ID" param-TeamId="@Model.Team.ID" param-PuzzleId="@item.ID" param-IsReadOnly=true param-ShowPresenceOnly=true param-MaxUsers=2 />
                         </td>
                     }
                     <td class="puzzle-list-submit-customizable">


### PR DESCRIPTION
This reverts commit c20ed268c569b37a7735cdf52c5b2640702ba297.

Just managing risk here.

Trying to ensure that we have a functional site so that our event can properly be validated - right now the site will keel over as soon as we solve !!!Start the Event!!! as solved, and we would have no choice but to immediately turn off ALL Blazor features. Bullet dodged that we discovered this before 10:31AM on event day.

If we have an appropriately LOW RISK approach well before pregame starts on 7/8, we can try again.