### PR TITLE
Presence List Perf Fix

### DIFF
--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -28,11 +28,13 @@
 @if (Model.Event.AllowBlazor)
 {
     <script>
-        window.showPresence = (puzzleId, presenceText) => {
-            let presenceId = document.querySelector(`#presence-${puzzleId}`);
-            if (presenceId) {
-                presenceId.textContent = presenceText;
-            }
+        window.showPresence = (allPresence) => {
+            allPresence.forEach(p => {
+                let presenceId = document.querySelector(`#presence-${p.puzzleId}`);
+                if (presenceId) {
+                    presenceId.textContent = p.presenceText;
+                }
+            });
         }
     </script>
     <component type="typeof(ServerCore.Pages.Components.TeamPresenceToJSComponent)" render-mode="Server" param-TeamId="@Model.Team.ID" param-MaxUsers=2 />


### PR DESCRIPTION
Sending an array of {puzzleId, presenceText} objects instead of just one per message. This allows us to batch up all presence on page load, and only send presence data for puzzles that have it.