### PR TITLE
State map presence icon

### DIFF
--- a/ServerCore/Pages/Events/Map.cshtml
+++ b/ServerCore/Pages/Events/Map.cshtml
@@ -59,7 +59,12 @@
                 var teamState = Model.StateMap[x, y] ?? MapModel.StateStats.Default;
 
                     <td class="stateparent">
-                        <a class="@teamState.Classes" asp-page="/Submissions/AuthorIndex" asp-route-puzzleId="@Model.Puzzles[x].Puzzle.ID" asp-route-teamId="@Model.Teams[y].Team.ID"></a>
+                        <a class="@teamState.Classes" asp-page="/Submissions/AuthorIndex" asp-route-puzzleId="@Model.Puzzles[x].Puzzle.ID" asp-route-teamId="@Model.Teams[y].Team.ID">
+                            @if (teamState.IsPresent)
+                            {
+                                <span>👀</span>
+                            }
+                        </a>
                     </td>
             }
                 </tr>

--- a/ServerCore/ServerMessages/PresenceStore.cs
+++ b/ServerCore/ServerMessages/PresenceStore.cs
@@ -88,6 +88,26 @@ namespace ServerCore.ServerMessages
                 await OnPresenceChange(message);
             }
         }
+
+        /// <summary>
+        /// Returns true if any user on a team is on a puzzle page
+        /// </summary>
+        /// <param name="teamID">Team to check presence for</param>
+        /// <param name="puzzleID">Puzzle to check presence for</param>
+        public bool IsPresent(int teamID, int puzzleID)
+        {
+            // Don't create stores if we don't need them -- it means nobody's present
+            if (!TeamStores.TryGetValue(teamID, out TeamStore teamStore))
+            {
+                return false;
+            }
+            if (!teamStore.TeamPuzzleStores.TryGetValue(puzzleID, out TeamPuzzleStore teamPuzzleStore))
+            {
+                return false;
+            }
+
+            return teamPuzzleStore.PresentPages.Count > 0;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Adds an eyes icon to the state map when a team is looking at a puzzle. Note that since the state map isn't Blazor, this still requires a refresh to get new data (like the rest of the state map). See screenshot:

![image](https://github.com/PuzzleServer/mainpuzzleserver/assets/11641665/4d2589ab-f8d6-4603-a187-5354e7b32d71)
