### PR TITLE
Fix auto team types not showing on the team composition page

### DIFF
--- a/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
+++ b/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
@@ -105,7 +105,8 @@ namespace ServerCore.Pages.Teams
                     })
                 .ToList()
                 .GroupBy(intermediate => intermediate.TeamID)
-                .Select(this.MapToTeamComposition);
+                .Select(this.MapToTeamComposition)
+                .ToList();
 
             foreach (TeamComposition t in TeamCompositions)
             {


### PR DESCRIPTION
Auto team string was getting set on an ephemeral object because the linq query was getting re-evaluated. Adds a ToList call to stop re-evaluation. The previous ToList call is still required to separate db-side and frontend-side processing.