### PR TITLE
Fix single player puzzle list

### DIFF
--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -26,7 +26,7 @@
         }
 </style>
 
-@if (Model.Event.AllowBlazor && canUsePresence)
+@if (Model.Event.AllowBlazor && canUsePresence && Model.Team != null)
 {
     <script>
         window.showPresence = (allPresence) => {


### PR DESCRIPTION
Single player puzzles allow playing without a team, but the presence on the puzzle list nullrefed. Add a null check