### PR TITLE
Notification Refresh

### DIFF
--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -388,9 +388,8 @@
             popToast(notification, true);
         };
 
-        document.addEventListener("DOMContentLoaded", function () { if (windowHasFocus) { resetAllToasts(); } documentLoaded = true; });
-        window.addEventListener("focus", function() { if (documentLoaded && !windowHasFocus) { resetAllToasts(); } windowHasFocus = true; });
-        window.addEventListener("blur", function () { windowHasFocus = false; });
+        document.addEventListener("DOMContentLoaded", function () { resetAllToasts(); documentLoaded = true; });
+        window.addEventListener("focus", function() { if (documentLoaded) { resetAllToasts(); } });
     </script>
 
     <div aria-live="polite" aria-atomic="true" class="position-relative">

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -340,7 +340,6 @@
     <script>
         var allEventToasts = {};
         var documentLoaded = false;
-        var windowHasFocus = false;
 
         function popToast(notification, animate) {
             let notificationList = document.querySelector("#notification-list");


### PR DESCRIPTION
Refreshing a page wasn't bringing the notifications along, only when the page explicitly got focus.

Fixing by being more aggressive about when to rebuild the notifications list, at the possible expense of some client perf (no additional server hits though). We rewrite localStorage whenever dismissing a notification, so I do not expect any new leaks.