### PR TITLE
Add team name to help threads

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml
@@ -39,13 +39,22 @@
         }
         else
         {
-            <a asp-page="/Puzzles/Edit" asp-route-puzzleId="@Model.Puzzle.ID">Go to puzzle</a>@(" |")
+            PuzzleStatePerTeam teamPuzzleState = Model.PuzzleState as PuzzleStatePerTeam;
+            SinglePlayerPuzzleStatePerPlayer singlePlayerPuzzleState = Model.PuzzleState as SinglePlayerPuzzleStatePerPlayer;
+            if (teamPuzzleState != null)
+            {
+                <a asp-page="/Teams/Details" asp-route-teamId="@teamPuzzleState.TeamID">Go to team</a>@(" |")
+            }
+
+            string goToPuzzleLabel = singlePlayerPuzzleState != null ? "Go to single player puzzle" : "Go to puzzle";
+            <a asp-page="/Puzzles/Edit" asp-route-puzzleId="@Model.Puzzle.ID">@goToPuzzleLabel</a>@(" |")
         }
         <a asp-page="/Threads/PuzzleThreads">See all threads</a>
     </span>
 </div>
 
-<h3>Thread for puzzle @Model.Puzzle.Name</h3>
+<h3>@Model.NewMessage.Subject</h3>
+
 <hr />
 @foreach (var message in Model.Messages)
 {

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -39,7 +39,7 @@ namespace ServerCore.Pages.Threads
         public Message EditMessage { get; set; }
 
         /// <summary>
-        /// Gets or sets the team.
+        /// Gets or sets the puzzle.
         /// </summary>
         public Puzzle Puzzle { get; set; }
 


### PR DESCRIPTION
#1071
Before, the help thread pages would be titled "Thread for <PUZZLE NAME>" 

Now we include team name as well
## What players see
![image](https://github.com/user-attachments/assets/9e0ec995-3b18-4b64-ab3e-39a14b2cee07)

## What GC sees
![image](https://github.com/user-attachments/assets/09997724-e966-4bff-8db8-a1f9fd64a0e2)
