### PR TITLE
Add full-sized test event option

### DIFF
--- a/ServerCore/Pages/Events/CreateDemo.cshtml
+++ b/ServerCore/Pages/Events/CreateDemo.cshtml
@@ -49,6 +49,13 @@
                     </label>
                 </div>
             </div>
+            <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <input asp-for="LargeEvent" /> Large event for stress testing. Takes a minute, do not cancel or reload.
+                    </label>
+                </div>
+            </div>
             <br />
             <div class="form-group">
                 <b>Usage:</b>


### PR DESCRIPTION
Adds an option to test event creation to create a real event-sized event for performance, stress, and load testing. The test event has 100 teams, each with 10 players and 100 puzzles. Half of the teams have submitted and solved on half the puzzles and sent threads on those puzzles.