### PR TITLE
Fix team unlock for single player puzzle

### DIFF
--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -429,7 +429,7 @@ namespace ServerCore
                                                         join unlockedBy in context.Prerequisites on possibleUnlock.PuzzleID equals unlockedBy.PuzzleID
                                                         join pspt in context.PuzzleStatePerTeam on unlockedBy.PrerequisiteID equals pspt.PuzzleID
                                                         join puz in context.Puzzles on unlockedBy.PrerequisiteID equals puz.ID
-                                                        where possibleUnlock.Prerequisite == puzzleJustSolved && !puz.IsForSinglePlayer && (team == null || pspt.TeamID == team.ID) && pspt.SolvedTime != null
+                                                        where possibleUnlock.Prerequisite == puzzleJustSolved && !possibleUnlock.Puzzle.IsForSinglePlayer && !puz.IsForSinglePlayer && (team == null || pspt.TeamID == team.ID) && pspt.SolvedTime != null
                                                         group puz by new { unlockedBy.PuzzleID, unlockedBy.Puzzle.MinPrerequisiteCount, unlockedBy.Puzzle.IsPuzzle, pspt.TeamID } into g
                                                         select new
                                                         {


### PR DESCRIPTION
#1076

During the event, we had a SinglePlayerPuzzle with a StartTheEvent puzzle prerequisite.
When we solved the StartTheEvent, no team puzzles were unlocked.
This was because it failed when we tried to update the team state for a single player puzzle. All single player puzzles should have been filtered out