### PR TITLE
Perf fix for threads version 2

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -118,19 +118,7 @@
                 Timestamp
             </th>
             <th>
-                Puzzle
-            </th>
-            @if (Model.IsGameControlRole())
-            {
-                <th>
-                    Team
-                </th>
-            }
-            <th>
                 Last message
-            </th>
-            <th>
-                Last message sender
             </th>
         </tr>
     </thead>
@@ -148,39 +136,13 @@
                     </td>
                 }
                 <td>
-                    <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID">@item.Subject</a>
+                    <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.PuzzleID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID">@item.Subject</a>
                 </td>
                 <td>
                     @Html.Raw(Model.LocalTime(@item.CreatedDateTimeInUtc))
                 </td>
                 <td>
-                    @if (Model.EventRole == ModelBases.EventRole.admin || Model.EventRole == ModelBases.EventRole.author)
-                    {
-                        <a asp-Page="/Puzzles/Edit" asp-route-puzzleId=@item.Puzzle.ID>@item.Puzzle.Name</a>
-                    }
-                    else
-                    {
-                        <a asp-page="/Submissions/Index" asp-route-puzzleId="@item.Puzzle.ID">@item.Puzzle.Name</a>
-                    }
-                </td>
-                @if (Model.IsGameControlRole())
-                {
-                            <td>
-                                @if (item.TeamID.HasValue)
-                                {
-                                    <a asp-page="/Teams/Status" asp-route-teamId="@item.TeamID.Value">@item.Team.Name</a>
-                                }
-                                else
-                                {
-                                    <span>N/A</span>
-                                }
-                            </td>
-                }
-                <td>
                     @(item.Text.Length > 93 ? $"{item.Text.Substring(0, 90)}..." : item.Text)
-                </td>
-                <td>
-                    @item.Sender.Name
                 </td>
             </tr>
         }

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
@@ -75,8 +75,8 @@ namespace ServerCore.Pages.Threads
                 refreshInterval: refreshInterval,
                 filterToSupportingPuzzlesOnly: filterToSupportingPuzzlesOnly);
 
-            IQueryable<Message> messages = this._context.Messages.Where(message => message.Puzzle != null
-                    && message.Puzzle.EventID == Event.ID);
+            IQueryable<Message> messages = this._context.Messages.Where(message => message.PuzzleID.HasValue
+                    && message.EventID == Event.ID);
             this.Title = "All help threads";
 
             // Based on the event role, filter the messages further.
@@ -132,7 +132,7 @@ namespace ServerCore.Pages.Threads
                 HashSet<int> authorPuzzleIds = UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
                     .Select(puzzle => puzzle.ID)
                     .ToHashSet();
-                messages = messages.Where(message => authorPuzzleIds.Contains(message.Puzzle.ID));
+                messages = messages.Where(message => authorPuzzleIds.Contains(message.PuzzleID.Value));
 
                 if (!Event.ShouldShowHelpMessageOnlyToAuthor && filterToSupportingPuzzlesOnly.Value)
                 {


### PR DESCRIPTION
#1068

I realized we didn't actually need the puzzle name or the team name on the chart because it is already part of the thread title.
The author can also click on the puzzle after clicking on the thread.

We actually don't need puzzle name or the team name because it is already part of the thread title
![image](https://github.com/user-attachments/assets/94adb32a-bf88-4a58-9fff-31be6ac3dbac)

Original query
```
SELECT [t0].[ID], [t0].[ClaimerID], [t0].[CreatedDateTimeInUtc], [t0].[EventID], [t0].[IsFromGameControl], [t0].[ModifiedDateTimeInUtc], [t0].[PlayerID], [t0].[PuzzleID], [t0].[SenderID], [t0].[Subject], [t0].[TeamID], [t0].[Text], [t0].[ThreadId]
FROM (
    SELECT [m].[ThreadId]
    FROM [Messages] AS [m]
    LEFT JOIN [Puzzles] AS [p] ON [m].[PuzzleID] = [p].[ID]
    WHERE ([p].[ID] IS NOT NULL) AND [m].[EventID] = @__Event_ID_0
    GROUP BY [m].[ThreadId]
) AS [t]
LEFT JOIN (
    SELECT [t1].[ID], [t1].[ClaimerID], [t1].[CreatedDateTimeInUtc], [t1].[EventID], [t1].[IsFromGameControl], [t1].[ModifiedDateTimeInUtc], [t1].[PlayerID], [t1].[PuzzleID], [t1].[SenderID], [t1].[Subject], [t1].[TeamID], [t1].[Text], [t1].[ThreadId]
    FROM (
        SELECT [m0].[ID], [m0].[ClaimerID], [m0].[CreatedDateTimeInUtc], [m0].[EventID], [m0].[IsFromGameControl], [m0].[ModifiedDateTimeInUtc], [m0].[PlayerID], [m0].[PuzzleID], [m0].[SenderID], [m0].[Subject], [m0].[TeamID], [m0].[Text], [m0].[ThreadId], ROW_NUMBER() OVER(PARTITION BY [m0].[ThreadId] ORDER BY [m0].[CreatedDateTimeInUtc] DESC) AS [row]
        FROM [Messages] AS [m0]
        LEFT JOIN [Puzzles] AS [p0] ON [m0].[PuzzleID] = [p0].[ID]
        WHERE ([p0].[ID] IS NOT NULL) AND [m0].[EventID] = @__Event_ID_0
    ) AS [t1]
    WHERE [t1].[row] <= 1
) AS [t0] ON [t].[ThreadId] = [t0].[ThreadId]
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [p].[ID], [p].[CustomAuthorText], [p].[CustomCSSFile], [p].[CustomSolutionURL], [p].[CustomURL], [p].[Description], [p].[Errata], [p].[EventID], [p].[Group], [p].[HasDataConfirmation], [p].[HintCoinsForSolve], [p].[HintsAreCumulative], [p].[IsCheatCode], [p].[IsFinalPuzzle], [p].[IsForSinglePlayer], [p].[IsFreeform], [p].[IsGloballyVisiblePrerequisite], [p].[IsMetaPuzzle], [p].[IsPuzzle], [p].[MaxAnnotationKey], [p].[MinInGroupCount], [p].[MinPrerequisiteCount], [p].[MinutesOfEventLockout], [p].[MinutesToAutomaticallySolve], [p].[Name], [p].[OrderInGroup], [p].[PieceMetaTagFilter], [p].[PieceMetaUsage], [p].[PieceTag], [p].[PieceWeight], [p].[PrerequisiteWeight], [p].[PuzzleVersion], [p].[SolveValue], [p].[SupportEmailAlias], [p].[Token]
FROM [Puzzles] AS [p]
WHERE [p].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (1ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [t].[ID], [t].[AutoApproveTeammates], [t].[AutoTeamType], [t].[Bio], [t].[CustomRoom], [t].[EventID], [t].[HintCoinCount], [t].[HintCoinsUsed], [t].[IsDisqualified], [t].[IsLookingForTeammates], [t].[MergedTeams], [t].[Name], [t].[Password], [t].[PrimaryContactEmail], [t].[PrimaryPhoneNumber], [t].[SecondaryPhoneNumber], [t].[ShowTeamAnnouncement]
FROM [Teams] AS [t]
WHERE [t].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (1ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [p].[ID], [p].[Email], [p].[EmployeeAlias], [p].[IdentityUserId], [p].[IsGlobalAdmin], [p].[MayBeAdminOrAuthor], [p].[Name], [p].[PhoneNumber], [p].[TShirtSize], [p].[VisibleToOthers]
FROM [PuzzleUsers] AS [p]
WHERE [p].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [t].[ID], [t].[AutoApproveTeammates], [t].[AutoTeamType], [t].[Bio], [t].[CustomRoom], [t].[EventID], [t].[HintCoinCount], [t].[HintCoinsUsed], [t].[IsDisqualified], [t].[IsLookingForTeammates], [t].[MergedTeams], [t].[Name], [t].[Password], [t].[PrimaryContactEmail], [t].[PrimaryPhoneNumber], [t].[SecondaryPhoneNumber], [t].[ShowTeamAnnouncement]
FROM [Teams] AS [t]
WHERE [t].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [p].[ID], [p].[Email], [p].[EmployeeAlias], [p].[IdentityUserId], [p].[IsGlobalAdmin], [p].[MayBeAdminOrAuthor], [p].[Name], [p].[PhoneNumber], [p].[TShirtSize], [p].[VisibleToOthers]
FROM [PuzzleUsers] AS [p]
WHERE [p].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [t].[ID], [t].[AutoApproveTeammates], [t].[AutoTeamType], [t].[Bio], [t].[CustomRoom], [t].[EventID], [t].[HintCoinCount], [t].[HintCoinsUsed], [t].[IsDisqualified], [t].[IsLookingForTeammates], [t].[MergedTeams], [t].[Name], [t].[Password], [t].[PrimaryContactEmail], [t].[PrimaryPhoneNumber], [t].[SecondaryPhoneNumber], [t].[ShowTeamAnnouncement]
FROM [Teams] AS [t]
WHERE [t].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [p].[ID], [p].[Email], [p].[EmployeeAlias], [p].[IdentityUserId], [p].[IsGlobalAdmin], [p].[MayBeAdminOrAuthor], [p].[Name], [p].[PhoneNumber], [p].[TShirtSize], [p].[VisibleToOthers]
FROM [PuzzleUsers] AS [p]
WHERE [p].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [t].[ID], [t].[AutoApproveTeammates], [t].[AutoTeamType], [t].[Bio], [t].[CustomRoom], [t].[EventID], [t].[HintCoinCount], [t].[HintCoinsUsed], [t].[IsDisqualified], [t].[IsLookingForTeammates], [t].[MergedTeams], [t].[Name], [t].[Password], [t].[PrimaryContactEmail], [t].[PrimaryPhoneNumber], [t].[SecondaryPhoneNumber], [t].[ShowTeamAnnouncement]
FROM [Teams] AS [t]
WHERE [t].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [p].[ID], [p].[Email], [p].[EmployeeAlias], [p].[IdentityUserId], [p].[IsGlobalAdmin], [p].[MayBeAdminOrAuthor], [p].[Name], [p].[PhoneNumber], [p].[TShirtSize], [p].[VisibleToOthers]
FROM [PuzzleUsers] AS [p]
WHERE [p].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (1ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [t].[ID], [t].[AutoApproveTeammates], [t].[AutoTeamType], [t].[Bio], [t].[CustomRoom], [t].[EventID], [t].[HintCoinCount], [t].[HintCoinsUsed], [t].[IsDisqualified], [t].[IsLookingForTeammates], [t].[MergedTeams], [t].[Name], [t].[Password], [t].[PrimaryContactEmail], [t].[PrimaryPhoneNumber], [t].[SecondaryPhoneNumber], [t].[ShowTeamAnnouncement]
FROM [Teams] AS [t]
WHERE [t].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [p].[ID], [p].[Email], [p].[EmployeeAlias], [p].[IdentityUserId], [p].[IsGlobalAdmin], [p].[MayBeAdminOrAuthor], [p].[Name], [p].[PhoneNumber], [p].[TShirtSize], [p].[VisibleToOthers]
FROM [PuzzleUsers] AS [p]
WHERE [p].[ID] = @__p_0
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (0ms) [Parameters=[@__p_0='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT [t].[ID], [t].[AutoApproveTeammates], [t].[AutoTeamType], [t].[Bio], [t].[CustomRoom], [t].[EventID], [t].[HintCoinCount], [t].[HintCoinsUsed], [t].[IsDisqualified], [t].[IsLookingForTeammates], [t].[MergedTeams], [t].[Name], [t].[Password], [t].[PrimaryContactEmail], [t].[PrimaryPhoneNumber], [t].[SecondaryPhoneNumber], [t].[ShowTeamAnnouncement]

And many other puzzle select statements
```

Final query
```
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (5ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
SELECT [m].[ID], [m].[ClaimerID], [m].[CreatedDateTimeInUtc], [m].[EventID], [m].[IsFromGameControl], [m].[ModifiedDateTimeInUtc], [m].[PlayerID], [m].[PuzzleID], [m].[SenderID], [m].[Subject], [m].[TeamID], [m].[Text], [m].[ThreadId]
FROM [Messages] AS [m]
Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.PageActionInvoker: Information: Executed handler method OnGetAsync, returned result Microsoft.AspNetCore.Mvc.RazorPages.PageResult.
'iisexpress.exe' (CoreCLR: clrhost): Loaded 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\7.0.20\System.Globalization.dll'. Skipped loading symbols. Module is optimized and the debugger option 'Just My Code' is enabled.
'iisexpress.exe' (CoreCLR: clrhost): Loaded 'C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\7.0.20\Microsoft.AspNetCore.DataProtection.Extensions.dll'. Skipped loading symbols. Module is optimized and the debugger option 'Just My Code' is enabled.
'iisexpress.exe' (CoreCLR: clrhost): Loaded 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App\7.0.20\Microsoft.CSharp.dll'. Skipped loading symbols. Module is optimized and the debugger option 'Just My Code' is enabled.
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (5ms) [Parameters=[@__ID_0='?' (DbType = Int32), @__thisEvent_ID_1='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT CASE
    WHEN EXISTS (
        SELECT 1
        FROM [Swag] AS [s]
        WHERE [s].[PlayerId] = @__ID_0 AND [s].[EventId] = @__thisEvent_ID_1) THEN CAST(1 AS bit)
    ELSE CAST(0 AS bit)
END
Microsoft.EntityFrameworkCore.Database.Command: Information: Executed DbCommand (8ms) [Parameters=[@__ID_0='?' (DbType = Int32), @__thisEvent_ID_1='?' (DbType = Int32)], CommandType='Text', CommandTimeout='30']
SELECT CASE
    WHEN EXISTS (
        SELECT 1
        FROM [TeamMembers] AS [t]
        INNER JOIN [PuzzleUsers] AS [p] ON [t].[User.ID] = [p].[ID]
        INNER JOIN [Teams] AS [t0] ON [t].[Team.ID] = [t0].[ID]
        INNER JOIN [Events] AS [e] ON [t0].[EventID] = [e].[ID]
        WHERE [p].[ID] = @__ID_0 AND [e].[ID] = @__thisEvent_ID_1) THEN CAST(1 AS bit)
    ELSE CAST(0 AS bit)
END
```


