### PR TITLE
Notification load generator

### DIFF
--- a/ServerCore/Pages/Events/LoadGenerator.cshtml
+++ b/ServerCore/Pages/Events/LoadGenerator.cshtml
@@ -1,0 +1,36 @@
+﻿@page "/{eventId}/{eventRole}/Events/LoadGenerator"
+@model ServerCore.Pages.Events.LoadGeneratorModel
+@{
+    ViewData["Title"] = "LoadGenerator";
+    ViewData["AdminRoute"] = "/Events/LoadGenerator";
+}
+
+<div>
+    <h2>Load Generator</h2>
+
+    <h3>Notification Load</h3>
+    <form method="post">
+        <dl>
+            <dt>
+                Team
+            </dt>
+            <dd>
+                <select class="form-control" asp-for="NotifyTeamId" asp-items="@(new SelectList(Model.Teams, "ID", "Name"))"></select>
+            </dd>
+            <dt>
+                Number of Notifications
+            </dt>
+            <dd>
+                <input type="text" asp-for="NotifyCount" />
+            </dd>
+            <dt>
+                Notification Spacing (ms)
+            </dt>
+            <dd>
+                <input type="text" asp-for="NotifySpacing" />
+            </dd>
+        </dl>
+
+        <input type="submit" value="Generate Notification Load" class="btn btn-default" />
+    </form>
+</div>

--- a/ServerCore/Pages/Events/LoadGenerator.cshtml.cs
+++ b/ServerCore/Pages/Events/LoadGenerator.cshtml.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+using ServerCore.ServerMessages;
+
+namespace ServerCore.Pages.Events
+{
+    [Authorize(Policy = "IsEventAdmin")]
+    public class LoadGeneratorModel : EventSpecificPageModel
+    {
+        [BindProperty]
+        public int NotifyTeamId { get; set; }
+
+        [BindProperty]
+        public int NotifyCount { get; set; }
+
+        [BindProperty]
+        public int NotifySpacing { get; set; }
+
+        public List<Team> Teams { get; set; }
+
+        private IHubContext<ServerMessageHub> messageHub;
+
+        public LoadGeneratorModel(PuzzleServerContext serverContext, UserManager<IdentityUser> manager, IHubContext<ServerMessageHub> messageHub) : base(serverContext, manager)
+        {
+            this.messageHub = messageHub;
+        }
+
+        public async Task<IActionResult> OnGetAsync(int teamId)
+        {
+            await SetupAsync();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            Team team = await _context.Teams.FindAsync(NotifyTeamId);
+
+            for (int i = 0; i < NotifyCount; i++)
+            {
+                await this.messageHub.SendNotification(team, $"Notification {i + 1} of {NotifyCount}", "Consider yourself notified.");
+                if (NotifySpacing > 0)
+                {
+                    await Task.Delay(NotifySpacing);
+                }
+            }
+
+            await SetupAsync();
+            return Page();
+        }
+
+        private async Task SetupAsync()
+        {
+            Teams = await _context.Teams.Where(t => t.EventID == Event.ID).OrderBy(t => t.Name).ToListAsync();
+        }
+    }
+}


### PR DESCRIPTION
Adds a page that can be used to generate different kinds of event loads - but the only load currently implemented is for notifications.

[Also: I tested notifications locally using this, and I could not replicate the issues seen during Puzzleday. I wonder if the same notifications were somehow being broadcast multiple times...]