### PR TITLE
Add live event schedule display page

### DIFF
--- a/Data/DataModel/Event.cs
+++ b/Data/DataModel/Event.cs
@@ -336,5 +336,11 @@ namespace ServerCore.DataModel
         /// </summary>
         [NotMapped]
         public bool EphemeralHackKillListPresence => EphemeralHacks?.Contains("kill-list-presence") == true;
+
+        /// <summary>
+        /// true if the link to the live events page on the puzzle page should be hidden regardless of live event status
+        /// </summary>
+        [NotMapped]
+        public bool EphemeralHackKillLiveEventPage => EphemeralHacks?.Contains("kill-live-event-page") == true;
     }
 }

--- a/ServerCore/Helpers/LiveEventHelper.cs
+++ b/ServerCore/Helpers/LiveEventHelper.cs
@@ -20,15 +20,15 @@ namespace ServerCore.Helpers
             await EventClosingReminder(context, currentEvent, hubContext);
         }
 
-        public static List<LiveEventSchedule> GetTeamSchedule(PuzzleServerContext context, Event currentEvent, Team team)
+        public static async Task<List<LiveEventSchedule>> GetTeamSchedule(PuzzleServerContext context, Event currentEvent, Team team)
         {
-            var eventSchedule = from schedule in context.LiveEventsSchedule
-                                join liveEvent in context.LiveEvents on schedule.LiveEventId equals liveEvent.ID
-                                join puzzle in context.Puzzles on liveEvent.AssociatedPuzzleId equals puzzle.ID
-                                where puzzle.EventID == currentEvent.ID && schedule.TeamId == team.ID
-                                select schedule;
+            var eventSchedule = await (from schedule in context.LiveEventsSchedule
+                                       join liveEvent in context.LiveEvents on schedule.LiveEventId equals liveEvent.ID
+                                       join puzzle in context.Puzzles on liveEvent.AssociatedPuzzleId equals puzzle.ID
+                                       where puzzle.EventID == currentEvent.ID && schedule.TeamId == team.ID
+                                       select schedule).ToListAsync();
 
-            return eventSchedule.ToList();
+            return eventSchedule;
         }
 
         /// <summary>

--- a/ServerCore/Helpers/LiveEventHelper.cs
+++ b/ServerCore/Helpers/LiveEventHelper.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using ServerCore.DataModel;
 using ServerCore.ServerMessages;
 
@@ -20,6 +18,17 @@ namespace ServerCore.Helpers
             await PreEventReminder(context, currentEvent, timerWindow, hubContext);
             await EventOpeningReminder(context, currentEvent, hubContext);
             await EventClosingReminder(context, currentEvent, hubContext);
+        }
+
+        public static List<LiveEventSchedule> GetTeamSchedule(PuzzleServerContext context, Event currentEvent, Team team)
+        {
+            var eventSchedule = from schedule in context.LiveEventsSchedule
+                                join liveEvent in context.LiveEvents on schedule.LiveEventId equals liveEvent.ID
+                                join puzzle in context.Puzzles on liveEvent.AssociatedPuzzleId equals puzzle.ID
+                                where puzzle.EventID == currentEvent.ID && schedule.TeamId == team.ID
+                                select schedule;
+
+            return eventSchedule.ToList();
         }
 
         /// <summary>
@@ -242,7 +251,7 @@ namespace ServerCore.Helpers
             }
         }
 
-        private static async Task<List<LiveEvent>> GetLiveEventsForEvent(PuzzleServerContext context, Event e, bool scheduledOnly, bool unscheduledOnly)
+        public static async Task<List<LiveEvent>> GetLiveEventsForEvent(PuzzleServerContext context, Event e, bool scheduledOnly, bool unscheduledOnly)
         {
             IQueryable<LiveEvent> liveEvents = from liveEvent in context.LiveEvents
                                                join puzzle in context.Puzzles on liveEvent.AssociatedPuzzleId equals puzzle.ID

--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -73,6 +73,12 @@
 <br />
 
 <h2>Team puzzles</h2>
+
+@if(Model.HasLiveEvents)
+{
+    <a asp-page="/Teams/LiveEventSchedule" asp-route-teamId="@Model.Team.ID">Click Here for the Live Event Schedule</a> <br/> <br/>
+}
+
 @if (Model.Team == null)
 {
     <p>You cannot see team puzzles because you are not yet on a team!<br/>

--- a/ServerCore/Pages/Puzzles/Play.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Play.cshtml.cs
@@ -43,6 +43,8 @@ namespace ServerCore.Pages.Puzzles
 
         public Team Team { get; set; }
 
+        public bool HasLiveEvents { get; set; }
+
         public async Task OnGetAsync(
             SortOrder? teamPuzzleSort,
             SortOrder? singlePlayerPuzzleSort,
@@ -74,6 +76,7 @@ namespace ServerCore.Pages.Puzzles
             VisibleSinglePlayerPuzzleViews = this.GetVisibleSinglePlayerPuzzleViews(singlePlayerPuzzleSort).ToList();
             this.PopulatePuzzleViewsWithFiles(VisibleSinglePlayerPuzzleViews, puzzleFiles, answerFiles);
             AnyErrata = VisibleSinglePlayerPuzzleViews.Any(v => v.Errata != null);
+            HasLiveEvents = LiveEventHelper.GetLiveEventsForEvent(_context, Event, false, false).Result.Any();
 
             Team = await UserEventHelper.GetTeamForPlayer(_context, Event, LoggedInUser);
             if (Team != null)

--- a/ServerCore/Pages/Puzzles/Play.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Play.cshtml.cs
@@ -76,7 +76,11 @@ namespace ServerCore.Pages.Puzzles
             VisibleSinglePlayerPuzzleViews = this.GetVisibleSinglePlayerPuzzleViews(singlePlayerPuzzleSort).ToList();
             this.PopulatePuzzleViewsWithFiles(VisibleSinglePlayerPuzzleViews, puzzleFiles, answerFiles);
             AnyErrata = VisibleSinglePlayerPuzzleViews.Any(v => v.Errata != null);
-            HasLiveEvents = LiveEventHelper.GetLiveEventsForEvent(_context, Event, false, false).Result.Any();
+
+            if (!Event.EphemeralHackKillLiveEventPage)
+            {
+                HasLiveEvents = (await LiveEventHelper.GetLiveEventsForEvent(_context, Event, false, false)).Any();
+            }
 
             Team = await UserEventHelper.GetTeamForPlayer(_context, Event, LoggedInUser);
             if (Team != null)

--- a/ServerCore/Pages/Teams/LiveEventSchedule.cshtml
+++ b/ServerCore/Pages/Teams/LiveEventSchedule.cshtml
@@ -1,0 +1,45 @@
+﻿@page "/{eventId}/{eventRole}/Teams/{teamId}/LiveEventSchedule"
+@model ServerCore.Pages.Teams.LiveEventScheduleModel
+@{
+    ViewData["Title"] = "Live Event Schedule";
+
+    <h2>Event Schedule for @Model.ThisTeam.Name</h2>
+    <p>Live events are activities that take place at a certain time and place. If you do not go to the event during that time you will not be able to get credit for it. If you miss a scheduled slot, please contact us using the help button on the puzzle page and we will see if we can reschedule, but there are no guarantees.</p>
+    <br />
+    <br />
+
+    <h3>Scheduled Events</h3>
+    <p>Your team has been given a specific time for the events listed below, please do not be late!</p>
+    <br />
+
+    @foreach (var item in Model.TeamSchedule)
+    {
+        <div style="margin-left:3%;">
+            <h4><b>@item.LiveEvent.Name</b></h4>
+            <div style="margin-left:2%;">
+                <p><b>Your team's scheduled time is:</b> @Html.Raw(Model.LocalTime(item.StartTimeUtc))</p>
+                <p><b>Go To:</b> @item.LiveEvent.Location</p>
+                <p>@item.LiveEvent.Description</p>
+            </div>
+        </div>
+    }
+
+    <br />
+    <br />
+
+    <h3>Unscheduled Events</h3>
+    <p>The following events are open for a set length of time and you may come anytime while they are open. We recommend coming in the middle for the shortest lines!</p>
+    <br />
+
+    @foreach (var item in Model.UnscheduledLiveEvents)
+    {
+        <div style="margin-left:3%;">
+            <h4><b>@item.Name</b></h4>
+            <div style="margin-left:2%;">
+                <p><b>This event runs between: </b> @Html.Raw(Model.LocalTime(item.EventStartTimeUtc)) and @Html.Raw(Model.LocalTime(@item.EventEndTimeUtc))</p>
+                <p><b>Go To:</b> @item.Location</p>
+                <p>@item.Description</p>
+            </div>
+        </div>
+    }
+}

--- a/ServerCore/Pages/Teams/LiveEventSchedule.cshtml.cs
+++ b/ServerCore/Pages/Teams/LiveEventSchedule.cshtml.cs
@@ -22,7 +22,7 @@ namespace ServerCore.Pages.Teams
         public async Task OnGetAsync()
         {
             ThisTeam = await UserEventHelper.GetTeamForPlayer(_context, Event, LoggedInUser);
-            TeamSchedule = LiveEventHelper.GetTeamSchedule(_context, Event, ThisTeam);
+            TeamSchedule = await LiveEventHelper.GetTeamSchedule(_context, Event, ThisTeam);
             UnscheduledLiveEvents = await LiveEventHelper.GetLiveEventsForEvent(_context, Event, false, true);
         }
     }

--- a/ServerCore/Pages/Teams/LiveEventSchedule.cshtml.cs
+++ b/ServerCore/Pages/Teams/LiveEventSchedule.cshtml.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Teams
+{
+    [Authorize(Policy = "IsEventAdminOrPlayerOnTeam")]
+    public class LiveEventScheduleModel : EventSpecificPageModel
+    {
+        public List<LiveEventSchedule> TeamSchedule { get; set; }
+        public Team ThisTeam { get; set; }
+        public List<LiveEvent> UnscheduledLiveEvents { get; set; }
+
+        public LiveEventScheduleModel(PuzzleServerContext serverContext, UserManager<IdentityUser> manager) : base(serverContext, manager)
+        {
+        }
+
+        public async Task OnGetAsync()
+        {
+            ThisTeam = await UserEventHelper.GetTeamForPlayer(_context, Event, LoggedInUser);
+            TeamSchedule = LiveEventHelper.GetTeamSchedule(_context, Event, ThisTeam);
+            UnscheduledLiveEvents = await LiveEventHelper.GetLiveEventsForEvent(_context, Event, false, true);
+        }
+    }
+}


### PR DESCRIPTION
Add a live event schedule page that shows the schedule for the current team and link it from the puzzles list page.