### PR TITLE
Notification UX Reorg

### DIFF
--- a/ServerCore/Helpers/LiveEventHelper.cs
+++ b/ServerCore/Helpers/LiveEventHelper.cs
@@ -243,11 +243,11 @@ namespace ServerCore.Helpers
         {
             if (team == null)
             {
-                await hubContext.SendNotification(e, title, message, puzzleUrl);
+                await hubContext.SendNotification(e, title, message, puzzleUrl, true);
             }
             else
             {
-                await hubContext.SendNotification(team, title, message, puzzleUrl);
+                await hubContext.SendNotification(team, title, message, puzzleUrl, true);
             }
         }
 

--- a/ServerCore/Helpers/LiveEventHelper.cs
+++ b/ServerCore/Helpers/LiveEventHelper.cs
@@ -243,11 +243,11 @@ namespace ServerCore.Helpers
         {
             if (team == null)
             {
-                await hubContext.SendNotification(e, title, message, puzzleUrl, true);
+                await hubContext.SendNotification(e, title, message, linkUrl: puzzleUrl, isCritical: true);
             }
             else
             {
-                await hubContext.SendNotification(team, title, message, puzzleUrl, true);
+                await hubContext.SendNotification(team, title, message, linkUrl: puzzleUrl, isCritical: true);
             }
         }
 

--- a/ServerCore/Pages/Events/Mailer.cshtml.cs
+++ b/ServerCore/Pages/Events/Mailer.cshtml.cs
@@ -102,11 +102,11 @@ namespace ServerCore.Pages.Events
                 if (TeamID != null)
                 {
                     var team = await _context.Teams.FindAsync(TeamID);
-                    await this.messageHub.SendNotification(team, MailSubject, "Check your email for details.");
+                    await this.messageHub.SendNotification(team, MailSubject, "Check your email for details.", null, true);
                 }
                 else
                 {
-                    await this.messageHub.SendNotification(Event, MailSubject, "Check your email for details.");
+                    await this.messageHub.SendNotification(Event, MailSubject, "Check your email for details.", null, true);
                 }
             }
 

--- a/ServerCore/Pages/Events/Mailer.cshtml.cs
+++ b/ServerCore/Pages/Events/Mailer.cshtml.cs
@@ -102,11 +102,11 @@ namespace ServerCore.Pages.Events
                 if (TeamID != null)
                 {
                     var team = await _context.Teams.FindAsync(TeamID);
-                    await this.messageHub.SendNotification(team, MailSubject, "Check your email for details.", null, true);
+                    await this.messageHub.SendNotification(team, MailSubject, "Check your email for details.", isCritical: true);
                 }
                 else
                 {
-                    await this.messageHub.SendNotification(Event, MailSubject, "Check your email for details.", null, true);
+                    await this.messageHub.SendNotification(Event, MailSubject, "Check your email for details.", isCritical: true);
                 }
             }
 

--- a/ServerCore/Pages/Events/Notifications.cshtml
+++ b/ServerCore/Pages/Events/Notifications.cshtml
@@ -1,0 +1,35 @@
+﻿@page "/{eventId}/{eventRole}/Events/Notifications"
+@model ServerCore.Pages.Events.NotificationsModel
+@{
+    ViewData["Title"] = "Notifications";
+    ViewData["AdminRoute"] = "/Events/Notifications";
+}
+
+<script>
+    newToastCount = 0;
+    localStorage.setItem("userToasts-@(Model.Event.ID)-new", newToastCount);
+    updateToastCount();
+
+    function resetAllPageToasts() {
+        navigator.locks.request("toastStorage", async (lock) => {
+            debugger;
+            var notificationList = document.querySelector("#notification-page-list");
+            notificationList.innerHTML = "";
+            allEventToasts = JSON.parse(localStorage.getItem("userToasts-@(Model.Event.ID)"));
+            if (allEventToasts) { for (const [key, value] of Object.entries(allEventToasts)) { popToast(notificationList, value, false, true); } }
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () { resetAllPageToasts(); });
+    window.addEventListener("focus", function () { if (documentLoaded) { resetAllPageToasts(); } });
+
+    // TODO: delete all?
+    // TODO: update list when new toasts arrive?
+</script>
+<div>
+    <h2>Notifications</h2>
+
+    <div id="notification-page-list" class="toast-container" style="position: relative">
+
+    </div>
+</div>

--- a/ServerCore/Pages/Events/Notifications.cshtml.cs
+++ b/ServerCore/Pages/Events/Notifications.cshtml.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Events
+{
+    public class NotificationsModel : EventSpecificPageModel
+    {
+        public NotificationsModel(PuzzleServerContext serverContext, UserManager<IdentityUser> manager) : base(serverContext, manager)
+        {
+        }
+
+        public IActionResult OnGet(int teamId)
+        {
+            return Page();
+        }
+    }
+}

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -392,6 +392,10 @@
 
             let toast = new bootstrap.Toast(notificationList.firstElementChild, { animation: animate, autohide: !isPageView && !notification.isCritical });
             toast.show();
+
+            if (notificationList.children.length > 5) {
+                bootstrap.Toast.getInstance(notificationList.lastElementChild).hide();
+            }
         }
 
         function updateToastCount() {

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -35,6 +35,14 @@
                 </button>
             </div>
 
+            @if (Event?.AllowBlazor == true && Event?.EphemeralHackKillNotifications != true)
+            {
+                <a class="nav-link position-relative" asp-page="/Events/Notifications">
+                    <span class="fab text-white">✉️</span>
+                    <span id="unreadCounter" class="position-absolute hidden top-0 start-50 translate-middle badge rounded-pill bg-danger">1</span>
+                </a>
+            }
+
             <div class="collapse navbar-collapse" id="topBarCollapsable">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
@@ -112,6 +120,14 @@
                 </button>
             </div>
 
+            @if (Event?.AllowBlazor == true && Event?.EphemeralHackKillNotifications != true)
+            {
+                <a class="nav-link position-relative" asp-page="/Events/Notifications">
+                    <span class="fab text-white">✉️</span>
+                    <span id="unreadCounter" class="position-absolute hidden top-0 start-50 translate-middle badge rounded-pill bg-danger">1</span>
+                </a>
+            }
+
             <div class="collapse navbar-collapse" id="topBarCollapsable">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item"><a asp-page="/EventSpecific/Index">Event</a></li>
@@ -167,6 +183,14 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
             </div>
+
+            @if (Event?.AllowBlazor == true && Event?.EphemeralHackKillNotifications != true)
+            {
+                <a class="nav-link position-relative" asp-page="/Events/Notifications">
+                    <span class="fab text-white">✉️</span>
+                    <span id="unreadCounter" class="position-absolute hidden top-0 start-50 translate-middle badge rounded-pill bg-danger">1</span>
+                </a>
+            }
 
             <div class="collapse navbar-collapse" id="topBarCollapsable">
                 <ul class="navbar-nav me-auto">
@@ -339,10 +363,11 @@
 {
     <script>
         var allEventToasts = {};
+        var criticalEventToasts = {};
+        var newToastCount = 0;
         var documentLoaded = false;
 
-        function popToast(notification, animate) {
-            let notificationList = document.querySelector("#notification-list");
+        function popToast(notificationList, notification, animate, isPageView) {
             notificationList.insertAdjacentHTML("afterbegin", `\
                     <div class='toast' role='alert' data-bs-dismiss='toast' aria-live='assertive' aria-atomic='true'> \
                         <div class='toast-header'> \
@@ -359,28 +384,43 @@
 
             if (notification.linkUrl) {
                 notificationList.firstElementChild.querySelector("a").addEventListener("click", (e) => {
-                    onDismissUserToast(notification.id);
+                    onDismissUserToast(notification.id, isPageView);
                 });
             }
 
-            notificationList.firstElementChild.addEventListener('hidden.bs.toast', () => { onDismissUserToast(notification.id); });
+            notificationList.firstElementChild.addEventListener('hidden.bs.toast', () => { onDismissUserToast(notification.id, isPageView); });
 
-            let toast = new bootstrap.Toast(notificationList.firstElementChild, { animation: animate, autohide: false });
+            let toast = new bootstrap.Toast(notificationList.firstElementChild, { animation: animate, autohide: !isPageView && !notification.isCritical });
             toast.show();
         }
 
-        function onDismissUserToast(id) {
+        function updateToastCount() {
+            if (newToastCount) { unreadCounter.classList.remove("hidden"); unreadCounter.innerHTML = newToastCount; }
+            else { unreadCounter.classList.add("hidden"); }
+        }
+
+        function onDismissUserToast(id, isPageView) {
             navigator.locks.request("toastStorage", async (lock) => {
-                delete allEventToasts[id];
-                localStorage.setItem("userToasts-@(Model.Event.ID)", JSON.stringify(allEventToasts));
+                if (criticalEventToasts[id]) {
+                    delete criticalEventToasts[id];
+                    localStorage.setItem("userToasts-@(Model.Event.ID)-critical", JSON.stringify(criticalEventToasts));
+                }
+                if (isPageView) {
+                    delete allEventToasts[id];
+                    localStorage.setItem("userToasts-@(Model.Event.ID)", JSON.stringify(allEventToasts));
+                }
             });
         }
 
         function resetAllToasts() {
             navigator.locks.request("toastStorage", async (lock) => {
-                document.querySelector("#notification-list").innerHTML = "";
-                allEventToasts = JSON.parse(localStorage.getItem("userToasts-@(Model.Event.ID)"));
-                if (allEventToasts) { for (const [key, value] of Object.entries(allEventToasts)) { popToast(value, false); } }
+                var notificationList = document.querySelector("#notification-list");
+                notificationList.innerHTML = "";
+                criticalEventToasts = JSON.parse(localStorage.getItem("userToasts-@(Model.Event.ID)-critical"));
+                if (criticalEventToasts) { for (const [key, value] of Object.entries(criticalEventToasts)) { popToast(notificationList, value, false, false); } }
+                newToastCount = localStorage.getItem("userToasts-@(Model.Event.ID)-new");
+                newToastCount = newToastCount ? parseInt(newToastCount) : 0;
+                updateToastCount();
             });
         }
 
@@ -388,9 +428,24 @@
             navigator.locks.request("toastStorage", async (lock) => {
                 allEventToasts = JSON.parse(localStorage.getItem("userToasts-@(Model.Event.ID)"));
                 if (!allEventToasts) { allEventToasts = {}; }
-                allEventToasts[notification.id] = notification;
-                localStorage.setItem("userToasts-@(Model.Event.ID)", JSON.stringify(allEventToasts));
-                popToast(notification, true);
+                if (!allEventToasts[notification.id]) {
+                    allEventToasts[notification.id] = notification;
+                    localStorage.setItem("userToasts-@(Model.Event.ID)", JSON.stringify(allEventToasts));
+                    newToastCount = localStorage.getItem("userToasts-@(Model.Event.ID)-new");
+                    newToastCount = newToastCount ? parseInt(newToastCount) : 0;
+                    newToastCount++;
+                    localStorage.setItem("userToasts-@(Model.Event.ID)-new", newToastCount);
+                }
+
+                if (notification.isCritical) {
+                    criticalEventToasts = JSON.parse(localStorage.getItem("userToasts-@(Model.Event.ID)-critical"));
+                    if (!criticalEventToasts) { criticalEventToasts = {}; }
+                    criticalEventToasts[notification.id] = notification;
+                    localStorage.setItem("userToasts-@(Model.Event.ID)-critical", JSON.stringify(criticalEventToasts));
+                }
+
+                popToast(document.querySelector("#notification-list"), notification, true, false);
+                updateToastCount();
             });
         };
 

--- a/ServerCore/ServerMessages/ServerMessageHub.cs
+++ b/ServerCore/ServerMessages/ServerMessageHub.cs
@@ -45,9 +45,9 @@ namespace ServerCore.ServerMessages
         /// <param name="title">Notification title</param>
         /// <param name="content">Notification content</param>
         /// <param name="linkUrl">Link for the notification if the player clicks it</param>
-        public static async Task SendNotification(this IHubContext<ServerMessageHub> hub, Event eventObj, string title, string content, string linkUrl = null)
+        public static async Task SendNotification(this IHubContext<ServerMessageHub> hub, Event eventObj, string title, string content, string linkUrl = null, bool isCritical = false)
         {
-            await hub.Clients.Groups(ServersGroup).SendAsync(nameof(Notification), new Notification() { Time = DateTime.UtcNow, EventID = eventObj.ID, Title = title, Content = content, LinkUrl = linkUrl });
+            await hub.Clients.Groups(ServersGroup).SendAsync(nameof(Notification), new Notification() { Time = DateTime.UtcNow, EventID = eventObj.ID, Title = title, Content = content, LinkUrl = linkUrl, IsCritical = isCritical });
         }
 
         /// <summary>
@@ -57,9 +57,9 @@ namespace ServerCore.ServerMessages
         /// <param name="title">Notification title</param>
         /// <param name="content">Notification content</param>
         /// <param name="linkUrl">Link for the notification if the player clicks it</param>
-        public static async Task SendNotification(this IHubContext<ServerMessageHub> hub, Team team, string title, string content, string linkUrl = null)
+        public static async Task SendNotification(this IHubContext<ServerMessageHub> hub, Team team, string title, string content, string linkUrl = null, bool isCritical = false)
         {
-            await hub.Clients.Groups(ServersGroup).SendAsync(nameof(Notification), new Notification() { Time = DateTime.UtcNow, TeamID = team.ID, Title = title, Content = content, LinkUrl = linkUrl });
+            await hub.Clients.Groups(ServersGroup).SendAsync(nameof(Notification), new Notification() { Time = DateTime.UtcNow, TeamID = team.ID, Title = title, Content = content, LinkUrl = linkUrl, IsCritical = isCritical });
         }
 
         /// <summary>
@@ -69,9 +69,9 @@ namespace ServerCore.ServerMessages
         /// <param name="title">Notification title</param>
         /// <param name="content">Notification content</param>
         /// <param name="linkUrl">Link for the notification if the player clicks it</param>
-        public static async Task SendNotification(this IHubContext<ServerMessageHub> hub, PuzzleUser user, string title, string content, string linkUrl = null)
+        public static async Task SendNotification(this IHubContext<ServerMessageHub> hub, PuzzleUser user, string title, string content, string linkUrl = null, bool isCritical = false)
         {
-            await hub.Clients.Groups(ServersGroup).SendAsync(nameof(Notification), new Notification() { Time = DateTime.UtcNow, UserID = user.ID, Title = title, Content = content, LinkUrl = linkUrl });
+            await hub.Clients.Groups(ServersGroup).SendAsync(nameof(Notification), new Notification() { Time = DateTime.UtcNow, UserID = user.ID, Title = title, Content = content, LinkUrl = linkUrl, IsCritical = isCritical });
         }
     }
 }

--- a/ServerCore/ServerMessages/ServerMessageTypes.cs
+++ b/ServerCore/ServerMessages/ServerMessageTypes.cs
@@ -107,4 +107,9 @@ public class Notification
     /// The link that should be followed if the notification is clicked.
     /// </summary>
     public string LinkUrl { get; set; }
+
+    /// <summary>
+    /// Says whether the notification is so critical that it should not disappear automatically
+    /// </summary>
+    public bool IsCritical { get; set; }
 }


### PR DESCRIPTION
Revising the UX for notifications to try to make it more palatable.

Changes:
- a new envelope icon has been added to the toolbar that also displays a count of new notifications.
- clicking the envelope icon takes you to a new page that lists all notifications and resets the new-notification count. Notifications can be permanently deleted from this page.
- Notifications are by default ephemeral, meaning they display onscreen for five seconds and then disappear (and be viewed later by clicking the envelope).
- Notifications can also be marked as critical, meaning that they do always stay up until manually dismissed.
- Two types of notifications have been marked as critical: direct emails from staff (bulk mail, not help thread responses), and upcoming live event warnings.

Other than the marking of notifications as critical, no other changes have been made to the model; other improvements might be possible by moving the storage location for notifications to the server.