### PR TITLE
Author Column in Help Thread List

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -142,9 +142,9 @@
                     <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.PuzzleID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID">@item.Subject</a>
                 </td>
                 <td>
-                    @if (@item.PuzzleID != null)
+                    @if (@item.PuzzleID.HasValue)
                     {
-                        @Model.AuthorsForPuzzleID[item.PuzzleID ?? 0]
+                        @Model.AuthorsForPuzzleID[item.PuzzleID.Value]
                     }
                 </td>
                 <td>

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -115,6 +115,9 @@
                 Thread
             </th>
             <th>
+                Author(s)
+            </th>
+            <th>
                 Timestamp
             </th>
             <th>
@@ -137,6 +140,12 @@
                 }
                 <td>
                     <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.PuzzleID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID">@item.Subject</a>
+                </td>
+                <td>
+                    @if (@item.PuzzleID != null)
+                    {
+                        @Model.AuthorsForPuzzleID[item.PuzzleID ?? 0]
+                    }
                 </td>
                 <td>
                     @Html.Raw(Model.LocalTime(@item.CreatedDateTimeInUtc))

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
@@ -175,10 +175,13 @@ namespace ServerCore.Pages.Threads
             AuthorsForPuzzleID = new Dictionary<int, string>();
 
             foreach (var message in LatestMessagesFromEachThread)
-            { 
-                IEnumerable<string> authorsForPuzzle = puzzleAuthors[message.PuzzleID ?? 0];
-                var authorList = authorsForPuzzle != null ? string.Join(", ", authorsForPuzzle) : "";
-                AuthorsForPuzzleID.Add(message.PuzzleID ?? 0, authorList);
+            {
+                if (message.PuzzleID.HasValue)
+                {
+                    IEnumerable<string> authorsForPuzzle = puzzleAuthors[message.PuzzleID.Value];
+                    string authorList = authorsForPuzzle != null ? string.Join(", ", authorsForPuzzle) : "";
+                    AuthorsForPuzzleID.Add(message.PuzzleID.Value, authorList);
+                }
             }
 
             return Page();


### PR DESCRIPTION
This adds a concatenated list of puzzle authors to the page of help threads.  

Context on the request here: [Feature request: ability to see puzzle authors from help thread list. #1062](https://github.com/PuzzleServer/mainpuzzleserver/issues/1062)

I chose the list of Authors instead of the CustomAuthorText field on the puzzle, since that seemed to be the standard for the admin views.  Please let me know if that was the wrong call (it's much less code to use the CustomAuthorText field).  I also chose to put it as the middle column to allow the most urgent information to remain easily scannable (though I am far from an expert at what the users of this page need!)

Example below, including testing that it still works if no Authors are returned:
![image](https://github.com/user-attachments/assets/29ef3545-9f93-45bd-a46c-c030b626f530)

