### PR TITLE
Registration Page Spaces and Button Styling

### DIFF
--- a/Data/DataModel/PuzzleUser.cs
+++ b/Data/DataModel/PuzzleUser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
@@ -31,6 +32,7 @@ namespace ServerCore.DataModel
 
         [PersonalData]
         [MaxLength(50)]
+        [DisplayName("Employee Alias")]
         public string EmployeeAlias { get; set; }
 
         [PersonalData]
@@ -42,10 +44,15 @@ namespace ServerCore.DataModel
         [PersonalData]
         [Phone]
         [MaxLength(20)]
+        [DisplayName("Phone Number")]
         public string PhoneNumber { get; set; }
+
         [PersonalData]
         [MaxLength(20)]
+        [DisplayName("T-shirt Size")]
         public string TShirtSize { get; set; }
+
+        [DisplayName("Visible To Others")]
         public bool VisibleToOthers { get; set; }
 
         /// <summary>

--- a/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml
+++ b/ServerCore/Areas/Identity/Pages/Account/ExternalLogin.cshtml
@@ -41,12 +41,12 @@
             </div>
             <div class="form-group">
                 <label asp-for="Input.VisibleToOthers"></label>
-                <input asp-for="Input.VisibleToOthers" class="form-control" />
+                <input asp-for="Input.VisibleToOthers" class="checkbox" />
                 <span asp-validation-for="Input.VisibleToOthers" class="text-danger"></span>
             </div>
             @* NOTE: If you add more properties here, please add them to Edit.cshtml as well! *@
             <input type="hidden" asp-for="Input.IdentityUserId" />
-            <button type="submit" class="btn btn-default">Register</button>
+            <button type="submit">Register</button>
         </form>
     </div>
 </div>


### PR DESCRIPTION
[[UI] Registration page not have spaces and other UI issues #1094](https://github.com/PuzzleServer/mainpuzzleserver/issues/1094)

This issue mentions 3 separate things to fix:

1. **No spaces in labels** 
For this one, I added DisplayName to the fields which should have spaces in their names.  I didn't add it to the ones where the DisplayName field would be identical to the variable name, but I can see value in doing that for consistency if preferred!

2. **Visible to others doesn't show** 
It appears to me that this is supposed to be a checkbox type.

3. **Register doesn't look like a button** 
Removed specific button class (same fix was made [in this PR](https://github.com/PuzzleServer/mainpuzzleserver/pull/972/files) for Login.cshtml)

Screenshots of before/after (apologies for the slightly differing window sizes)

Before:
![image](https://github.com/user-attachments/assets/1f9959d2-418b-4225-99cc-034cec248f59)


After:
![image](https://github.com/user-attachments/assets/85b191c2-113c-4582-b640-ad2d1f06a4cc)

