### PR TITLE
Allow edit of hint coin cost for threads

### DIFF
--- a/ServerCore/Pages/Events/Create.cshtml
+++ b/ServerCore/Pages/Events/Create.cshtml
@@ -211,6 +211,11 @@
             </div>
             <div class="description-column">Hides the link for players to view hints and authors to manage hints. Also hides hint statistics from the event standings.</div>
             <div class="form-group">
+                <label asp-for="Event.DefaultCostForHelpThread"></label>
+                <input asp-for="Event.DefaultCostForHelpThread" />
+            </div>
+            <div class="description-column">When hints are not hidden, players will need this number of hint coins to unlock help threads for a puzzle (individual puzzles can override this). Note that if you set this to -1, no help threads will be available.</div>
+            <div class="form-group">
                 <label asp-for="Event.AllowFeedback"></label>
                 <input asp-for="Event.AllowFeedback" />
             </div>

--- a/ServerCore/Pages/Events/Delete.cshtml
+++ b/ServerCore/Pages/Events/Delete.cshtml
@@ -174,6 +174,12 @@
         @Model.Event.HideHints
     </div>
     <div>
+        DefaultCostForHelpThread
+    </div>
+    <div>
+        @Model.Event.DefaultCostForHelpThread
+    </div>
+    <div>
         AllowFeedback
     </div>
     <div>

--- a/ServerCore/Pages/Events/Details.cshtml
+++ b/ServerCore/Pages/Events/Details.cshtml
@@ -172,6 +172,12 @@
         @Model.Event.HideHints
     </div>
     <div>
+        DefaultCostForHelpThread
+    </div>
+    <div>
+        @Model.Event.DefaultCostForHelpThread
+    </div>
+    <div>
         AllowFeedback
     </div>
     <div>

--- a/ServerCore/Pages/Events/Edit.cshtml
+++ b/ServerCore/Pages/Events/Edit.cshtml
@@ -223,6 +223,11 @@
             </div>
             <div class="description-column">Hides the link for players to view hints and authors to manage hints. Also hides hint statistics from the event standings.</div>
             <div class="form-group">
+                <label asp-for="EditableEvent.DefaultCostForHelpThread"></label>
+                <input asp-for="EditableEvent.DefaultCostForHelpThread" />
+            </div>
+            <div class="description-column">When hints are not hidden, players will need this number of hint coins to unlock help threads for a puzzle (individual puzzles can override this). Note that if you set this to -1, no help threads will be available.</div>
+            <div class="form-group">
                 <label asp-for="EditableEvent.AllowFeedback"></label>
                 <input asp-for="EditableEvent.AllowFeedback" />
             </div>

--- a/ServerCore/Pages/Puzzles/Edit.cshtml
+++ b/ServerCore/Pages/Puzzles/Edit.cshtml
@@ -159,6 +159,11 @@
                                     <input asp-for="Puzzle.HintCoinsForSolve" class="form-control" />
                                     <span asp-validation-for="Puzzle.HintCoinsForSolve" class="text-danger"></span>
                                 </div>
+                                <div class="form-group">
+                                    <label asp-for="Puzzle.CostForHelpThread" class="control-label"></label>
+                                    <input asp-for="Puzzle.CostForHelpThread" class="form-control" />
+                                    <span asp-validation-for="Puzzle.CostForHelpThread" class="text-danger"></span>
+                                </div>
                             }
                             <div class="form-group">
                                 <label asp-for="Puzzle.Token" class="control-label"></label>

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -403,24 +403,22 @@
         </div>
     }
 
-    @if (!Model.PuzzleState.IsEmailOnlyMode)
+    @if (!Model.Event.HideHints)
     {
         <h3>Need some help?</h3>
-        @if (!Model.Event.HideHints)
+        if (Model.Puzzle.IsForSinglePlayer)
         {
-            if (Model.Puzzle.IsForSinglePlayer)
-            {
-                <p><a asp-page="/Puzzles/SinglePlayerPuzzleHints" asp-route-puzzleid="Model.Puzzle.ID" target="_blank">Click this link</a> to access hints for this puzzle.</p>
-            }
-            else
-            {
-                <p><a asp-page="/Teams/Hints" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team.ID" target="_blank">Click this link</a> to access hints for this puzzle.</p>
-            }
+            <p><a asp-page="/Puzzles/SinglePlayerPuzzleHints" asp-route-puzzleid="Model.Puzzle.ID" target="_blank">Click this link</a> to access hints for this puzzle.</p>
         }
         else
         {
-            <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to ask for help!</a></p>
+            <p><a asp-page="/Teams/Hints" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team.ID" target="_blank">Click this link</a> to access hints for this puzzle.</p>
         }
+    }
+    else if (!Model.PuzzleState.IsEmailOnlyMode)
+    {
+        <h3>Need some help?</h3>
+        <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to ask for help!</a></p>
     }
 
     @if (Model.Event.AllowFeedback)

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -406,7 +406,21 @@
     @if (!Model.PuzzleState.IsEmailOnlyMode)
     {
         <h3>Need some help?</h3>
-        <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to ask for help!</a></p>
+        @if (!Model.Event.HideHints)
+        {
+            if (Model.Puzzle.IsForSinglePlayer)
+            {
+                <p><a asp-page="/Puzzles/SinglePlayerPuzzleHints" asp-route-puzzleid="Model.Puzzle.ID" target="_blank">Click this link</a> to access hints for this puzzle.</p>
+            }
+            else
+            {
+                <p><a asp-page="/Teams/Hints" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team.ID" target="_blank">Click this link</a> to access hints for this puzzle.</p>
+            }
+        }
+        else
+        {
+            <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to ask for help!</a></p>
+        }
     }
 
     @if (Model.Event.AllowFeedback)


### PR DESCRIPTION
#974

This is part 2/3 PRs to implement this feature.
This PR focuses on allowing edits to the number of hint coins needed to unlock a help thread.

## Event create page
![image](https://github.com/user-attachments/assets/6e821f21-fbbb-4526-b7cf-4a0c6feea160)

## Event details page
![image](https://github.com/user-attachments/assets/a92d94e7-c7bf-4932-a02b-4a811ac5df69)

### Event edit page
![image](https://github.com/user-attachments/assets/a41843b8-fd4a-4863-89a8-9fe825466268)

## Event delete page
![image](https://github.com/user-attachments/assets/5fef9c9f-02ff-4143-aedd-46c1bbdb2a7c)

## Puzzle edit page
![image](https://github.com/user-attachments/assets/2aab685b-de2a-4d14-802e-8c98c5947938)

## Non-embeded puzzle player view
![image](https://github.com/user-attachments/assets/2618717b-6607-42ab-b086-104d9d59798e)

