### PR TITLE
Update help thread delete and don't send mail in intern events

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml
@@ -112,7 +112,14 @@
             </div>
         }
         <div id="MessageText_@message.ID">
-            <p class="message-main-content" style="white-space: pre-wrap;">@message.Text</p>
+            @if (message.Text == PuzzleThreadModel.DeletedMessage)
+            {
+                <p class="message-main-content" style="white-space: pre-wrap;"><i>@message.Text</i></p>
+            }
+            else
+            {
+                <p class="message-main-content" style="white-space: pre-wrap;">@message.Text</p>
+            }
             <span>
                 @if (isAllowedToEditMessage)
                 {

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -254,7 +254,8 @@ namespace ServerCore.Pages.Threads
                 }
             }
 
-            if (isMessageAdded)
+            // We don't really want to send an email non-module events because they are often already watching the site
+            if (isMessageAdded && !Event.IsInternEvent)
             {
                 await this.SendEmailNotifications(m, puzzle);
             }


### PR DESCRIPTION
#1069 - don't send mail in non-module events (don't have a flag for it so used the intern flag instead)
#1061 - instead of deleting a message, replace it with a "Deleted" message
![image](https://github.com/user-attachments/assets/89c2d787-3159-476c-a94f-f08e0ee87179)
