### PR TITLE
Notification updates

### DIFF
--- a/ServerCore/Pages/Events/Edit.cshtml.cs
+++ b/ServerCore/Pages/Events/Edit.cshtml.cs
@@ -2,24 +2,29 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
 using ServerCore.DataModel;
 using ServerCore.ModelBases;
+using ServerCore.ServerMessages;
 
 namespace ServerCore.Pages.Events
 {
     [Authorize(Policy = "IsEventAdmin")]
     public class EditModel : EventSpecificPageModel
     {
-        public EditModel(PuzzleServerContext context, UserManager<IdentityUser> userManager) : base(context, userManager)
+        private IHubContext<ServerMessageHub> messageHub;
+
+        public EditModel(PuzzleServerContext context, UserManager<IdentityUser> userManager, IHubContext<ServerMessageHub> messageHub) : base(context, userManager)
         {
+            this.messageHub = messageHub;
         }
 
         // Admittedly unusual pattern, with the noble purpose of putting the [BindProperty] attribute on here without leaving it permanently on for every page.
         // Note that naming this property "Event" and using the "new" keyword was sadly insufficient.
         [BindProperty]
         public Event EditableEvent { get; set; }
-
 
         public IActionResult OnGet(int id)
         {
@@ -32,6 +37,11 @@ namespace ServerCore.Pages.Events
             if (!ModelState.IsValid)
             {
                 return Page();
+            }
+
+            if (!string.IsNullOrEmpty(EditableEvent.Announcement) && EditableEvent.Announcement != Event.Announcement)
+            {
+                await this.messageHub.SendNotification(Event, "Announcement", EditableEvent.Announcement, isCritical: true);
             }
 
             // not using attach here because Event is already attached

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -399,6 +399,9 @@
         }
 
         function updateToastCount() {
+            var unreadCounter = document.querySelector("#unreadCounter");
+            if (!unreadCounter) return;
+
             if (newToastCount) { unreadCounter.classList.remove("hidden"); unreadCounter.innerHTML = newToastCount; }
             else { unreadCounter.classList.add("hidden"); }
         }

--- a/ServerCore/Pages/Teams/Create.cshtml.cs
+++ b/ServerCore/Pages/Teams/Create.cshtml.cs
@@ -70,7 +70,7 @@ namespace ServerCore.Pages.Teams
                 return NotFound();
             }
 
-            if (await (from member in _context.TeamMembers
+            if (EventRole != EventRole.admin && await (from member in _context.TeamMembers
                        where member.Member == LoggedInUser &&
                        member.Team.Event == Event
                        select member).AnyAsync())


### PR DESCRIPTION
Send notifications when TeamAnnouncement is triggered, or when Announcement is changed. This way, players who are sticking on one page for a while (e.g. solving a puzzle) will still have an opportunity to see notifications.

Bonus fixes:
- A JS notification exception with unregistered players has been fixed.
- Admins can add new (empty) teams even if they are already on another team.

Fixes #1059.
Fixes #1078.