### PR TITLE
Handle Login Drift

### DIFF
--- a/ServerCore/Startup.cs
+++ b/ServerCore/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -149,6 +150,13 @@ namespace ServerCore
             services.AddSingleton<ServerMessageListener>();
             services.AddSingleton<PresenceStore>();
             services.AddSingleton<NotificationHelper>();
+
+            // Require emails to be unique so that we can be resilient to external provider login changes.
+            // Search the codebase for "RequireUniqueEmail" for the code that requires this.
+            services.Configure<IdentityOptions>(options =>
+            {
+                options.User.RequireUniqueEmail = true;
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
For years, we've been beset by a small number of users losing access to their accounts, needing manual reset at extremely inopportune times.

After a good deal of code review and web searching, I've finally discovered that a) this is normal and b) there is a simple bit of code that can be used for automatic and instantaneous account recovery.

I've tested this by mangling my local DB ProviderKey values, and observing that it successfully self-heals with the user being none the wiser.

Fixes #1073, though does it in a better way than expected.