### PR TITLE
Thread Tweaks

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -362,7 +362,7 @@ namespace ServerCore.Pages.Threads
         {
             // Send a notification email to further alert both authors and players.
             string emailTitle = $"{newMessage.Subject} thread update!";
-            string emailContent = "You have an update on your help message thread.";
+            string emailContent = newMessage.Text;
             string toastTitle = $"Help message from {(newMessage.IsFromGameControl ? "Game Control" : newMessage.Sender.Name)}";
             string toastContent = $"{newMessage.Subject}";
             string threadUrlSuffix = $"Threads/PuzzleThread/{newMessage.PuzzleID}?teamId={newMessage.TeamID}&playerId={newMessage.PlayerID}";

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
@@ -188,7 +188,7 @@ namespace ServerCore.Pages.Threads
                 {
                     IEnumerable<string> authorsForPuzzle = puzzleAuthors[message.PuzzleID.Value];
                     string authorList = authorsForPuzzle != null ? string.Join(", ", authorsForPuzzle) : "";
-                    AuthorsForPuzzleID.Add(message.PuzzleID.Value, authorList);
+                    AuthorsForPuzzleID[message.PuzzleID.Value] = authorList;
                 }
             }
 


### PR DESCRIPTION
- major issue: When an author has more than one thread, AuthorsForPuzzleID.Add() was crashing because the entry had already been added. Changing to a pattern that does the same thing minus the exceptions.

- minor issue: When thread messages are rare, it's inconvenient to get mail saying to check the site, when the mail could just as easily have the actual message. I assume that players feel the same way about answers to their questions.