### PR TITLE
File Upload Enhancements

### DIFF
--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml
@@ -37,7 +37,7 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Puzzle.ID" />
             <p>
-                <input type="checkbox" asp-for="ExpandZipFiles" />
+                <input type="checkbox" asp-for="ExpandZipFiles" checked />
                 &lt;- Check this box to automatically extract the contents of zip files in materials or solve tokens into the same directory.
             </p>
             <p>

--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml.cs
@@ -297,7 +297,7 @@ namespace ServerCore.Pages.Puzzles
             // - the file is not named index.html
             // - the file is not a material or solution file
             // - the appropriate Custom[Solution]URL is non-blank
-            if (!file.ShortName.EndsWith("index.html") ||
+            if (Path.GetFileName(file.ShortName).ToLower() != "index.html" ||
                 !(file.FileType == ContentFileType.PuzzleMaterial || file.FileType == ContentFileType.SolveToken) || 
                 (file.FileType == ContentFileType.PuzzleMaterial && !string.IsNullOrEmpty(Puzzle.CustomURL)) ||
                 (file.FileType == ContentFileType.SolveToken && !string.IsNullOrEmpty(Puzzle.CustomSolutionURL)))

--- a/ServerCore/Pages/Puzzles/ResourceManagement.cshtml
+++ b/ServerCore/Pages/Puzzles/ResourceManagement.cshtml
@@ -34,7 +34,7 @@
         <form method="post" enctype="multipart/form-data">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <p>
-                <input type="checkbox" asp-for="ExpandZipFiles" />
+                <input type="checkbox" asp-for="ExpandZipFiles" checked />
                 &lt;- Check this box to automatically extract the contents of zip files in materials or solve tokens into the same directory.
             </p>
             <p>


### PR DESCRIPTION
Removing some user busywork!

- Zip checkbox is now checked by default - when was the last time we wanted to upload a zip as a single file?
- If any file in the upload is named "index.html", fill that in as the Custom[Solution]URL (unless there's already a value there, in case that value has custom args etc)