### PR TITLE
Migrate to the Azure.Storage.Blobs API

### DIFF
--- a/ServerCore/FileManager.cs
+++ b/ServerCore/FileManager.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Microsoft.AspNetCore.StaticFiles;
-using Microsoft.CodeAnalysis.Elfie.Model.Strings;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
 using ServerCore.DataModel;
 
 namespace ServerCore
@@ -29,9 +27,23 @@ namespace ServerCore
         /// <returns>Url of the file in blob storage</returns>
         public static async Task<Uri> UploadBlobAsync(string fileName, int eventId, Stream contents, string specificDirectory = null)
         {
-            CloudBlockBlob blob = await CreateNewBlob(fileName, eventId, specificDirectory ?? GetRandomDirectoryName());
+            BlobContainerClient containerClient = await GetOrCreateEventContainerAsync(eventId);
+            string directory = specificDirectory ?? GetRandomDirectoryName();
+            string blobPath = $"{directory}/{fileName}";
 
-            await blob.UploadFromStreamAsync(contents);
+            return await UploadBlobToContainerAsync(fileName, contents, containerClient, blobPath);
+        }
+
+        private static async Task<Uri> UploadBlobToContainerAsync(string fileName, Stream contents, BlobContainerClient containerClient, string blobPath)
+        {
+            BlobClient blob = containerClient.GetBlobClient(blobPath);
+            await blob.UploadAsync(contents);
+
+            if (fileExtensionProvider.TryGetContentType(fileName, out string contentType))
+            {
+                await blob.SetHttpHeadersAsync(new BlobHttpHeaders() { ContentType = contentType });
+            }
+
             return blob.Uri;
         }
 
@@ -44,14 +56,11 @@ namespace ServerCore
         /// <returns>Url of the file in blob storage</returns>
         public static async Task<Uri> CloneBlobAsync(string fileName, int eventId, Uri sourceUri)
         {
-            CloudBlockBlob blobSource = new CloudBlockBlob(sourceUri, StorageAccount.Credentials);
-            Uri sourceContainerUri = new Uri(blobSource.Container.Uri.ToString() + "/");
-            Uri relativeUri = sourceContainerUri.MakeRelativeUri(sourceUri);
-            string newFileName = relativeUri.ToString();
-            CloudBlockBlob blob = await CreateNewBlob(newFileName, eventId, "");
-            await blob.StartCopyAsync(blobSource);
+            BlobUriBuilder uriBuilder = new BlobUriBuilder(sourceUri);
+            BlobClient destinationBlob = new BlobClient(ConnectionString, $"evt{eventId}", uriBuilder.BlobName);
+            await destinationBlob.StartCopyFromUriAsync(sourceUri);
 
-            return blob.Uri;
+            return destinationBlob.Uri;
         }
 
         /// <summary>
@@ -62,37 +71,18 @@ namespace ServerCore
         /// <returns>The names and URIs of all the files in the directory.</returns>
         public static async Task<List<DirectoryFileResult>> GetDirectoryContents(int eventId, string directoryName)
         {
-            CloudBlobDirectory directory = await GetPuzzleDirectoryAsync(eventId, directoryName);
-
-            BlobContinuationToken continuationToken = null;
             List<DirectoryFileResult> results = new List<DirectoryFileResult>();
-            do
+            BlobContainerClient eventContainer = await GetOrCreateEventContainerAsync(eventId);
+            var blobs = eventContainer.GetBlobsByHierarchyAsync(prefix: directoryName);
+            await foreach(var blob in blobs)
             {
-                bool useFlatBlobListing = true;
-                BlobListingDetails blobListingDetails = BlobListingDetails.None;
-                int maxBlobsPerRequest = 500;
-                var response = await directory.ListBlobsSegmentedAsync(useFlatBlobListing, blobListingDetails, maxBlobsPerRequest, continuationToken, null, null);
-                continuationToken = response.ContinuationToken;
-                foreach (var result in response.Results)
-                {
-                    results.Add(new DirectoryFileResult() {  Name = (result as CloudBlockBlob)?.Name, Uri = result.Uri });
-                }
+                BlobUriBuilder uriBuilder = new BlobUriBuilder(eventContainer.Uri);
+                uriBuilder.BlobName = blob.Blob.Name;
+                
+                results.Add(new DirectoryFileResult() { Name = blob.Blob.Name, Uri = uriBuilder.ToUri() });
             }
-            while (continuationToken != null);
+
             return results;
-        }
-
-        private static async Task<CloudBlockBlob> CreateNewBlob(string fileName, int eventId, string puzzleDirectoryName)
-        {
-            CloudBlobDirectory puzzleDirectory = await GetPuzzleDirectoryAsync(eventId, puzzleDirectoryName);
-
-            CloudBlockBlob blob = puzzleDirectory.GetBlockBlobReference(fileName);
-            if (fileExtensionProvider.TryGetContentType(fileName, out string contentType))
-            {
-                blob.Properties.ContentType = contentType;
-            }
-
-            return blob;
         }
 
         /// <summary>
@@ -105,20 +95,14 @@ namespace ServerCore
         /// <returns>A dictionary with key of the file names and value of the urls of the files in blob storage</returns>
         public static async Task<Dictionary<string, Uri>> UploadBlobsAsync(Dictionary<string, Stream> files, int eventId, string specificDirectory = null)
         {
-            CloudBlobDirectory puzzleDirectory = await GetPuzzleDirectoryAsync(eventId, specificDirectory ?? GetRandomDirectoryName());
+            BlobContainerClient containerClient = await GetOrCreateEventContainerAsync(eventId);
+            string directory = specificDirectory ?? GetRandomDirectoryName();
             Dictionary<string, Uri> fileUrls = new Dictionary<string, Uri>(files.Count);
 
             foreach (KeyValuePair<string, Stream> file in files)
             {
-                CloudBlockBlob blob = puzzleDirectory.GetBlockBlobReference(file.Key);
-                if (fileExtensionProvider.TryGetContentType(file.Key, out string contentType))
-                {
-                    blob.Properties.ContentType = contentType;
-                }
-
-                await blob.UploadFromStreamAsync(file.Value);
-
-                fileUrls[file.Key] = blob.Uri;
+                string fullPath = $"{directory}/{file.Key}";
+                fileUrls[file.Key] = await UploadBlobToContainerAsync(file.Key, file.Value, containerClient, fullPath);
             }
 
             return fileUrls;
@@ -130,21 +114,9 @@ namespace ServerCore
         /// <param name="fileUri">Full URL of the file to delete</param>
         public static async Task DeleteBlobAsync(Uri fileUri)
         {
-            CloudBlob blobToDelete = new CloudBlob(fileUri, StorageAccount.Credentials);
+            BlobUriBuilder uriBuilder = new BlobUriBuilder(fileUri);
+            BlobClient blobToDelete = new BlobClient(ConnectionString, uriBuilder.BlobContainerName, uriBuilder.BlobName);
             await blobToDelete.DeleteIfExistsAsync();
-        }
-
-        /// <summary>
-        /// Gets a reference to a random directory
-        /// </summary>
-        /// <param name="eventId">Event the directory should be associated with</param>
-        /// <param name="puzzleDirectoryName">Name of a subdirectory to concatenate. Use empty string for none.</param>
-        private static async Task<CloudBlobDirectory> GetPuzzleDirectoryAsync(int eventId, string puzzleDirectoryName)
-        {
-            CloudBlobContainer eventContainer = await GetOrCreateEventContainerAsync(eventId);
-            CloudBlobDirectory puzzleDirectory = eventContainer.GetDirectoryReference(puzzleDirectoryName);
-
-            return puzzleDirectory;
         }
 
         /// <summary>
@@ -152,8 +124,7 @@ namespace ServerCore
         /// </summary>
         /// <returns>The url as a string</returns>
         public static string GetFileStoragePrefix(int eventId, string puzzleDirectoryName) {
-            CloudBlobClient blobClient = StorageAccount.CreateCloudBlobClient();
-            CloudBlobContainer eventContainer = blobClient.GetContainerReference($"evt{eventId}");
+            BlobContainerClient eventContainer = new BlobContainerClient(ConnectionString, $"evt{eventId}");
             return eventContainer.Uri.AbsoluteUri;
         }
 
@@ -172,21 +143,11 @@ namespace ServerCore
         /// <summary>
         /// Ensure a container exists for the event
         /// </summary>
-        private static async Task<CloudBlobContainer> GetOrCreateEventContainerAsync(int eventId)
+        private static async Task<BlobContainerClient> GetOrCreateEventContainerAsync(int eventId)
         {
-            CloudBlobClient blobClient = StorageAccount.CreateCloudBlobClient();
-
-            CloudBlobContainer eventContainer = blobClient.GetContainerReference($"evt{eventId}");
-            await eventContainer.CreateIfNotExistsAsync(BlobContainerPublicAccessType.Blob, null, null);
+            BlobContainerClient eventContainer = new BlobContainerClient(ConnectionString, $"evt{eventId}");
+            await eventContainer.CreateIfNotExistsAsync(PublicAccessType.Blob);
             return eventContainer;
-        }
-
-        private static CloudStorageAccount StorageAccount
-        {
-            get
-            {
-                return CloudStorageAccount.Parse(ConnectionString);
-            }
         }
     }
 

--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.WindowsAzure.Storage.Blob;
 using ServerCore.DataModel;
 using ServerCore.Helpers;
 

--- a/ServerCore/ServerCore.csproj
+++ b/ServerCore/ServerCore.csproj
@@ -54,7 +54,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.7" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />


### PR DESCRIPTION
Migrate to the Azure.Storage.Blobs API, replacing the deprecated WindowsAzure.Storage API. Fixes #863 .