### PR TITLE
Fix Files view for local deployments

### DIFF
--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml
@@ -53,7 +53,7 @@
                     if (puzzleFile != null)
                     {
                                         <input type="checkbox" asp-route-id="@Model.Puzzle.ID" name="SelectedFiles" value="@puzzleFile.ID" />
-                                        @Html.ActionLink(puzzleFile.ShortName, "Index", "Files", new { eventId = Model.Event.ID, filename = puzzleFile.ShortName })
+                                        <a href="@Model.LinkFromShortName(puzzleFile)">@puzzleFile.ShortName</a>
                                         <a href="@puzzleFile.UrlString">[Raw]</a>
                                         <button type="submit" asp-route-id="@Model.Puzzle.ID" asp-route-fileId="@puzzleFile.ID" asp-page-handler="Delete">Delete</button>
                     }
@@ -70,7 +70,7 @@
                     if (answerFile != null)
                     {
                                         <input type="checkbox" asp-route-id="@Model.Puzzle.ID" name="SelectedFiles" value="@answerFile.ID" />
-                                        @Html.ActionLink(answerFile.ShortName, "Index", "Files", new { eventId = Model.Event.ID, filename = answerFile.ShortName })
+                                        <a href="@Model.LinkFromShortName(answerFile)">@answerFile.ShortName</a>
                                         <a href="@answerFile.UrlString">[Raw]</a>
 
                                         <button type="submit" asp-route-id="@Model.Puzzle.ID" asp-route-fileId="@answerFile.ID" asp-page-handler="Delete">Delete</button>
@@ -89,7 +89,7 @@
             {
                 <p>
                     <input class="materialFileCheckbox" type="checkbox" asp-route-id="@Model.Puzzle.ID" name="SelectedFiles" value="@material.ID" />
-                    @Html.ActionLink(material.ShortName, "Index", "Files", new { eventId = Model.Event.ID, filename = material.ShortName })
+                    <a href="@Model.LinkFromShortName(material)">@material.ShortName</a>
                     <a href="@material.UrlString">[Raw]</a>
                     <button type="submit" asp-route-id="@Model.Puzzle.ID" asp-route-fileId="@material.ID" asp-page-handler="Delete">Delete</button>
                 </p>
@@ -103,7 +103,7 @@
             {
                 <p>
                     <input type="checkbox" asp-route-id="@Model.Puzzle.ID" name="SelectedFiles" value="@solveFile.ID" />
-                    @Html.ActionLink(solveFile.ShortName, "Index", "Files", new { eventId = Model.Event.ID, filename = solveFile.ShortName })
+                    <a href="@Model.LinkFromShortName(solveFile)">@solveFile.ShortName</a>
                     <a href="@solveFile.UrlString">[Raw]</a>
                     <button type="submit" asp-route-id="@Model.Puzzle.ID" asp-route-fileId="@solveFile.ID" asp-page-handler="Delete">Delete</button>
                 </p>

--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml.cs
@@ -288,6 +288,27 @@ namespace ServerCore.Pages.Puzzles
         }
 
         /// <summary>
+        /// Makes a clean link to the ContentFile based on ShortName, that is specific to this event.
+        /// </summary>
+        /// <param name="file">The ContentFile</param>
+        /// <returns>a link that explicitly includes the eventId</returns>
+        public string LinkFromShortName(ContentFile file)
+        {
+            return this.HttpContext.Request.Scheme + "://" + this.HttpContext.Request.Host + "/" + this.Event.ID + "/Files/" + file.ShortName;
+        }
+
+        /// <summary>
+        /// Makes a clean link to the ContentFile based on ShortName, that is not specific to this event.
+        /// </summary>
+        /// <param name="file">The ContentFile</param>
+        /// <returns>a link that replaces the explicit eventId with {eventId}, best used for Puzzle.CustomURL and Puzzle.CustomSolutionURL.</returns>
+        public string EventAgnosticLinkFromShortName(ContentFile file)
+        {
+            // lack of translation of {eventId} is very intentional - this is translated at runtime and makes the field value portable
+            return this.HttpContext.Request.Scheme + "://" + this.HttpContext.Request.Host + "/{eventId}/Files/" + file.ShortName;
+        }
+
+        /// <summary>
         /// Promotes files named "index.html" to the CustomURL or CustomSolutionURL properties of the puzzle.
         /// </summary>
         /// <param name="file">The file being uploaded</param>
@@ -305,8 +326,7 @@ namespace ServerCore.Pages.Puzzles
                 return;
             }
 
-            // lack of translation of {eventId} is very intentional - this is translated at runtime and makes the field value portable
-            string filePath = this.HttpContext.Request.Scheme + "://" + this.HttpContext.Request.Host + "/{eventId}/Files/" + file.ShortName;
+            string filePath = this.EventAgnosticLinkFromShortName(file);
             if (file.FileType == ContentFileType.PuzzleMaterial)
             {
                 Puzzle.CustomURL = filePath;


### PR DESCRIPTION
Something about the presentation of ShortName links in the Files view has gone wonky for local deployments and erodes confidence in the overall system, even though it works fine at runtime. This seems to be due to some change in IIS Express or ASP.NET, but hasn't been explicitly identified.

This change, using code adapted from the automatic CustomURL filler, seems to work cleanly.