### PR TITLE
Add single player puzzle state map

### DIFF
--- a/ServerCore/Pages/Events/Map.cshtml.cs
+++ b/ServerCore/Pages/Events/Map.cshtml.cs
@@ -245,17 +245,13 @@ namespace ServerCore.Pages.Events
             public DateTime FinalMetaSolveTime { get; set; } = DateTime.MaxValue;
         }
 
-        public class StateStats
+        public abstract class StateStatsBase
         {
-            public static StateStats Default { get; } = new StateStats();
-
             public PuzzleStats Puzzle { get; set; }
-            public TeamStats Team { get; set; }
-            public bool UnlockedAtStart { get; set; }
             public DateTime? UnlockedTime { get; set; }
+            public bool UnlockedAtStart { get; set; }
             public DateTime? SolvedTime { get; set; }
             public bool LockedOut { get; set; }
-            public bool IsPresent { get; set; }
 
             public string Classes
             {
@@ -298,6 +294,13 @@ namespace ServerCore.Pages.Events
                     return puzzleState != null ? $"statecell {puzzleType} {puzzleState}" : $"statecell {puzzleType}";
                 }
             }
+        }
+
+        public class StateStats : StateStatsBase
+        {
+            public static StateStats Default { get; } = new StateStats();
+            public TeamStats Team { get; set; }
+            public bool IsPresent { get; set; }
         }
     }
 }

--- a/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml
+++ b/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml
@@ -25,7 +25,7 @@
             <th>
                 Score
             </th>
-            @foreach (SinglePlayerPuzzleStateMapModel.PuzzleStats puzzleStat in Model.PuzzleStatList)
+            @foreach (MapModel.PuzzleStats puzzleStat in Model.PuzzleStatList)
             {
                 <th>
                     <a asp-page="/Puzzles/Status" asp-route-puzzleId="@puzzleStat.Puzzle.ID">@puzzleStat.Puzzle.PlaintextName (@puzzleStat.SolveCount)</a>

--- a/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml
+++ b/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml
@@ -1,0 +1,67 @@
+﻿@page "/{eventId}/{eventRole}/Events/SinglePlayerPuzzleStateMap"
+@model ServerCore.Pages.Events.SinglePlayerPuzzleStateMapModel
+
+@{
+    @using Helpers;
+
+    ViewData["Title"] = "SinglePlayerPuzzle State Map";
+    ViewData["AdminRoute"] = "/Events/SinglePlayerPuzzleStateMap";
+    ViewData["AuthorRoute"] = "/Events/SinglePlayerPuzzleStateMap";
+}
+
+<h2>Single Player Puzzle State Map</h2>
+<table class="table table-condensed ph-statemap">
+    <thead>
+        <tr>
+            <th>
+                Rank
+            </th>
+            <th>
+                Name
+            </th>
+            <th>
+                Puzzles
+            </th>
+            <th>
+                Score
+            </th>
+            @foreach (SinglePlayerPuzzleStateMapModel.PuzzleStats puzzleStat in Model.PuzzleStatList)
+            {
+                <th>
+                    <a asp-page="/Puzzles/Status" asp-route-puzzleId="@puzzleStat.Puzzle.ID">@puzzleStat.Puzzle.PlaintextName (@puzzleStat.SolveCount)</a>
+                </th>
+            }
+        </tr>
+    </thead>
+    <tbody>
+        @for (int playerIndex = 0; playerIndex < Model.PlayerStatList.Count; playerIndex++)
+        {
+            var playerStat = Model.PlayerStatList[playerIndex];
+            var rank = playerIndex + 1;
+            <tr>
+                <td>
+                    @rank
+                </td>
+                <td>
+                    <a asp-page="/Player/Details" asp-route-id="@playerStat.Player.ID">@(playerStat.Player.Name)</a>
+                </td>
+                <td>
+                    @playerStat.SolveCount
+                </td>
+                <td>
+                    @playerStat.Score
+                </td>
+                @for (int puzzleIndex = 0; puzzleIndex < Model.PuzzleStatList.Count; puzzleIndex++)
+                {
+                    var statState = Model.StateMap[playerIndex, puzzleIndex] ?? SinglePlayerPuzzleStateMapModel.StateStats.Default;
+
+                    <td class="stateparent">
+                        <a class="@statState.Classes" asp-page="/Submissions/SinglePlayerPuzzleAuthorIndex" asp-route-puzzleId="@Model.PuzzleStatList[puzzleIndex].Puzzle.ID" asp-route-playerId="@Model.PlayerStatList[playerIndex].Player.ID">
+                        </a>
+                    </td>
+                }
+            </tr>
+        }
+    </tbody>
+</table>
+

--- a/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml.cs
+++ b/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.Helpers;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Events
+{
+    [Authorize(Policy = "IsEventAdminOrEventAuthor")]
+    public class SinglePlayerPuzzleStateMapModel : EventSpecificPageModel
+    {
+        public List<PuzzleStats> PuzzleStatList { get; private set; }
+
+        public List<PlayerStats> PlayerStatList { get; private set; }
+
+        public StateStats[,] StateMap { get; private set; }
+
+        public SinglePlayerPuzzleStateMapModel(PuzzleServerContext serverContext,
+                        UserManager<IdentityUser> userManager)
+            : base(serverContext, userManager)
+        {
+        }
+
+        public async Task<IActionResult> OnGetAsync(string? groups)
+        {
+            // Get relevant SinglePlayerPuzzles
+            List<Puzzle> puzzles;
+            if (EventRole == EventRole.admin)
+            {
+                puzzles = await _context.Puzzles.Where(p => p.Event == Event)
+                    .Where(p => p.IsForSinglePlayer)
+                    .ToListAsync();
+            }
+            else
+            {
+                puzzles = await UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
+                    .Where(p => p.IsForSinglePlayer)
+                    .ToListAsync();
+            }
+
+            // Gets all relevant single player puzzle states per player
+            List<SinglePlayerPuzzleStatePerPlayer> puzzleStatesPerPlayer = await _context.SinglePlayerPuzzleStatePerPlayer
+                .Where(puzzleState => puzzleState.Puzzle.Event == this.Event && puzzleState.Puzzle.IsForSinglePlayer)
+                .ToListAsync();
+
+            // Create the puzzle and player stats
+            Dictionary<int, PuzzleStats> puzzleIdToPuzzleStatsMap = puzzles.ToDictionary(puzzle => puzzle.ID, puzzle => new PuzzleStats() { Puzzle = puzzle});
+            var playerIdToPlayerStatsMap = new Dictionary<int, PlayerStats>();
+            foreach (SinglePlayerPuzzleStatePerPlayer puzzleState in puzzleStatesPerPlayer)
+            {
+                if (!playerIdToPlayerStatsMap.ContainsKey(puzzleState.PlayerID))
+                {
+                    playerIdToPlayerStatsMap[puzzleState.PlayerID] = new PlayerStats { Player = puzzleState.Player };
+                }
+
+                if (puzzleState.SolvedTime != null)
+                {
+                    puzzleIdToPuzzleStatsMap[puzzleState.PuzzleID].SolveCount++;
+                    playerIdToPlayerStatsMap[puzzleState.PlayerID].SolveCount++;
+                    playerIdToPlayerStatsMap[puzzleState.PlayerID].Score += puzzleState.Puzzle.SolveValue;
+                }
+            }
+
+            // Order both lists
+            this.PuzzleStatList = puzzleIdToPuzzleStatsMap
+                .Values
+                .OrderBy(puzzleStat => puzzleStat.SolveCount)
+                .ThenBy(puzzleStat => puzzleStat.Puzzle.Name)
+                .ToList();
+
+            this.PlayerStatList = playerIdToPlayerStatsMap
+                .Values
+                .OrderBy(playerStat => playerStat.Score)
+                .ThenBy(playerStat => playerStat.SolveCount)
+                .ThenBy(playerStat => playerStat.Player.Name)
+                .ToList();
+
+            // Create maps from each puzzle/player id to it's sorted index
+            var index = 0;
+            Dictionary<int, int> puzzleIdToIndexMap = this.PuzzleStatList.ToDictionary(puzzleStat => puzzleStat.Puzzle.ID, puzzleStat => index++);
+
+            index = 0;
+            Dictionary<int, int> playerIdToIndexMap = this.PlayerStatList.ToDictionary(playerStat => playerStat.Player.ID, playerStat => index++);
+
+            // Create final stat matrix
+            this.StateMap = new StateStats[this.PlayerStatList.Count, this.PuzzleStatList.Count];
+            foreach (SinglePlayerPuzzleStatePerPlayer statePerPlayer in puzzleStatesPerPlayer)
+            {
+                int playerIndex = playerIdToIndexMap[statePerPlayer.PlayerID];
+                int puzzleIndex = puzzleIdToIndexMap[statePerPlayer.Puzzle.ID];
+                this.StateMap[playerIndex, puzzleIndex] = new StateStats()
+                {
+                    UnlockedTime = statePerPlayer.UnlockedTime,
+                    SolvedTime = statePerPlayer.SolvedTime,
+                    LockedOut = statePerPlayer.IsLockedOut
+                };
+            }
+
+            return Page();
+        }
+
+        public class PuzzleStats
+        {
+            public Puzzle Puzzle { get; set; }
+            public int SolveCount { get; set; }
+        }
+
+        public class PlayerStats
+        {
+            public PuzzleUser Player { get; set; }
+            public int SolveCount { get; set; }
+            public int Score { get; set; }
+        }
+
+        public class StateStats
+        {
+            public static StateStats Default => new StateStats();
+
+            public DateTime? UnlockedTime { get; set; }
+            public DateTime? SolvedTime { get; set; }
+            public bool LockedOut { get; set; }
+
+            public string Classes
+            {
+                get
+                {
+                    string puzzleState = null;
+
+                    if (LockedOut)
+                    {
+                        puzzleState = "email-mode";
+                    }
+                    else if (SolvedTime != null)
+                    {
+                        int minutes = (int)((DateTime.UtcNow - SolvedTime.Value).TotalMinutes);
+                        puzzleState = minutes > 15 ? "solved-old" : "solved-recent";
+                    }
+                    else if (UnlockedTime == null)
+                    {
+                        puzzleState = "still-locked";
+                    }
+                    else
+                    {
+                        int minutes = (int)((DateTime.UtcNow - UnlockedTime.Value).TotalMinutes);
+                        puzzleState = minutes > 15 ? "unlocked-old" : "unlocked-recent";
+                    }
+
+                    return puzzleState != null ? $"statecell {puzzleState}" : "statecell";
+                }
+            }
+        }
+    }
+}

--- a/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml.cs
+++ b/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
 using ServerCore.Helpers;
 using ServerCore.ModelBases;
+using static ServerCore.Pages.Events.MapModel;
 
 namespace ServerCore.Pages.Events
 {
@@ -105,12 +106,6 @@ namespace ServerCore.Pages.Events
             return Page();
         }
 
-        public class PuzzleStats
-        {
-            public Puzzle Puzzle { get; set; }
-            public int SolveCount { get; set; }
-        }
-
         public class PlayerStats
         {
             public PuzzleUser Player { get; set; }
@@ -118,42 +113,14 @@ namespace ServerCore.Pages.Events
             public int Score { get; set; }
         }
 
-        public class StateStats
+        public class StateStats : StateStatsBase
         {
-            public static StateStats Default => new StateStats();
-
-            public DateTime? UnlockedTime { get; set; }
-            public DateTime? SolvedTime { get; set; }
-            public bool LockedOut { get; set; }
-
-            public string Classes
+            public StateStats()
             {
-                get
-                {
-                    string puzzleState = null;
-
-                    if (LockedOut)
-                    {
-                        puzzleState = "email-mode";
-                    }
-                    else if (SolvedTime != null)
-                    {
-                        int minutes = (int)((DateTime.UtcNow - SolvedTime.Value).TotalMinutes);
-                        puzzleState = minutes > 15 ? "solved-old" : "solved-recent";
-                    }
-                    else if (UnlockedTime == null)
-                    {
-                        puzzleState = "still-locked";
-                    }
-                    else
-                    {
-                        int minutes = (int)((DateTime.UtcNow - UnlockedTime.Value).TotalMinutes);
-                        puzzleState = minutes > 15 ? "unlocked-old" : "unlocked-recent";
-                    }
-
-                    return puzzleState != null ? $"statecell {puzzleState}" : "statecell";
-                }
+                this.UnlockedAtStart = false;
             }
+
+            public static StateStats Default => new StateStats();
         }
     }
 }

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -67,7 +67,10 @@
                                 <li><a class="dropdown-item" asp-page="/Events/Standings">Standings</a></li>
                                 <li><a class="dropdown-item" asp-page="/Events/FastestSolves">Fastest solves</a></li>
                                 <li><a class="dropdown-item" asp-page="/Events/Map">Puzzle state map</a></li>
-                                <li><a class="dropdown-item" asp-page="/Events/SinglePlayerPuzzleStateMap">Single player puzzle state map</a></li>
+                                @if (Event.ShouldShowSinglePlayerPuzzles)
+                                {
+                                    <li><a class="dropdown-item" asp-page="/Events/SinglePlayerPuzzleStateMap">Single player puzzle state map</a></li>
+                                }
                                 <li><a class="dropdown-item" asp-page="/Events/PlayerSubmissions">Shared submissions</a></li>
                             </ul>
                         </div>

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -67,6 +67,7 @@
                                 <li><a class="dropdown-item" asp-page="/Events/Standings">Standings</a></li>
                                 <li><a class="dropdown-item" asp-page="/Events/FastestSolves">Fastest solves</a></li>
                                 <li><a class="dropdown-item" asp-page="/Events/Map">Puzzle state map</a></li>
+                                <li><a class="dropdown-item" asp-page="/Events/SinglePlayerPuzzleStateMap">Single player puzzle state map</a></li>
                                 <li><a class="dropdown-item" asp-page="/Events/PlayerSubmissions">Shared submissions</a></li>
                             </ul>
                         </div>


### PR DESCRIPTION
#1054
### What you see when no puzzles are unlocked and no players have seen it
![image](https://github.com/user-attachments/assets/88bce0d3-d8e8-4550-a647-8c6ebf1466f7)
- Remember that SinglePlayerPuzzle states are created lazily so if a player has not tried to look at the puzzle page, a SinglePlayerPuzzleStatePerPlayer will not be created for them

### What you see after unlock one of the puzzles for all players
Same as section above

### What you see after player actually looks at the unlocked single player puzzle
![image](https://github.com/user-attachments/assets/c6786a37-5fb8-4f05-a3f1-24dd9940092e)

### What you see when a player solves one of the puzzles
![image](https://github.com/user-attachments/assets/a20137d8-2a5e-4c6a-b4c3-807424ebf7bf)

