### PR TITLE
Bulk File Uploader

### DIFF
--- a/ServerCore/FileManager.cs
+++ b/ServerCore/FileManager.cs
@@ -37,7 +37,7 @@ namespace ServerCore
         private static async Task<Uri> UploadBlobToContainerAsync(string fileName, Stream contents, BlobContainerClient containerClient, string blobPath)
         {
             BlobClient blob = containerClient.GetBlobClient(blobPath);
-            await blob.UploadAsync(contents);
+            await blob.UploadAsync(contents, overwrite: true);
 
             if (fileExtensionProvider.TryGetContentType(fileName, out string contentType))
             {

--- a/ServerCore/Pages/Puzzles/BulkFiles.cshtml
+++ b/ServerCore/Pages/Puzzles/BulkFiles.cshtml
@@ -21,8 +21,7 @@
     <hr />
     <h3>What the Bulk File Uploader WILL do</h3>
     <ul>
-        <li>Upload new versions of files for puzzles/solutions, when stored in folders that match the folder names used previously</li>
-        <li>Correctly handle new files added to existing puzzles and solutions</li>
+        <li>Upload and add/replace files for puzzles/solutions, when stored in folders that match the folder names used previously for that puzzle</li>
         <li>Drill into root folders named "puzzles" and/or "solutions"</li>
     </ul>
     <h3>What the Bulk File Uploader WILL NOT do</h3>

--- a/ServerCore/Pages/Puzzles/BulkFiles.cshtml
+++ b/ServerCore/Pages/Puzzles/BulkFiles.cshtml
@@ -1,0 +1,66 @@
+﻿@page  "/{eventId}/{eventRole}/Puzzles/BulkFiles/{handler?}"
+@model ServerCore.Pages.Puzzles.BulkFilesModel
+
+@{
+    ViewData["Title"] = "Bulk File management";
+    ViewData["AdminRoute"] = "../Puzzles/BulkFiles";
+    ViewData["AuthorRoute"] = "../Puzzles/BulkFiles";
+    ViewData["PlayRoute"] = "/Puzzles/Play";
+}
+
+<script type="text/javascript">
+</script>
+
+<h2>@Model.Event.Name: Bulk Files</h2>
+
+<p>
+    <a asp-page="/Puzzles/Index">Back to puzzle list</a>
+</p>
+
+<div>
+    <hr />
+    <h3>What the Bulk File Uploader WILL do</h3>
+    <ul>
+        <li>Upload new versions of files for puzzles/solutions, when stored in folders that match the folder names used previously</li>
+        <li>Correctly handle new files added to existing puzzles and solutions</li>
+        <li>Drill into root folders named "puzzles" and/or "solutions"</li>
+    </ul>
+    <h3>What the Bulk File Uploader WILL NOT do</h3>
+    <ul>
+        <li>Delete old files that are no longer needed</li>
+        <li>Add files to puzzles/solutions that have never had files uploaded before</li>
+    </ul>
+    <div class="form-group">
+        <form method="post" enctype="multipart/form-data">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input asp-for="NewBulkFiles" class="form-control" style="height:auto" />
+            <span asp-validation-for="NewBulkFiles" class="text-danger"></span>
+
+            <div class="form-group">
+                <input type="submit" value="Upload" class="btn btn-default" />
+            </div>
+        </form>
+    </div>
+    @if (Model.FoldersCopied.Count > 0)
+    {
+        <br/>
+        <h3>Folders Copied:</h3>
+        <ul>
+            @foreach (var folder in Model.FoldersCopied)
+            {
+                <li>@folder</li>
+            }
+        </ul>
+    }
+    @if (Model.FilesIgnored.Count > 0)
+    {
+        <br/>
+        <h3>Files Ignored:</h3>
+        <ul>
+            @foreach (var file in Model.FilesIgnored)
+            {
+                <li>@file</li>
+            }
+        </ul>
+    }
+</div>

--- a/ServerCore/Pages/Puzzles/BulkFiles.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/BulkFiles.cshtml.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServerCore.DataModel;
+using ServerCore.ModelBases;
+
+namespace ServerCore.Pages.Puzzles
+{
+    /// <summary>
+    /// Page for managing all files in bulk
+    /// </summary>
+    [Authorize(Policy = "IsEventAdminOrEventAuthor")]
+    public class BulkFilesModel : EventSpecificPageModel
+    {
+        public BulkFilesModel(PuzzleServerContext serverContext, UserManager<IdentityUser> userManager) : base(serverContext, userManager)
+        {
+        }
+
+        [BindProperty]
+        public List<string> FoldersCopied { get; set; } = new List<string>();
+
+        [BindProperty]
+        public List<string> FilesIgnored { get; set; } = new List<string>();
+
+        [BindProperty]
+        public List<IFormFile> NewBulkFiles { get; set; }
+
+        /// <summary>
+        /// Handler for listing files
+        /// </summary>
+        public IActionResult OnGet(int puzzleId)
+        {
+            return Page();
+        }
+
+        /// <summary>
+        /// Handler for uploading files
+        /// </summary>
+        public async Task<IActionResult> OnPostAsync(int puzzleId)
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            if (NewBulkFiles != null)
+            {
+                foreach (IFormFile resourceFile in NewBulkFiles)
+                {
+                    await UploadFileAsync(resourceFile);
+                }
+            }
+
+            return Page();
+        }
+
+        /// <summary>
+        /// Helper for taking an uploaded form file, uploading it, and tracking it in the database
+        /// </summary>
+        private async Task UploadFileAsync(IFormFile uploadedFile)
+        {
+            if (Path.GetExtension(uploadedFile.FileName).Equals(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                await UploadZipAsync(uploadedFile);
+                return;
+            }
+        }
+
+        private class DirData
+        {
+            public string RawDirectory;
+            public int PuzzleID;
+            public ContentFileType FileType;
+            public Dictionary<string, Stream> Files = new Dictionary<string, Stream>();
+        }
+
+        /// <summary>
+        /// Extracts the contents of a zip file and uploads the contents into a single directory
+        /// </summary>
+        private async Task UploadZipAsync(IFormFile uploadedFile)
+        {
+            Uri fileStoragePrefix = new Uri(FileManager.GetFileStoragePrefix(Event.ID, "") + "/", UriKind.Absolute);
+            List<int> authorPuzzles = (EventRole == EventRole.admin) ? null : await _context.PuzzleAuthors.Where(pa => pa.Author.ID == LoggedInUser.ID).Select(pa => pa.PuzzleID).ToListAsync();
+
+            Dictionary<string, DirData> dirs = new Dictionary<string, DirData>();
+
+            //
+            // Build a mapping table of all existing content
+            //
+            Dictionary<string, ContentFile> existingContent = await (from contentFile in this._context.ContentFiles
+                                         where contentFile.Event == this.Event
+                                         select contentFile).ToDictionaryAsync(c => c.ShortName);
+
+            foreach (ContentFile contentFile in existingContent.Values)
+            {
+                string originalDirectory = Path.GetDirectoryName(contentFile.ShortName);
+                
+                if (!dirs.ContainsKey(originalDirectory))
+                {
+                    Uri uriMinusPrefix = fileStoragePrefix.MakeRelativeUri(contentFile.Url);
+                    string rawDirectory = Uri.UnescapeDataString(uriMinusPrefix.OriginalString.Split('/')[0]);
+                    dirs[originalDirectory] = (authorPuzzles != null && !authorPuzzles.Contains(contentFile.PuzzleID)) ? null : new DirData() { RawDirectory = rawDirectory, PuzzleID = contentFile.PuzzleID, FileType = contentFile.FileType, Files = new Dictionary<string, Stream>() };
+                }
+            }
+
+            //
+            // Walk through all files in the zip, strip puzzles/ and solutions/ directory prefixes if present, and map to existing structure
+            //
+            ZipArchive archive = new ZipArchive(uploadedFile.OpenReadStream(), ZipArchiveMode.Read);
+            foreach (ZipArchiveEntry entry in archive.Entries)
+            {
+                if (entry.FullName.EndsWith("/"))
+                {
+                    continue;
+                }
+
+                if (entry.FullName.StartsWith("/") || entry.FullName.StartsWith("\\") || entry.FullName.Contains(".."))
+                {
+                    throw new ArgumentException();
+                }
+
+                string fileName = entry.FullName;
+                string directory = fileName.Split('/')[0];
+                if (directory == "puzzles" || directory == "solutions")
+                {
+                    fileName = fileName.Substring(directory.Length + 1);
+                    directory = fileName.Split('/')[0];
+                }
+
+                if (dirs.ContainsKey(directory) && dirs[directory] != null)
+                {
+                    dirs[directory].Files[fileName] = entry.Open();
+                }
+                else
+                {
+                    FilesIgnored.Add(entry.FullName);
+                }
+            }
+
+            //
+            // Now upload files and add missing ContentFiles, one directory at a time
+            //
+            foreach (var pair in dirs)
+            {
+                Dictionary<string, Uri> fileUrls = await FileManager.UploadBlobsAsync(pair.Value.Files, Event.ID, pair.Value.RawDirectory);
+                bool addedAny = false;
+
+                foreach (string shortName in fileUrls.Keys)
+                {
+                    if (!existingContent.ContainsKey(shortName))
+                    {
+                        ContentFile file = new ContentFile()
+                        {
+                            ShortName = shortName,
+                            PuzzleID = pair.Value.PuzzleID,
+                            Event = Event,
+                            FileType = pair.Value.FileType,
+                            Url = fileUrls[shortName],
+                        };
+                        _context.ContentFiles.Add(file);
+                        addedAny = true;
+                    }
+                }
+
+                if (addedAny)
+                {
+                    await _context.SaveChangesAsync();
+                }
+
+                FoldersCopied.Add(pair.Key);
+            }
+        }
+    }
+}

--- a/ServerCore/Pages/Puzzles/BulkFiles.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/BulkFiles.cshtml.cs
@@ -70,7 +70,10 @@ namespace ServerCore.Pages.Puzzles
             if (Path.GetExtension(uploadedFile.FileName).Equals(".zip", StringComparison.OrdinalIgnoreCase))
             {
                 await UploadZipAsync(uploadedFile);
-                return;
+            }
+            else
+            {
+                FilesIgnored.Add(uploadedFile.FileName);
             }
         }
 

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -22,7 +22,8 @@
         <a asp-page="/Hints/Responses">View all hint responses</a> @(" |")
     }
     <a asp-page="/Puzzles/Checklist">View puzzle checklist</a> |
-    <a asp-page="/Puzzles/ResourceManagement">Manage shared resources</a>
+    <a asp-page="/Puzzles/ResourceManagement">Manage shared resources</a> |
+    <a asp-page="/Puzzles/BulkFiles">Bulk File Upload</a>
 </p>
 <p>
     Support:


### PR DESCRIPTION
Uploads one or more puzzles/solutions from a zip file, adding files as necessary. Does updating and adds new files, but can't be used for the first upload of a puzzle/solution since it uses the results of a previous upload to build the proper mapping.