### PR TITLE
Add allow-modals to iframes

### DIFF
--- a/ServerCore/Pages/Shared/_ContentFilePartial.cshtml
+++ b/ServerCore/Pages/Shared/_ContentFilePartial.cshtml
@@ -47,7 +47,7 @@
         }
     });
 </script>
-<iframe id="@(pageType)-frame" class="unsized" title="@(pageType) content" sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-top-navigation" src="@(fileStoragePrefix)/resources/@(pageType)-content.html"></iframe>
+<iframe id="@(pageType)-frame" class="unsized" title="@(pageType) content" sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-modals" src="@(fileStoragePrefix)/resources/@(pageType)-content.html"></iframe>
 <div style="display:none;">
     <h3>Unable to load @(pageType) content file</h3>
     <p>If you're seeing this message, it's because the website was unable to load the content expected to be here. If you're an admin or have the ability to upload shared resources, please check the following:</p>

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -741,7 +741,7 @@ else
                 urlSuffix += "?";
             }
             urlSuffix += "embed=true";
-            <iframe id="puzzle-frame" class="unsized" title="@Model.Puzzle.Name" sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads" src="@puzzleFilePath@urlSuffix"></iframe>
+            <iframe id="puzzle-frame" class="unsized" title="@Model.Puzzle.Name" sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads allow-modals" src="@puzzleFilePath@urlSuffix"></iframe>
             break;
         case 4: // Images
             <img id="img-frame" src="@puzzleFilePath" alt="An image containing a puzzle" />


### PR DESCRIPTION
allow-modals allows for confirm() to pop up a modal box from within an <iframe>.

This is used for older puzzles (that didn't save state) when navigating away, and for newer puzzles where the latest puzzle.js pops up a confirm on pressing Reset.