### PR TITLE
Fix Blazor causing reloads on Razor pages

### DIFF
--- a/ServerCore/Pages/Shared/_Layout.cshtml
+++ b/ServerCore/Pages/Shared/_Layout.cshtml
@@ -93,7 +93,14 @@
 <body class="body-customizable">
     @if (ev != null && ev.AllowBlazor)
     {
-        <script src="_framework/blazor.web.js"></script>
+        <script src="_framework/blazor.web.js" autostart="false"></script>
+        <script>
+            // disableDomPreservation disables Blazor Enhanced Navigation, which causes a reload on every page,
+            // hurting perf and breaking requests that change the db
+            Blazor.start({
+              ssr: { disableDomPreservation: true }
+            });
+        </script>
         <script>
             var lockResolver;
             if (navigator && navigator.locks && navigator.locks.request) {


### PR DESCRIPTION
Fix Blazor causing reloads on Razor pages, which was breaking alpha testing and adding players to teams