### PR TITLE
Fix sync in production

### DIFF
--- a/ClientSyncComponent/ClientSyncComponent.Client/Pages/ClientSyncComponent.razor.cs
+++ b/ClientSyncComponent/ClientSyncComponent.Client/Pages/ClientSyncComponent.razor.cs
@@ -35,7 +35,7 @@ namespace ClientSyncComponent.Client.Pages
         [Parameter]
         public int FastestSyncInterval { get; set; } = 0;
 
-        DateTimeOffset LastSyncUtc = DateTimeOffset.MinValue;
+        DateTimeOffset LastSyncUtc = new DateTimeOffset(2024, 1, 1, 1, 1, 1, TimeSpan.Zero);
 
         DateTimeOffset DisplayLastSyncUtc = DateTimeOffset.MinValue;
 


### PR DESCRIPTION
Fix sync queries against production tables that don't accept DateTimeOffset.Min