### PR TITLE
Fix syncing null items

### DIFF
--- a/ClientSyncComponent/ClientSyncComponent.Client/PuzzleItemProperty.cs
+++ b/ClientSyncComponent/ClientSyncComponent.Client/PuzzleItemProperty.cs
@@ -21,7 +21,9 @@ namespace ClientSyncComponent.Client
             SubPuzzleId = subPuzzleId;
             LocationKey = locationKey;
             PropertyKey = propertyKey;
-            Value = value;
+
+            // Azure tables can't store null values, so substitute empty string (which puzzle.js can handle equivalently to null)
+            Value = value ?? String.Empty;
             PlayerId = playerId;
             Channel = channel;
         }


### PR DESCRIPTION
The Table service does not persist null values for properties, so convert them to empty strings