### PR TITLE
Fix Bootstrap test

### DIFF
--- a/ServerCore/Pages/Shared/_Layout.cshtml
+++ b/ServerCore/Pages/Shared/_Layout.cshtml
@@ -51,7 +51,7 @@
         </script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js"
                 asp-fallback-src="~/lib/bootstrap-5.3.2-dist/js/bootstrap.min.js"
-                asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
+                asp-fallback-test="window.bootstrap"
                 crossorigin="anonymous"
                 integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+">
         </script>


### PR DESCRIPTION
This bootstrap test was previously looking for jQuery, not Bootstrap, and when loading the fallback it was causing integrity errors that only Edge seems to ignore. The result was causing Bootstrap-generated toast to dismiss incorrectly, surely among other things.