### PR TITLE
Fix null criticalEventToasts

### DIFF
--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -429,6 +429,7 @@
                 notificationList.innerHTML = "";
                 criticalEventToasts = JSON.parse(localStorage.getItem("userToasts-@(Model.Event.ID)-critical"));
                 if (criticalEventToasts) { for (const [key, value] of Object.entries(criticalEventToasts)) { popToast(notificationList, value, false, false); } }
+                else { criticalEventToasts = {}; }
                 newToastCount = localStorage.getItem("userToasts-@(Model.Event.ID)-new");
                 newToastCount = newToastCount ? parseInt(newToastCount) : 0;
                 updateToastCount();


### PR DESCRIPTION
Elsewhere in the code, a call to get a list of toasts from localStorage would create an empty object in case of null/undefined (example: line 442 of this file). Should have been here as well.