### PR TITLE
Fix #1178 by checking against the event associated with the puzzle ID…

### DIFF
--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -75,6 +75,29 @@ namespace ServerCore.Areas.Identity
             return EventRole.play;
         }
 
+        public async Task IsPuzzleAdminCheck(AuthorizationHandlerContext authContext, IAuthorizationRequirement requirement)
+        {
+            EventRole role = GetEventRoleFromRoute();
+            if (role != EventRole.admin)
+            {
+                return;
+            }
+
+            PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
+            Puzzle puzzle = await GetPuzzleFromRoute();
+            Event thisEvent = await GetEventFromRoute();
+
+            if (thisEvent != null && await UserEventHelper.IsAdminOfPuzzle(dbContext, puzzle, puzzleUser))
+            {
+                authContext.Succeed(requirement);
+            }
+
+            if (puzzle != null)
+            {
+                dbContext.Entry(puzzle).State = EntityState.Detached;
+            }
+        }
+
         public async Task IsEventAdminCheck(AuthorizationHandlerContext authContext, IAuthorizationRequirement requirement)
         {
             EventRole role = GetEventRoleFromRoute();

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrAuthorOfPuzzle.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/IsEventAdminOrAuthorOfPuzzle.cs
@@ -27,7 +27,7 @@ namespace ServerCore.Areas.Identity.UserAuthorizationPolicy
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext authContext,
                                                        IsEventAdminOrAuthorOfPuzzleRequirement requirement)
         {
-            await authHelper.IsEventAdminCheck(authContext, requirement);
+            await authHelper.IsPuzzleAdminCheck(authContext, requirement);
         }
     }
 

--- a/ServerCore/Helpers/UserEventHelper.cs
+++ b/ServerCore/Helpers/UserEventHelper.cs
@@ -35,6 +35,16 @@ namespace ServerCore.Helpers
         }
 
         /// <summary>
+        /// Returns whether the user is an author of this puzzle
+        /// </summary>
+        /// <param name="puzzle">The puzzle that's being checked</param>
+        /// <param name="puzzleServerContext">Current PuzzleServerContext</param>
+        public static Task<bool> IsAdminOfPuzzle(PuzzleServerContext dbContext, Puzzle puzzle, PuzzleUser user)
+        {
+            return dbContext.EventAdmins.Where(ea => ea.Admin.ID == user.ID && ea.Event.ID == puzzle.Event.ID).AnyAsync();
+        }
+
+        /// <summary>
         /// Returns the the team for the given player
         /// </summary>
         /// <param name="dbContext">Current PuzzleServerContext</param>

--- a/ServerCore/Helpers/UserEventHelper.cs
+++ b/ServerCore/Helpers/UserEventHelper.cs
@@ -35,7 +35,7 @@ namespace ServerCore.Helpers
         }
 
         /// <summary>
-        /// Returns whether the user is an author of this puzzle
+        /// Returns whether the user is an admin of the event containing this puzzle
         /// </summary>
         /// <param name="puzzle">The puzzle that's being checked</param>
         /// <param name="puzzleServerContext">Current PuzzleServerContext</param>


### PR DESCRIPTION
… instead of the event associated with the URL. This is basically a mirror of the author logic.