### PR TITLE
Change DbContext to DbContextFactory

### DIFF
--- a/ServerCore/Areas/Deployment/DeploymentConfiguration.cs
+++ b/ServerCore/Areas/Deployment/DeploymentConfiguration.cs
@@ -13,23 +13,24 @@ namespace ServerCore.Areas.Deployment
         internal static void ConfigureDatabase(IConfiguration configuration, IServiceCollection services, IWebHostEnvironment env)
         {
             // Use SQL Database if in Azure, otherwise, use localdb
+            // Using a DbContextFactory allows for factories to be used in Blazor components and this also registers the DbContext in the usual way as well behind the scenes
             if (env.IsStaging() && Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") == "PuzzleServerTestDeploy")
             {
-                services.AddDbContext<PuzzleServerContext>
+                services.AddDbContextFactory<PuzzleServerContext>
                     (options => options.UseLazyLoadingProxies()
                         .UseSqlServer(configuration.GetConnectionString("PuzzleServerSQLConnectionString")));
             }
             else if (env.IsProduction() && (Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") == "puzzlehunt" || Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") == "puzzleday"))
             {
-                services.AddDbContext<PuzzleServerContext>
+                services.AddDbContextFactory<PuzzleServerContext>
                     (options => options.UseLazyLoadingProxies()
                         .UseSqlServer(configuration.GetConnectionString("PuzzleServerSQLConnectionString")));
             }
             else
             {
-                services.AddDbContext<PuzzleServerContext>
+                services.AddDbContextFactory<PuzzleServerContext>
                     (options => options.UseLazyLoadingProxies()
-                       .UseSqlServer(configuration.GetConnectionString("PuzzleServerContextLocal")));
+                        .UseSqlServer(configuration.GetConnectionString("PuzzleServerContextLocal")));
             }
         }
     }


### PR DESCRIPTION
Allows Blazor to have multiple scoped DbContexts on a single page, has no impact on other pages (per documentation and spot checking on site).