### PR TITLE
Html.Raw puzzle title support

### DIFF
--- a/ServerCore/Helpers/SubmissionEvaluator.cs
+++ b/ServerCore/Helpers/SubmissionEvaluator.cs
@@ -278,7 +278,7 @@ namespace ServerCore.Helpers
                     var authors = await context.PuzzleAuthors.Where((pa) => pa.Puzzle == submission.Puzzle).Select((pa) => pa.Author.Email).ToListAsync();
                     string affectedEntity = (!puzzle.IsForSinglePlayer) ? $"Team {team.Name}" : $"User {loggedInUser.Name ?? loggedInUser.Email}";
                     MailHelper.Singleton.SendPlaintextBcc(authors,
-                        $"{thisEvent.Name}: {affectedEntity} is in email mode for {submission.Puzzle.Name}",
+                        $"{thisEvent.Name}: {affectedEntity} is in email mode for {submission.Puzzle.PlaintextName}",
                         "");
                 }
                 else

--- a/ServerCore/Pages/Events/FastestSolves.cshtml.cs
+++ b/ServerCore/Pages/Events/FastestSolves.cshtml.cs
@@ -84,7 +84,7 @@ namespace ServerCore.Pages.Events
                                     !pspt.Team.IsDisqualified &&
                                     pspt.Puzzle.Event == Event &&
                                     (EventRole != EventRole.author || authorPuzzleIds.Contains(pspt.PuzzleID))
-                                    let puzzleToGroup = new { PuzzleID = pspt.Puzzle.ID, PuzzleName = pspt.Puzzle.Name } // Using 'let' to work around EF grouping limitations (https://www.codeproject.com/Questions/5266406/Invalidoperationexception-the-LINQ-expression-for)
+                                    let puzzleToGroup = new { PuzzleID = pspt.Puzzle.ID, PuzzleName = pspt.Puzzle.PlaintextName } // Using 'let' to work around EF grouping limitations (https://www.codeproject.com/Questions/5266406/Invalidoperationexception-the-LINQ-expression-for)
                                     group puzzleToGroup by puzzleToGroup.PuzzleID into puzzleGroup
                                     orderby puzzleGroup.Count() descending, puzzleGroup.Max(puzzleGroup => puzzleGroup.PuzzleName) // Using Max(PuzzleName) because only aggregate operators are allowed
                                     select new { PuzzleID = puzzleGroup.Key, PuzzleName = puzzleGroup.Max(puzzleGroup => puzzleGroup.PuzzleName), SolveCount = puzzleGroup.Count() }).ToListAsync();
@@ -223,7 +223,7 @@ namespace ServerCore.Pages.Events
                                      let puzzleToGroup = new
                                      {
                                          PuzzleID = statePerPlayer.Puzzle.ID,
-                                         PuzzleName = statePerPlayer.Puzzle.Name,
+                                         PuzzleName = statePerPlayer.Puzzle.PlaintextName,
                                          PuzzleUserId = statePerPlayer.PlayerID,
                                          IsUnlocked = statePerPlayer.UnlockedTime.HasValue,
                                          SolveTime = statePerPlayer.SolvedTime

--- a/ServerCore/Pages/Events/Mailer.cshtml
+++ b/ServerCore/Pages/Events/Mailer.cshtml
@@ -7,7 +7,7 @@
     ViewData["PlayRoute"] = "/EventSpecific/Index";
 }
 
-<h2>Mail to: @(Model.Team?.Name ?? "All") @Model.Group @(Model.Puzzle == null ? null : $"of {Model.Puzzle.Name}")</h2>
+<h2>Mail to: @(Model.Team?.Name ?? "All") @Model.Group @(Model.Puzzle == null ? null : $"of {Model.Puzzle.PlaintextName}")</h2>
 
 <form method="post">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>

--- a/ServerCore/Pages/Events/PlayerSubmissions.cshtml.cs
+++ b/ServerCore/Pages/Events/PlayerSubmissions.cshtml.cs
@@ -70,7 +70,7 @@ namespace ServerCore.Pages.Events
 
             FreeformPuzzles = await (puzzleQuery.Select(puzzle => new SelectListItem()
                                      {
-                                         Text = puzzle.Name,
+                                         Text = puzzle.PlaintextName,
                                          Value = puzzle.ID.ToString(),
                                          Selected = (puzzleId != null && puzzle.ID == puzzleId.Value)
                                      })).ToListAsync();
@@ -89,7 +89,7 @@ namespace ServerCore.Pages.Events
                 return NotFound();
             }
 
-            PuzzleName = selectedPuzzle.Name;
+            PuzzleName = selectedPuzzle.PlaintextName;
 
             Submissions = await (from submission in _context.Submissions
                                  join puzzle in _context.Puzzles on submission.PuzzleID equals puzzle.ID

--- a/ServerCore/Pages/Hints/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Hints/AuthorIndex.cshtml
@@ -18,7 +18,7 @@
     // TODO: Do we need a combined layout, or is that rare enough as to be unnecessary? Maybe those bar layouts should be sections/components?
 }
 
-<h2>@if (Model.Puzzle != null) { <text>@Model.Puzzle.Name:</text> } Hints @if (Model.Team != null) { <text>by @Model.Team.Name</text> }</h2>
+<h2>@if (Model.Puzzle != null) { <text>@Model.Puzzle.PlaintextName:</text> } Hints @if (Model.Team != null) { <text>by @Model.Team.Name</text> }</h2>
 <a asp-page="/Puzzles/Index">Back to puzzle list</a>
 
 <br />

--- a/ServerCore/Pages/Hints/AuthorIndex.cshtml.cs
+++ b/ServerCore/Pages/Hints/AuthorIndex.cshtml.cs
@@ -48,18 +48,18 @@ namespace ServerCore.Pages.Hints
                     if (teamId == null)
                     {
                         HintViews = await _context.HintStatePerTeam.Where((h) => h.UnlockTime != null && h.Team.Event == Event)
-                            .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.Name, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime  })
+                            .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.PlaintextName, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime  })
                             .ToListAsync();
                     }
                     else
                     {
                         HintViews = await _context.HintStatePerTeam.Where((h) => h.UnlockTime != null && h.TeamID == teamId)
-                            .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.Name, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
+                            .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.PlaintextName, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
                             .ToListAsync();
                     }
 
                     SinglePlayerPuzzleHintViews = await _context.SinglePlayerPuzzleHintStatePerPlayer.Where((h) => h.UnlockTime != null && h.Hint.Puzzle.Event == Event)
-                            .Select(hspp => new SinglePlayerPuzzleHintView { PlayerId = hspp.PlayerID, PlayerName = hspp.Player.Name, PuzzleId = hspp.Hint.Puzzle.ID, PuzzleName = hspp.Hint.Puzzle.Name, Description = hspp.Hint.Description, Cost = hspp.Hint.Cost, UnlockTime = hspp.UnlockTime })
+                            .Select(hspp => new SinglePlayerPuzzleHintView { PlayerId = hspp.PlayerID, PlayerName = hspp.Player.Name, PuzzleId = hspp.Hint.Puzzle.ID, PuzzleName = hspp.Hint.Puzzle.PlaintextName, Description = hspp.Hint.Description, Cost = hspp.Hint.Cost, UnlockTime = hspp.UnlockTime })
                             .ToListAsync();
                 }
                 else
@@ -69,7 +69,7 @@ namespace ServerCore.Pages.Hints
                         HintViews = await (from p in UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
                                            join hspt in _context.HintStatePerTeam on p equals hspt.Hint.Puzzle
                                            where hspt.UnlockTime != null
-                                           select new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.Name, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
+                                           select new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.PlaintextName, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
                                            .ToListAsync();
                     }
                     else
@@ -77,14 +77,14 @@ namespace ServerCore.Pages.Hints
                         HintViews = await (from p in UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
                                            join hspt in _context.HintStatePerTeam on p equals hspt.Hint.Puzzle
                                            where hspt.UnlockTime != null && hspt.TeamID == teamId
-                                           select new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.Name, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
+                                           select new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.PlaintextName, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
                                            .ToListAsync();
                     }
 
                     SinglePlayerPuzzleHintViews = await (from p in UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
                                                          join hspp in _context.SinglePlayerPuzzleHintStatePerPlayer on p.ID equals hspp.Hint.PuzzleID
                                                          where hspp.UnlockTime != null
-                                                         select new SinglePlayerPuzzleHintView { PlayerId = hspp.PlayerID, PlayerName = hspp.Player.Name, PuzzleId = hspp.Hint.Puzzle.ID, PuzzleName = hspp.Hint.Puzzle.Name, Description = hspp.Hint.Description, Cost = hspp.Hint.Cost, UnlockTime = hspp.UnlockTime })
+                                                         select new SinglePlayerPuzzleHintView { PlayerId = hspp.PlayerID, PlayerName = hspp.Player.Name, PuzzleId = hspp.Hint.Puzzle.ID, PuzzleName = hspp.Hint.Puzzle.PlaintextName, Description = hspp.Hint.Description, Cost = hspp.Hint.Cost, UnlockTime = hspp.UnlockTime })
                                                          .ToListAsync();
                 }
             }
@@ -110,7 +110,7 @@ namespace ServerCore.Pages.Hints
                 {
                     HintViews = new List<HintView>();
                     SinglePlayerPuzzleHintViews = await _context.SinglePlayerPuzzleHintStatePerPlayer.Where((h) => h.UnlockTime != null && h.Hint.PuzzleID == puzzleId)
-                            .Select(hspp => new SinglePlayerPuzzleHintView { PlayerId = hspp.PlayerID, PlayerName = hspp.Player.Name, PuzzleId = hspp.Hint.Puzzle.ID, PuzzleName = hspp.Hint.Puzzle.Name, Description = hspp.Hint.Description, Cost = hspp.Hint.Cost, UnlockTime = hspp.UnlockTime })
+                            .Select(hspp => new SinglePlayerPuzzleHintView { PlayerId = hspp.PlayerID, PlayerName = hspp.Player.Name, PuzzleId = hspp.Hint.Puzzle.ID, PuzzleName = hspp.Hint.Puzzle.PlaintextName, Description = hspp.Hint.Description, Cost = hspp.Hint.Cost, UnlockTime = hspp.UnlockTime })
                             .ToListAsync();
                 }
                 else
@@ -119,13 +119,13 @@ namespace ServerCore.Pages.Hints
                     if (teamId == null)
                     {
                         HintViews = await _context.HintStatePerTeam.Where((h) => h.UnlockTime != null && h.Hint.Puzzle == Puzzle)
-                                .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.Name, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
+                                .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.PlaintextName, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
                                 .ToListAsync();
                     }
                     else
                     {
                         HintViews = await _context.HintStatePerTeam.Where((h) => h.UnlockTime != null && h.TeamID == teamId && h.Hint.Puzzle == Puzzle)
-                                .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.Name, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
+                                .Select(hspt => new HintView { TeamId = hspt.TeamID, TeamName = hspt.Team.Name, PuzzleId = hspt.Hint.Puzzle.ID, PuzzleName = hspt.Hint.Puzzle.PlaintextName, Description = hspt.Hint.Description, Cost = hspt.Hint.Cost, UnlockTime = hspt.UnlockTime })
                                 .ToListAsync();
                     }
                 }

--- a/ServerCore/Pages/Hints/Index.cshtml.cs
+++ b/ServerCore/Pages/Hints/Index.cshtml.cs
@@ -26,7 +26,7 @@ namespace ServerCore.Pages.Hints
         {
             PuzzleId = puzzleId;
             Hints = await _context.Hints.Where(hint => hint.Puzzle.ID == puzzleId).OrderBy(hint => hint.DisplayOrder).ThenBy(hint => hint.Description).ToListAsync();
-            PuzzleName = await _context.Puzzles.Where(puzzle => puzzle.ID == puzzleId).Select(puzzle => puzzle.Name).FirstOrDefaultAsync();
+            PuzzleName = await _context.Puzzles.Where(puzzle => puzzle.ID == puzzleId).Select(puzzle => puzzle.PlaintextName).FirstOrDefaultAsync();
         }
     }
 }

--- a/ServerCore/Pages/Hints/Responses.cshtml.cs
+++ b/ServerCore/Pages/Hints/Responses.cshtml.cs
@@ -32,14 +32,14 @@ namespace ServerCore.Pages.Hints
             if (EventRole == EventRole.admin)
             {
                 HintViews = await _context.Hints.Where(h => h.Puzzle.Event == Event)
-                    .Select(h => new HintView { PuzzleId = h.Puzzle.ID, PuzzleName = h.Puzzle.Name, Description = h.Description, Content=h.Content, Cost = h.Cost })
+                    .Select(h => new HintView { PuzzleId = h.Puzzle.ID, PuzzleName = h.Puzzle.PlaintextName, Description = h.Description, Content=h.Content, Cost = h.Cost })
                     .ToListAsync();
             }
             else
             {
                 HintViews = await (from p in UserEventHelper.GetPuzzlesForAuthorAndEvent(_context, Event, LoggedInUser)
                                    join h in _context.Hints on p equals h.Puzzle
-                                   select new HintView { PuzzleId = p.ID, PuzzleName = p.Name, Description = h.Description, Content = h.Content, Cost = h.Cost })
+                                   select new HintView { PuzzleId = p.ID, PuzzleName = p.PlaintextName, Description = h.Description, Content = h.Content, Cost = h.Cost })
                                    .ToListAsync();
             }
 

--- a/ServerCore/Pages/Pieces/Create.cshtml
+++ b/ServerCore/Pages/Pieces/Create.cshtml
@@ -6,7 +6,7 @@
     ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
 }
 
-<h2>@Model.Puzzle.Name:  Create puzzle piece</h2>
+<h2>@Model.Puzzle.PlaintextName:  Create puzzle piece</h2>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>

--- a/ServerCore/Pages/Pieces/CreateBulk.cshtml
+++ b/ServerCore/Pages/Pieces/CreateBulk.cshtml
@@ -9,7 +9,7 @@
     ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
 }
 
-<h2>@Model.Puzzle.Name: Create pieces (bulk)</h2>
+<h2>@Model.Puzzle.PlaintextName: Create pieces (bulk)</h2>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>

--- a/ServerCore/Pages/Pieces/Delete.cshtml
+++ b/ServerCore/Pages/Pieces/Delete.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Delete";
 }
 
-<h2>@Model.Piece.Puzzle.Name:  Delete piece</h2>
+<h2>@Model.Piece.Puzzle.PlaintextName:  Delete piece</h2>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>
@@ -19,7 +19,7 @@
             Puzzle
         </dt>
         <dd>
-            @Model.Piece.Puzzle.Name
+            @Model.Piece.Puzzle.PlaintextName
         </dd>
         <dt>
             ProgressLevel

--- a/ServerCore/Pages/Pieces/Edit.cshtml
+++ b/ServerCore/Pages/Pieces/Edit.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Edit puzzle piece";
 }
 
-<h2>@Model.Piece.Puzzle.Name:  Edit puzzle piece</h2>
+<h2>@Model.Piece.Puzzle.PlaintextName:  Edit puzzle piece</h2>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>

--- a/ServerCore/Pages/Pieces/SimpleMeta.cshtml
+++ b/ServerCore/Pages/Pieces/SimpleMeta.cshtml
@@ -2,10 +2,10 @@
 @model ServerCore.Pages.Pieces.SimpleMetaModel
 
 @{
-    ViewData["Title"] = $"{Model.Puzzle.Name} Meta";
+    ViewData["Title"] = $"{Model.Puzzle.PlaintextName} Meta";
 }
 
-<h2>@(Model.Puzzle.Name) Pieces Earned</h2>
+<h2>@ServerCore.Helpers.RawHtmlHelper.Display(@Model.Puzzle.Name, Model.Event.ID, Html) Pieces Earned</h2>
 
 <table class="table">
     <tbody>

--- a/ServerCore/Pages/PuzzleApiController.cs
+++ b/ServerCore/Pages/PuzzleApiController.cs
@@ -94,7 +94,7 @@ namespace ServerCore.Pages
 
             MailInfo mailInfo = new MailInfo();
 
-            mailInfo.PuzzleName = puzzle.Name;
+            mailInfo.PuzzleName = puzzle.PlaintextName;
             mailInfo.PuzzleSupportAlias = puzzle.SupportEmailAlias ?? currentEvent.ContactEmail ?? "puzzhunt@microsoft.com";
             mailInfo.TeamName = team.Name;
 

--- a/ServerCore/Pages/Puzzles/Feedback.cshtml
+++ b/ServerCore/Pages/Puzzles/Feedback.cshtml
@@ -64,7 +64,7 @@ else
         {
             <tr>
                 <td>
-                    @item.Puzzle.Name
+                    @item.Puzzle.PlaintextName
                 </td>
                 <td>
                     @item.TeamName

--- a/ServerCore/Pages/Puzzles/Feedback.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Feedback.cshtml.cs
@@ -94,7 +94,7 @@ namespace ServerCore.Pages.Puzzles
                     return Forbid();
                 }
 
-                PuzzleName = puzzle.Name;
+                PuzzleName = puzzle.PlaintextName;
 
                 Dictionary<int, string> playerIdToTeamName = _context.TeamMembers
                     .Where(teamMember => teamMember.Team.Event == Event)

--- a/ServerCore/Pages/Puzzles/FileManagement.cshtml
+++ b/ServerCore/Pages/Puzzles/FileManagement.cshtml
@@ -28,7 +28,7 @@
     }
 </script>
 
-<h2>@Model.Puzzle.Name: File management</h2>
+<h2>@Model.Puzzle.PlaintextName: File management</h2>
 
 <div>
     <hr />

--- a/ServerCore/Pages/Puzzles/SinglePlayerPuzzleHints.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/SinglePlayerPuzzleHints.cshtml.cs
@@ -169,7 +169,7 @@ namespace ServerCore.Pages.Puzzles
             PuzzleID = puzzleId;
             PuzzleName = await (from Puzzle in _context.Puzzles
                                 where Puzzle.ID == puzzleId
-                                select Puzzle.Name).FirstOrDefaultAsync();
+                                select Puzzle.PlaintextName).FirstOrDefaultAsync();
             Hints = await GetHints(puzzleId);
 
             if (this.PlayerInEvent == null)

--- a/ServerCore/Pages/Puzzles/SinglePlayerPuzzleStatus.cshtml
+++ b/ServerCore/Pages/Puzzles/SinglePlayerPuzzleStatus.cshtml
@@ -10,7 +10,7 @@
     Layout = "_puzzleManagementLayout.cshtml";
 }
 
-<h2>@Model.Puzzle.Name: Status</h2>
+<h2>@Model.Puzzle.PlaintextName: Status</h2>
 @if (Model.UnlockedTime != null)
 {
     <h4 style="color:green">Puzzle was unlocked for all players at @Html.Raw(Model.LocalTime(Model.UnlockedTime))</h4>

--- a/ServerCore/Pages/Puzzles/Status.cshtml
+++ b/ServerCore/Pages/Puzzles/Status.cshtml
@@ -10,7 +10,7 @@
     Layout = "_puzzleManagementLayout.cshtml";
 }
 
-<h2>@Model.Puzzle.Name: Status</h2>
+<h2>@Model.Puzzle.PlaintextName: Status</h2>
 
 <table class="table">
     <thead>

--- a/ServerCore/Pages/Puzzles/SubmitFeedback.cshtml
+++ b/ServerCore/Pages/Puzzles/SubmitFeedback.cshtml
@@ -10,7 +10,7 @@
     var id = ViewContext.RouteData.Values["puzzleId"];
 }
 
-<h2>Submit feedback for @(Model.Puzzle.Name)</h2>
+<h2>Submit feedback for @(Model.Puzzle.PlaintextName)</h2>
 <div>
     <a asp-page="/Puzzles/Play">Back to puzzle list</a>
 </div>

--- a/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml
+++ b/ServerCore/Pages/Puzzles/UnlockSinglePlayerPuzzleForPlayer.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = "Unlock single player puzzle for player";
 }
 
-<h2>Unlock @Model.Puzzle.Name for a player</h2>
+<h2>Unlock @Model.Puzzle.PlaintextName for a player</h2>
 
 <div>
     <a asp-page="/Puzzles/SinglePlayerPuzzleStatus" asp-route-puzzleid=@Model.Puzzle.ID>Cancel</a>

--- a/ServerCore/Pages/Responses/Create.cshtml
+++ b/ServerCore/Pages/Responses/Create.cshtml
@@ -23,7 +23,7 @@
     }
 </script>
 
-<h2>@Model.Puzzle.Name: Create response</h2>
+<h2>@Model.Puzzle.PlaintextName: Create response</h2>
 <h5>Note: ResponseText can either be plaintext or Raw HTML.</h5>
 <h5>If you are using HTML, write it as "<i>&lt;Plaintext version&gt;</i> Html.Raw(<i>&lt;YOUR HTML&gt;</i>)" and <b>CHECK IT VERY CAREFULLY!</b><br />Example: You are correct Html.Raw(&lt;span&gt;You are &lt;b&gt;correct&lt;/b&gt;/&lt;span&gt;)<br />Failure to be careful may make responses uneditable, and you may have to delete your puzzle and start over.</h5>
 <div>

--- a/ServerCore/Pages/Responses/CreateBulk.cshtml
+++ b/ServerCore/Pages/Responses/CreateBulk.cshtml
@@ -9,7 +9,7 @@
     ViewData["RoutingPuzzleId"] = ViewContext.RouteData.Values["puzzleId"];
 }
 
-<h2>@Model.Puzzle.Name: Create responses (bulk)</h2>
+<h2>@Model.Puzzle.PlaintextName: Create responses (bulk)</h2>
 <h5>Note: ResponseText can either be plaintext or Raw HTML.</h5>
 <h5>If you are using HTML, write it as "<i>&lt;Plaintext version&gt;</i> Html.Raw(<i>&lt;YOUR HTML&gt;</i>)" and <b>CHECK IT VERY CAREFULLY!</b><br />Example: You are correct Html.Raw(&lt;span&gt;You are &lt;b&gt;correct&lt;/b&gt;/&lt;span&gt;)<br />Failure to be careful may make responses uneditable, and you may have to delete your puzzle and start over.</h5>
 <div>

--- a/ServerCore/Pages/Responses/CreateBulkMulti.cshtml.cs
+++ b/ServerCore/Pages/Responses/CreateBulkMulti.cshtml.cs
@@ -72,7 +72,7 @@ namespace ServerCore.Pages.Responses
                 if (puzzleName != null && !puzzleTitleLookup.TryGetValue(puzzleName, out puzzleId))
                 {
                     Puzzle puzzle = await (from Puzzle p in _context.Puzzles
-                                           where p.Name == puzzleName && p.EventID == this.Event.ID
+                                           where p.PlaintextName == puzzleName && p.EventID == this.Event.ID
                                            select p).FirstOrDefaultAsync();
 
                     if (puzzle == null)

--- a/ServerCore/Pages/Responses/Delete.cshtml
+++ b/ServerCore/Pages/Responses/Delete.cshtml
@@ -8,7 +8,7 @@
     //Needs route data - ViewData["PlayRoute"] = "/Submissions/Index";
 }
 
-<h2>@Model.PuzzleResponse.Puzzle.Name: Delete response</h2>
+<h2>@Model.PuzzleResponse.Puzzle.PlaintextName: Delete response</h2>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>

--- a/ServerCore/Pages/Responses/Details.cshtml
+++ b/ServerCore/Pages/Responses/Details.cshtml
@@ -8,7 +8,7 @@
     //Needs route data - ViewData["PlayRoute"] = "/Submissions/Index";
 }
 
-<h2>@Model.PuzzleResponse.Puzzle.Name: Response details</h2>
+<h2>@Model.PuzzleResponse.Puzzle.PlaintextName: Response details</h2>
 <div>
     <a asp-page="./Edit" asp-route-id="@Model.PuzzleResponse.ID" asp-route-puzzleid="@Model.PuzzleId">Edit</a> |
     <a asp-page="./Delete" asp-route-id="@Model.PuzzleResponse.ID" asp-route-puzzleid="@Model.PuzzleId">Delete</a> |

--- a/ServerCore/Pages/Responses/Edit.cshtml
+++ b/ServerCore/Pages/Responses/Edit.cshtml
@@ -8,7 +8,7 @@
     //Needs route data - ViewData["PlayRoute"] = "/Submissions/Index";
 }
 
-<h2>@Model.PuzzleResponse.Puzzle.Name: Edit response</h2>
+<h2>@Model.PuzzleResponse.Puzzle.PlaintextName: Edit response</h2>
 <div>
     <a asp-page="./Index" asp-route-puzzleid="@Model.PuzzleId">Cancel</a>
 </div>

--- a/ServerCore/Pages/Responses/Index.cshtml
+++ b/ServerCore/Pages/Responses/Index.cshtml
@@ -10,7 +10,7 @@
     Layout = "../Puzzles/_puzzleManagementLayout.cshtml";
 }
 
-<h2>@Model.Puzzle.Name: Responses</h2>
+<h2>@Model.Puzzle.PlaintextName: Responses</h2>
 
 <p>
     <a asp-page="Create" asp-route-puzzleId="@Model.PuzzleId">Create New</a> |

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml
@@ -18,7 +18,7 @@
     // TODO: Do we need a combined layout, or is that rare enough as to be unnecessary? Maybe those bar layouts should be sections/components?
 }
 
-<h2>@if (Model.Puzzle != null) { <text>@Model.Puzzle.Name:</text> } Submissions @if (Model.Team != null) { <text>by @Model.Team.Name</text> }</h2>
+<h2>@if (Model.Puzzle != null) { <text>@Model.Puzzle.PlaintextName:</text> } Submissions @if (Model.Team != null) { <text>by @Model.Team.Name</text> }</h2>
 <a asp-page="/Puzzles/Index">Back to puzzle list</a> | <a asp-page="/Submissions/SubmissionsWithoutResponses" asp-route-puzzleId="@Model.Puzzle?.ID">Submissions without responses</a>
 <div>
     @if(Model.Puzzle != null) { <a asp-page="./AuthorIndex" asp-route-puzzleId="" asp-route-teamId="@Model.Team?.ID" asp-route-hideFreeform="@Model.HideFreeform" asp-route-favoritesOnly="@Model.FavoritesOnly">Clear Puzzle Filter</a> }

--- a/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
+++ b/ServerCore/Pages/Submissions/AuthorIndex.cshtml.cs
@@ -176,7 +176,7 @@ namespace ServerCore.Pages.Submissions
                 {
                     SubmitterName = s.Submitter.Name,
                     PuzzleID = s.Puzzle.ID,
-                    PuzzleName = s.Puzzle.Name,
+                    PuzzleName = s.Puzzle.PlaintextName,
                     TeamID = s.Team.ID,
                     TeamName = s.Team.Name,
                     IsFreeform = s.Puzzle.IsFreeform,

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml
@@ -10,7 +10,7 @@
     if (Model.Puzzle != null)
     {
         Layout = "../Puzzles/_puzzleManagementLayout.cshtml";
-        <h2>@Model.Puzzle.Name: Freeform Queue</h2>
+        <h2>@Model.Puzzle.PlaintextName: Freeform Queue</h2>
     }
     else
     {

--- a/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
+++ b/ServerCore/Pages/Submissions/FreeformQueue.cshtml.cs
@@ -106,7 +106,7 @@ namespace ServerCore.Pages.Submissions
                                   select new SubmissionView()
                                   {
                                       PuzzleId = puzzle.ID,
-                                      PuzzleName = puzzle.Name,
+                                      PuzzleName = puzzle.PlaintextName,
                                       TeamName = pspt.Team.Name,
                                       SubmissionText = submission.UnformattedSubmissionText,
                                       SubmissionId = submission.ID,
@@ -176,9 +176,9 @@ namespace ServerCore.Pages.Submissions
 
             if (submission != null)
             {
-                MailHelper.Singleton.SendPlaintextOneAddress(submission.Submitter.Email, $"{submission.Puzzle.PlaintextName} Submission {Result}", $"Your submission for {submission.Puzzle.Name} has been {Result} with the response: {FreeformResponse}");
+                MailHelper.Singleton.SendPlaintextOneAddress(submission.Submitter.Email, $"{submission.Puzzle.PlaintextName} Submission {Result}", $"Your submission for {submission.Puzzle.PlaintextName} has been {Result} with the response: {FreeformResponse}");
 
-                await this.messageHub.SendNotification(submission.Submitter, $"{submission.Puzzle.PlaintextName} Submission {Result}", $"Your submission for {submission.Puzzle.Name} has been {Result} with the response: {FreeformResponse}");
+                await this.messageHub.SendNotification(submission.Submitter, $"{submission.Puzzle.PlaintextName} Submission {Result}", $"Your submission for {submission.Puzzle.PlaintextName} has been {Result} with the response: {FreeformResponse}");
             }
 
             return RedirectToPage();

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -6,7 +6,7 @@
 
     if (Model.Event.EmbedPuzzles)
     {
-        ViewData["Title"] = Model.Puzzle.Name;
+        ViewData["Title"] = Model.Puzzle.PlaintextName;
     }
     else
     {

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -230,7 +230,7 @@ namespace ServerCore.Pages.Submissions
                     var authors = await _context.PuzzleAuthors.Where((pa) => pa.Puzzle == submission.Puzzle).Select((pa) => pa.Author.Email).ToListAsync();
                     string affectedEntity = IsPuzzleForSinglePlayer ? $"User {LoggedInUser.Name ?? LoggedInUser.Email}" : $"Team {Team.Name}";
                     MailHelper.Singleton.SendPlaintextBcc(authors,
-                        $"{Event.Name}: {affectedEntity} is in email mode for {submission.Puzzle.Name}",
+                        $"{Event.Name}: {affectedEntity} is in email mode for {submission.Puzzle.PlaintextName}",
                         "");
                 }
                 else
@@ -312,7 +312,7 @@ namespace ServerCore.Pages.Submissions
                 .Where(pa => pa.Puzzle.ID == Puzzle.ID)
                 .Select(pa => pa.Author).ToArrayAsync();
 
-            string claimMessage = $"{LoggedInUser.Name} has claimed {Puzzle.Name} for testing.";
+            string claimMessage = $"{LoggedInUser.Name} has claimed {Puzzle.PlaintextName} for testing.";
             foreach (var author in authors)
             {
                 await messageHub.SendNotification(author, "Puzzle Claimed", claimMessage);

--- a/ServerCore/Pages/Submissions/SinglePlayerPuzzleAuthorIndex.cshtml
+++ b/ServerCore/Pages/Submissions/SinglePlayerPuzzleAuthorIndex.cshtml
@@ -17,7 +17,7 @@
 <h2>
     @if (Model.Puzzle != null)
     {
-        <text>@Model.Puzzle.Name:</text>
+        <text>@Model.Puzzle.PlaintextName:</text>
     } Submissions @if (Model.PlayerName != null)
     {
         <text>by @Model.PlayerName</text>

--- a/ServerCore/Pages/Submissions/SinglePlayerPuzzleAuthorIndex.cshtml.cs
+++ b/ServerCore/Pages/Submissions/SinglePlayerPuzzleAuthorIndex.cshtml.cs
@@ -161,7 +161,7 @@ namespace ServerCore.Pages.Submissions
                 {
                     SubmitterName = s.Submitter.Name,
                     PuzzleID = s.Puzzle.ID,
-                    PuzzleName = s.Puzzle.Name,
+                    PuzzleName = s.Puzzle.PlaintextName,
                     IsFreeform = s.Puzzle.IsFreeform,
                     SubmissionText = s.Puzzle.IsFreeform ? s.UnformattedSubmissionText : s.SubmissionText,
                     ResponseText = s.Response == null ? null : s.Response.ResponseText,

--- a/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml
+++ b/ServerCore/Pages/Submissions/SubmissionsWithoutResponses.cshtml
@@ -23,7 +23,7 @@
 }
 else
 {
-    <h2>Incorrect Submissions for "@Model.Puzzle.Name"</h2>
+    <h2>Incorrect Submissions for "@Model.Puzzle.PlaintextName"</h2>
     <div>
         <a asp-page="./SubmissionsWithoutResponses" asp-route-puzzleId="">Clear Puzzle Filter</a>
     </div>
@@ -52,7 +52,7 @@ else
             {
                 <tr>
                     <td>
-                        <a asp-page="./SubmissionsWithoutResponses" asp-route-puzzleId="@item.PuzzleID">@item.PuzzleName</a>
+                        <a asp-page="./SubmissionsWithoutResponses" asp-route-puzzleId="@item.PuzzleID">@ServerCore.Helpers.RawHtmlHelper.Display(item.PuzzleName, Model.Event.ID, Html)</a>
                     </td>
                     <td>
                         @item.SubmissionText

--- a/ServerCore/Pages/Teams/Answers.cshtml
+++ b/ServerCore/Pages/Teams/Answers.cshtml
@@ -22,7 +22,7 @@
             </th>
             <th>
                 <a asp-page="./Answers" asp-route-teamId="@Model.TeamID" asp-route-sort="@(Model.SortForColumnLink(AnswersModel.SortOrder.GroupAscending, AnswersModel.SortOrder.GroupDescending))">
-                    Group
+                    @(Model.Event.TermForGroup ?? "Group")
                 </a>
             </th>
             <th>
@@ -46,10 +46,10 @@
                     @Html.Raw(Model.LocalTime(item.SolvedTime))
                 </td>
                 <td class="puzzle-list-group-customizable">
-                    @item.Group
+                    @ServerCore.Helpers.RawHtmlHelper.Display(item.Group, Model.Event.ID, Html)
                 </td>
                 <td class="puzzle-list-title-customizable">
-                    @item.Name
+                    @ServerCore.Helpers.RawHtmlHelper.Display(item.Name, Model.Event.ID, Html)
                 </td>
                 @if(string.IsNullOrEmpty(item.SubmissionText)) {
                     <td class="puzzle-list-submission-customizable">

--- a/ServerCore/Pages/Teams/Hints.cshtml.cs
+++ b/ServerCore/Pages/Teams/Hints.cshtml.cs
@@ -147,7 +147,7 @@ namespace ServerCore.Pages.Teams
                 where Puzzle.ID == puzzleId
                 select Puzzle).FirstOrDefaultAsync();
 
-            PuzzleName = puzzle?.Name;
+            PuzzleName = puzzle?.PlaintextName;
 
             bool shouldShowThreadOption = Event.DefaultCostForHelpThread >= 0;
             HintViewStates = await GetAllTeamHints(puzzle, teamId);

--- a/ServerCore/Pages/Teams/Status.cshtml
+++ b/ServerCore/Pages/Teams/Status.cshtml
@@ -45,28 +45,28 @@
         {
             <tr>
                 <td>
-                    <a asp-page="../Puzzles/Status" asp-route-puzzleid="@item.Puzzle.ID">@item.Puzzle.Name</a>
+                    <a asp-page="../Puzzles/Status" asp-route-puzzleid="@item.Puzzle.ID">@item.Puzzle.PlaintextName</a>
                 </td>
                 <td>
                     @if (item.UnlockedTime == null)
                     {
-                        <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as unlocked?')">Unlock</a>
+                        <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.PlaintextName) as unlocked?')">Unlock</a>
                     }
                     else
                     {
                         @Html.Raw(Model.LocalTime(item.UnlockedTime))
-                        <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as locked?')"> X</a>
+                        <a asp-page-handler="UnlockState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.PlaintextName) as locked?')"> X</a>
                     }
                 </td>
                 <td>
                     @if (item.SolvedTime == null)
                     {
-                        <a asp-page-handler="SolveState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as solved?')">Solve</a>
+                        <a asp-page-handler="SolveState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.PlaintextName) as solved?')">Solve</a>
                     }
                     else
                     {
                         @Html.Raw(Model.LocalTime(item.SolvedTime))
-                        <a asp-page-handler="SolveState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.Name) as unsolved?')"> X</a>
+                        <a asp-page-handler="SolveState" asp-route-sort="@Model.Sort" asp-route-puzzleId="@item.Puzzle.ID" asp-route-teamId="@Model.Team.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Puzzle.PlaintextName) as unsolved?')"> X</a>
                     }
                 </td>
                 <td>
@@ -78,11 +78,11 @@
                 <td>
                     @if (item.IsEmailOnlyMode == true)
                     {
-                        <a asp-page-handler="EmailMode" asp-route-sort="@Model.Sort" asp-route-teamId="@Model.Team.ID" asp-route-puzzleid="@item.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to release @(item.Puzzle.Name) from email-only mode?')">Release</a>
+                        <a asp-page-handler="EmailMode" asp-route-sort="@Model.Sort" asp-route-teamId="@Model.Team.ID" asp-route-puzzleid="@item.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to release @(item.Puzzle.PlaintextName) from email-only mode?')">Release</a>
                     }
                     else
                     {
-                        <a asp-page-handler="EmailMode" asp-route-sort="@Model.Sort" asp-route-teamId="@Model.Team.ID" asp-route-puzzleid="@item.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to restrict @(item.Puzzle.Name) to email-only mode?')">Restrict</a>
+                        <a asp-page-handler="EmailMode" asp-route-sort="@Model.Sort" asp-route-teamId="@Model.Team.ID" asp-route-puzzleid="@item.Puzzle.ID" asp-route-value="true" onclick="return confirm('Are you sure you want to restrict @(item.Puzzle.PlaintextName) to email-only mode?')">Restrict</a>
                     }
                 </td>
             </tr>

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -129,7 +129,7 @@ namespace ServerCore.Pages.Threads
                     return NotFound();
                 }
 
-                subject = $"[{singlePlayerPuzzlePlayer.Name}]{Puzzle.Name}";
+                subject = $"[{singlePlayerPuzzlePlayer.Name}]{Puzzle.PlaintextName}";
                 threadId = MessageHelper.GetSinglePlayerPuzzleThreadId(Puzzle.ID, playerId.Value);
                 teamId = null;
                 PuzzleState = await SinglePlayerPuzzleStateHelper.GetOrAddStateIfNotThere(
@@ -153,7 +153,7 @@ namespace ServerCore.Pages.Threads
                     return NotFound();
                 }
 
-                subject = $"[{team.Name}]{Puzzle.Name}";
+                subject = $"[{team.Name}]{Puzzle.PlaintextName}";
                 threadId = MessageHelper.GetTeamPuzzleThreadId(Puzzle.ID, teamId.Value);
                 playerId = null;
                 PuzzleState = await PuzzleStateHelper

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml.cs
@@ -96,7 +96,7 @@ namespace ServerCore.Pages.Threads
                 }
 
                 messages = messages.Where(message => message.PuzzleID == puzzleId.Value);
-                this.Title = $"Help threads for puzzle {puzzle.Name}";
+                this.Title = $"Help threads for puzzle {puzzle.PlaintextName}";
             }
 
             if (teamId.HasValue)

--- a/ServerCore/PuzzleStateHelper.cs
+++ b/ServerCore/PuzzleStateHelper.cs
@@ -212,7 +212,7 @@ namespace ServerCore
                 // only send this notification when puzzles are embedded; otherwise, the notification is sent when there are no pages connected!
                 if (eventObj.EmbedPuzzles && puzzle.IsPuzzle)
                 {
-                    await ServiceProvider.GetRequiredService<IHubContext<ServerMessageHub>>().SendNotification(team, "Puzzle solved!", $"{puzzle.Name} has been solved!", $"/{puzzle.Event.EventID}/play/Submissions/{puzzle.ID}");
+                    await ServiceProvider.GetRequiredService<IHubContext<ServerMessageHub>>().SendNotification(team, "Puzzle solved!", $"{puzzle.PlaintextName} has been solved!", $"/{puzzle.Event.EventID}/play/Submissions/{puzzle.ID}");
                 }
 
                 await UnlockAnyPuzzlesThatThisSolveUnlockedAsync(context,
@@ -525,7 +525,7 @@ namespace ServerCore
 
                         foreach (var puzzle in puzzles)
                         {
-                            await ServiceProvider.GetRequiredService<IHubContext<ServerMessageHub>>().SendNotification(t, "New puzzle!", $"{puzzle.Name} has been unlocked!", $"/{eventObj.EventID}/play/Submissions/{puzzle.ID}");
+                            await ServiceProvider.GetRequiredService<IHubContext<ServerMessageHub>>().SendNotification(t, "New puzzle!", $"{puzzle.PlaintextName} has been unlocked!", $"/{eventObj.EventID}/play/Submissions/{puzzle.ID}");
                         }
                     }
                 }


### PR DESCRIPTION
Adding support for the raw syntax to a whole mess of scenarios. Should fix most/all issues in #1173 and a whole mess of unreported issues.

Note that a lot of these changes use puzzle.PlaintextName, which is already used in many places, defined as follows, and must be provided for this to work:

        /// The plaintext name of the puzzle, which is a subset of the name when the name is of the form:
        /// {plaintextName}Html.Raw({htmlName})