### PR TITLE
Fix bulk hints crash

### DIFF
--- a/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
+++ b/ServerCore/Pages/Hints/CreateBulk.cshtml.cs
@@ -47,7 +47,8 @@ namespace ServerCore.Pages.Hints
 
         public async Task<IActionResult> OnPostAsync(int puzzleId)
         {
-            if (!ModelState.IsValid)
+            Puzzle = await _context.Puzzles.Where(m => m.ID == puzzleId).FirstOrDefaultAsync();
+            if (Puzzle == null || !ModelState.IsValid)
             {
                 return Page();
             }


### PR DESCRIPTION
The single-player-puzzle check in OnPostAsync was assuming that Puzzle was initialized, but it wasn't.