### PR TITLE
Adjust time on server, proof of concept

### DIFF
--- a/ServerCore/Components/NotificationComponent.razor.cs
+++ b/ServerCore/Components/NotificationComponent.razor.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using ServerCore.Helpers;
 
 namespace ServerCore.Components
 {
@@ -30,6 +31,20 @@ namespace ServerCore.Components
         {
             NotificationHelper.RegisterForNotifications(EventID, TeamID, UserID, this.OnNotify);
             base.OnInitialized();
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender && UserID.HasValue && !TimeHelper.TryGetTimeZone(UserID.Value, out var timeZoneInfo))
+            {
+                string timeZone = await this.JS.InvokeAsync<string>("getBrowserTimeZone");
+                if (!TimeZoneInfo.TryFindSystemTimeZoneById(timeZone, out timeZoneInfo))
+                {
+                    timeZoneInfo = null;
+                }
+                TimeHelper.SetTimeZone(UserID.Value, timeZoneInfo);
+            }
+            base.OnAfterRender(firstRender);
         }
 
         private Task OnNotify(Notification notification)

--- a/ServerCore/Helpers/TimeHelper.cs
+++ b/ServerCore/Helpers/TimeHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -8,14 +9,35 @@ namespace ServerCore.Helpers
 {
     public static class TimeHelper
     {
+        private static Dictionary<int, TimeZoneInfo> TimeZoneLookup = new Dictionary<int, TimeZoneInfo>();
+        public static bool TryGetTimeZone(int userId, out TimeZoneInfo result)
+        {
+            return TimeZoneLookup.TryGetValue(userId, out result);
+        }
+
+        public static void SetTimeZone(int userId, TimeZoneInfo timeZone)
+        {
+            TimeZoneLookup[userId] = timeZone;
+        }
+
         /// <summary>
         /// returns a time with the formatting required for the jQuery code in site.js to convert it to browser local time
         /// </summary>
         /// <param name="date"></param>
         /// <returns></returns>
-        public static string LocalTime(DateTime? date)
+        public static string LocalTime(DateTime? date, int userId)
         {
-            return date == null ? "&nbsp;" : $"<time>{date.Value.ToString("yyyy-MM-ddTHH:mm:ssZ")}</time>";
+            if (date == null)
+            {
+                return "&nbsp;";
+            }
+            else if (TryGetTimeZone(userId, out TimeZoneInfo timeZone) && timeZone != null)
+            {
+                // TODO is there a way to get a format in the user's culture etc
+                // Note: DO NOT use <time> here because then it would be adjusted on both server and client!
+                return (date.Value + timeZone.BaseUtcOffset).ToString();
+            }
+            return $"<time>{date.Value.ToString("yyyy-MM-ddTHH:mm:ssZ")}</time>";
         }
     }
 }

--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -204,7 +204,7 @@ namespace ServerCore.ModelBases
 
         public string LocalTime(DateTime? date)
         {
-            return TimeHelper.LocalTime(date);
+            return TimeHelper.LocalTime(date, LoggedInUser.ID);
         }
 
         public bool IsGameControlRole()

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -460,6 +460,11 @@
             });
         };
 
+        window.getBrowserTimeZone = function() {
+            const options = Intl.DateTimeFormat().resolvedOptions();
+            return options.timeZone;
+        }
+
         document.addEventListener("DOMContentLoaded", function () { resetAllToasts(); documentLoaded = true; });
         window.addEventListener("focus", function() { if (documentLoaded) { resetAllToasts(); } });
     </script>


### PR DESCRIPTION
This version has no expiry, so if a user changes time zones without the server front end restarting, they will get the old time zone.

Uses the previous client-based mechanism for the first render, as well as for non-Blazor scenarios.