### PR TITLE
Fix autoteams

### DIFF
--- a/Data/DataModel/Team.cs
+++ b/Data/DataModel/Team.cs
@@ -15,6 +15,10 @@ namespace ServerCore.DataModel
         // Commitment level
         Casual = 0x4,
         Serious = 0x8,
+
+        // Location
+        Local = 0x10,
+        Remote = 0x20,
     }
 
     public class Team

--- a/ServerCore/Pages/Teams/AutoTeam.razor
+++ b/ServerCore/Pages/Teams/AutoTeam.razor
@@ -1,20 +1,30 @@
 @using ServerCore.DataModel;
 
-<p>I&apos;m a...</p>
 <EditForm Model="this" OnValidSubmit="OnSubmit">
     <DataAnnotationsValidator />
     <ValidationSummary />
 
+    @if (IsMicrosoft && Event != null && Event.AllowsRemoteTeams)
+    {
+        <p>I&apos;ll play...</p>
+        <InputRadioGroup Name="PlayerLocation" @bind-Value="PlayerLocation">
+            <label><InputRadio Name="PlayerLocation" Value="@AutoTeamType.Local"></InputRadio> Locally</label><br />
+            <label><InputRadio Name="PlayerLocation" Value="@AutoTeamType.Remote"></InputRadio> Remotely</label><br />
+        </InputRadioGroup>
+        <br />
+    }
+
+    <p>I&apos;m a...</p>
     <InputRadioGroup Name="PlayerExperienceSelector" @bind-Value="PlayerExperience">
-        <label><InputRadio Name="PlayerExperienceSelector" Value="@AutoTeamType.Beginner.ToString()"></InputRadio> Beginner Puzzler</label><br />
-        <label><InputRadio Name="PlayerExperienceSelector" Value="@AutoTeamType.Expert.ToString()"></InputRadio> Expert Puzzler</label><br />
+        <label><InputRadio Name="PlayerExperienceSelector" Value="@AutoTeamType.Beginner"></InputRadio> Beginner Puzzler</label><br />
+        <label><InputRadio Name="PlayerExperienceSelector" Value="@AutoTeamType.Expert"></InputRadio> Expert Puzzler</label><br />
     </InputRadioGroup>
 
     <br />
     <p>... and I&apos;m feeling...</p>
     <InputRadioGroup Name="PlayerCommitmentSelector" @bind-Value="PlayerCommitment">
-        <label><InputRadio Name="PlayerCommitmentSelector" Value="@AutoTeamType.Casual.ToString()"></InputRadio> Chill about the event -- I&apos;m just here to have fun</label><br />
-        <label><InputRadio Name="PlayerCommitmentSelector" Value="@AutoTeamType.Serious.ToString()"></InputRadio> Serious -- I&apos;m in it to win it</label><br />
+        <label><InputRadio Name="PlayerCommitmentSelector" Value="@AutoTeamType.Casual"></InputRadio> Chill about the event -- I&apos;m just here to have fun</label><br />
+        <label><InputRadio Name="PlayerCommitmentSelector" Value="@AutoTeamType.Serious"></InputRadio> Serious -- I&apos;m in it to win it</label><br />
     </InputRadioGroup>
 
     <input type="submit" value="Place me on a team" />

--- a/ServerCore/Pages/Teams/SignupHub.razor
+++ b/ServerCore/Pages/Teams/SignupHub.razor
@@ -5,23 +5,26 @@
         <div class="btn-group" role="group">
         @if (CanCreateTeam)
         {
-            <InputRadio Name="SignupPicker" Value="@SignupStrategy.Create.ToString()" class="btn-check" id="create" />
+            <InputRadio Name="SignupPicker" Value="@SignupStrategy.Create" class="btn-check" id="create" />
             <label class="btn btn-outline-primary" for="create">
                 Create a team
             </label>
         }
         @if (CanJoinTeam)
         {
-            <InputRadio Name="SignupPicker" Value="@SignupStrategy.Join.ToString()" class="btn-check" id="join" />
+            <InputRadio Name="SignupPicker" Value="@SignupStrategy.Join" class="btn-check" id="join" />
             <label class="btn btn-outline-primary" for="join">
                 Apply for an existing team
             </label>
 
             @* Limit auto teams to FTEs and interns if there's a minimum so it always builds teams that meet the minimums *@
             @if (EventRole == ModelBases.EventRole.play && 
-            ((Event != null && Event.MaxExternalsPerTeam >= Event.MaxTeamSize) || IsMicrosoft))
+            ((Event != null && Event.MaxExternalsPerTeam >= Event.MaxTeamSize) ||
+            IsMicrosoft ||
+            (Event != null && Event.AllowsRemoteTeams))
+            )
             {
-                <InputRadio Name="SignupPicker" Value="@SignupStrategy.Auto.ToString()" class="btn-check" id="auto" />
+                <InputRadio Name="SignupPicker" Value="@SignupStrategy.Auto" class="btn-check" id="auto" />
                 <label class="btn btn-outline-primary" for="auto">
                     Choose a team for me
                 </label>
@@ -47,7 +50,7 @@
         <JoinTeam Event="@Event" EventRole="@EventRole" LoggedInUserId="@LoggedInUserId" />
         break;
     case SignupStrategy.Auto:
-        <AutoTeam Event="@Event" EventRole="@EventRole" LoggedInUserId="@LoggedInUserId" />
+        <AutoTeam Event="@Event" EventRole="@EventRole" LoggedInUserId="@LoggedInUserId" IsMicrosoft="@IsMicrosoft" />
         break;
     case SignupStrategy.None:
         break;


### PR DESCRIPTION
Fix auto teams radio and signup hub radio buttons that didn't show that they were clicked (even though they were), differentiate local and remote auto-teams and allow remote auto-teams for non-MS