### PR TITLE
Remove large margins on mobile

### DIFF
--- a/ServerCore/Pages/Shared/_Layout.cshtml
+++ b/ServerCore/Pages/Shared/_Layout.cshtml
@@ -144,7 +144,7 @@
         <partial name="/Pages/Shared/_EventNavigationPartial.cshtml" />
     }
 
-    <div class="container body-content body-content-customizable">
+    <div class="container-md body-content body-content-customizable">
         @if (!string.IsNullOrEmpty(ev?.Announcement))
             {
             <p class="announcement announcement-customizable no-print">@ev?.Announcement</p>


### PR DESCRIPTION
Remove large margins on mobile to give the puzzle and answer box more space