### PR TITLE
Admin quality of life updates

### DIFF
--- a/ServerCore/Pages/Puzzles/Checklist.cshtml
+++ b/ServerCore/Pages/Puzzles/Checklist.cshtml
@@ -26,6 +26,9 @@
                 Author(s)
             </th>
             <th>
+                Custom Author Text
+            </th>
+            <th>
                 Puzzle file
             </th>
             <th>
@@ -36,6 +39,9 @@
             </th>
             <th>
                 Pre-requisites
+            </th>
+            <th>
+                Prerequisite Weight
             </th>
             <th>
                 Min in group count
@@ -77,6 +83,9 @@
                 @item.Authors
             </td>
             <td>
+                @item.CustomAuthorText
+            </td>
+            <td>
                 @if (item.Puzzle.CustomURL != null)
                 {
                     <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.Puzzle, Model.Event.ID)" target="_blank">Link</a>
@@ -105,6 +114,9 @@
                 {
                     <font color="red">WARNING: Fewer prereqs than min</font>
                 }
+            </td>
+            <td>
+                @item.Puzzle.PrerequisiteWeight
             </td>
             <td>
                 @(item.Puzzle.MinInGroupCount)

--- a/ServerCore/Pages/Puzzles/Checklist.cshtml
+++ b/ServerCore/Pages/Puzzles/Checklist.cshtml
@@ -83,7 +83,7 @@
                 @item.Authors
             </td>
             <td>
-                @item.CustomAuthorText
+                @item.Puzzle.CustomAuthorText
             </td>
             <td>
                 @if (item.Puzzle.CustomURL != null)

--- a/ServerCore/Pages/Puzzles/Checklist.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Checklist.cshtml.cs
@@ -23,6 +23,7 @@ namespace ServerCore.Pages.Puzzles
         {
             public Puzzle Puzzle { get; set; }
             public string Authors { get; set; }
+            public string CustomAuthorText { get; set; }
             public ContentFile PuzzleFile { get; set; }
             public ContentFile AnswerFile { get; set; }
             public string Prerequisites { get; set; }
@@ -108,6 +109,7 @@ namespace ServerCore.Pages.Puzzles
                 {
                     Puzzle = puzzle,
                     Authors = authors != null ? string.Join(", ", authors) : "",
+                    CustomAuthorText = puzzle.CustomAuthorText,
                     PuzzleFile = puzzleFile,
                     AnswerFile = puzzleAnswer,
                     Prerequisites = prereqs != null ? string.Join(", ", prereqs.OrderBy(prereq => prereq)) : "",

--- a/ServerCore/Pages/Puzzles/Checklist.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Checklist.cshtml.cs
@@ -23,7 +23,6 @@ namespace ServerCore.Pages.Puzzles
         {
             public Puzzle Puzzle { get; set; }
             public string Authors { get; set; }
-            public string CustomAuthorText { get; set; }
             public ContentFile PuzzleFile { get; set; }
             public ContentFile AnswerFile { get; set; }
             public string Prerequisites { get; set; }
@@ -109,7 +108,6 @@ namespace ServerCore.Pages.Puzzles
                 {
                     Puzzle = puzzle,
                     Authors = authors != null ? string.Join(", ", authors) : "",
-                    CustomAuthorText = puzzle.CustomAuthorText,
                     PuzzleFile = puzzleFile,
                     AnswerFile = puzzleAnswer,
                     Prerequisites = prereqs != null ? string.Join(", ", prereqs.OrderBy(prereq => prereq)) : "",

--- a/ServerCore/Pages/Puzzles/Index.cshtml
+++ b/ServerCore/Pages/Puzzles/Index.cshtml
@@ -79,6 +79,12 @@
             <th>
                 Support
             </th>
+            @if (Model.Event.AllowsRemoteTeams)
+            {
+                <th>
+                    Puzzle Availability
+                </th>
+            }
             <th>
                 Shortcuts
             </th>
@@ -153,6 +159,12 @@
                 <td>
                     @item.Puzzle.SupportEmailAlias
                 </td>
+                @if (Model.Event.AllowsRemoteTeams)
+                {
+                    <td>
+                        @item.Puzzle.Availability
+                    </td>
+                }
                 <td>
                     <div class="shortcut-menu-dropdown">
                         <span><a>Jump to...</a></span>

--- a/ServerCore/Pages/Puzzles/Status.cshtml
+++ b/ServerCore/Pages/Puzzles/Status.cshtml
@@ -82,7 +82,14 @@
                 @if (Model.Event.AllowsRemoteTeams)
                 {
                     <td>
-                        @item.Team.IsRemoteTeam ? Remote : Local
+                        @if(item.Team.IsRemoteTeam)
+                        {
+                            <div>Remote</div>
+                        }
+                        else
+                        {
+                            <div>Local</div>
+                        }
                     </td>
                 }
                 <td>

--- a/ServerCore/Pages/Puzzles/Status.cshtml
+++ b/ServerCore/Pages/Puzzles/Status.cshtml
@@ -30,11 +30,20 @@
                     SolvedTime
                 </a>
             </th>
+            @if (Model.Event.AllowsRemoteTeams)
+            {
+                <th>
+                    Team Location
+                </th>
+            }
             <th>
                 Printed
             </th>
             <th>
                 Notes
+            </th>
+            <th>
+                IsLockedOut
             </th>
             <th>
                 IsEmailOnlyMode
@@ -70,11 +79,20 @@
                         <a asp-page-handler="SolveState" asp-route-sort="@Model.Sort" asp-route-teamId="@item.Team.ID" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-value="false" onclick="return confirm('Are you sure you want to mark @(item.Team.Name) as unsolved?')"> X</a>
                     }
                 </td>
+                @if (Model.Event.AllowsRemoteTeams)
+                {
+                    <td>
+                        @item.Team.IsRemoteTeam ? Remote : Local
+                    </td>
+                }
                 <td>
                     @item.Printed
                 </td>
                 <td>
                     @item.Notes
+                </td>
+                <td>
+                    @item.IsLockedOut
                 </td>
                 <td>
                     @if (item.IsEmailOnlyMode == true)

--- a/ServerCore/Pages/Teams/AllTeams.cshtml
+++ b/ServerCore/Pages/Teams/AllTeams.cshtml
@@ -59,7 +59,7 @@ Registered Teams: <b>@Model.Teams.Count/@Model.Event.MaxNumberOfTeams</b>, Regis
                     <td>
                         if (item.IsRemoteTeam)
                         {
-                        <text>Remote</text>
+                            <text>Remote</text>
                         }
                         else
                         {

--- a/ServerCore/Pages/Teams/AllTeams.cshtml
+++ b/ServerCore/Pages/Teams/AllTeams.cshtml
@@ -11,9 +11,9 @@
 <h2>All teams</h2>
 @if(Model.PlayerNotOnTeam)
 {
-<p>
-    You are not yet part of a team. To join a team, go to the register page.
-</p>
+    <p>
+        You are not yet part of a team. To join a team, go to the register page.
+    </p>
 }
 Registered Teams: <b>@Model.Teams.Count/@Model.Event.MaxNumberOfTeams</b>, Registered Players: <b>@Model.PlayerCount/@(Model.Event.MaxNumberOfTeams * Model.Event.MaxTeamSize)</b>
 <table class="table">
@@ -26,13 +26,16 @@ Registered Teams: <b>@Model.Teams.Count/@Model.Event.MaxNumberOfTeams</b>, Regis
                 Team size
             </th>
             @if (Model.EventRole == ModelBases.EventRole.admin ||
-               Model.EventRole == ModelBases.EventRole.author)
+              Model.EventRole == ModelBases.EventRole.author)
             {
+                @if (Model.Event.AllowsRemoteTeams)
+                {
+                    <th>
+                        Team Location
+                    </th>
+                }
             <th>
                 Qualification Status
-            </th>
-            <th>
-                Team Location
             </th>
             }
         </tr>
@@ -50,21 +53,22 @@ Registered Teams: <b>@Model.Teams.Count/@Model.Event.MaxNumberOfTeams</b>, Regis
                 @if (Model.EventRole == ModelBases.EventRole.admin ||
                      Model.EventRole == ModelBases.EventRole.author)
                 {
-                    <td>
-                    if (item.IsDisqualified)
+                    @if (Model.Event.AllowsRemoteTeams)
                     {
-                        <text>Disqualified</text>
-                    }
-                    </td>
-                    <td>
-                        if (item.IsRemoteTeam)
+                        @if (item.IsRemoteTeam)
                         {
-                            <text>Remote</text>
+                            <td>Remote</td>
                         }
                         else
                         {
-                            <text>Local</text>
+                            <td>Local</td>
                         }
+                    }
+                    <td>
+                    @if (item.IsDisqualified)
+                    {
+                        <text>Disqualified</text>
+                    }
                     </td>
                 }
             </tr>

--- a/ServerCore/Pages/Teams/AllTeams.cshtml
+++ b/ServerCore/Pages/Teams/AllTeams.cshtml
@@ -31,6 +31,9 @@ Registered Teams: <b>@Model.Teams.Count/@Model.Event.MaxNumberOfTeams</b>, Regis
             <th>
                 Qualification Status
             </th>
+            <th>
+                Team Location
+            </th>
             }
         </tr>
     </thead>
@@ -52,6 +55,16 @@ Registered Teams: <b>@Model.Teams.Count/@Model.Event.MaxNumberOfTeams</b>, Regis
                     {
                         <text>Disqualified</text>
                     }
+                    </td>
+                    <td>
+                        if (item.IsRemoteTeam)
+                        {
+                        <text>Remote</text>
+                        }
+                        else
+                        {
+                            <text>Local</text>
+                        }
                     </td>
                 }
             </tr>

--- a/ServerCore/Pages/Teams/Index.cshtml
+++ b/ServerCore/Pages/Teams/Index.cshtml
@@ -70,9 +70,9 @@
             </th>
             @if (Model.EventRole == ModelBases.EventRole.admin && !string.IsNullOrEmpty(Model.Event.TeamAnnouncement))
             {
-            <th>
-                TeamAnnouncement
-            </th>
+                <th>
+                    TeamAnnouncement
+                </th>
             }
             <th>
                 PrimaryContactEmail
@@ -83,6 +83,12 @@
             <th>
                 SecondaryPhoneNumber
             </th>
+            @if (Model.Event.AllowsRemoteTeams)
+            {
+                <th>
+                    Team Location
+                </th>
+            }
             <th>
                 IsDisqualified
             </th>
@@ -135,6 +141,17 @@
                 <td>
                     @item.SecondaryPhoneNumber
                 </td>
+                @if (Model.Event.AllowsRemoteTeams)
+                {
+                    @if (item.IsRemoteTeam)
+                    {
+                        <td>Remote</td>
+                    }
+                    else
+                    {
+                        <td>Local</td>
+                    }
+                }
                 <td>
                     @if(item.IsDisqualified)
                     {

--- a/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml
+++ b/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml
@@ -9,11 +9,11 @@
 
 <style>
     td, th {
-        text-align:center;
+    text-align:center;
     }
 
     .sortButton {
-        padding: 0px 20px;
+    padding: 0px 20px;
     }
 </style>
 <a asp-page="/Teams/Index">Back to team list</a>
@@ -47,9 +47,13 @@
                 <th>
                     Automatic Team Type
                 </th>
-                <th>
-                    Team is Remote
-                </th>
+                @if (Model.Event.AllowsRemoteTeams)
+                {
+                    <th>
+                        Team Location <br />
+                        (Count Remote)
+                    </th>
+                }
                 <th>
                     Total
                 </th>
@@ -80,9 +84,17 @@
                     <td>
                         @teamComp.AutoTeamTypeString
                     </td>
-                    <td>
-                        @teamComp.TeamIsRemote
-                    </td>
+                    @if(Model.Event.AllowsRemoteTeams)
+                    {
+                        @if(teamComp.TeamIsRemote)
+                        {
+                            <td>Remote</td>
+                        }
+                        else
+                        {
+                            <td>Local</td>
+                        }
+                    }
                     <td>
                         @teamComp.Total
                     </td>
@@ -113,9 +125,12 @@
                 </td>
                 <td>
                 </td>
-                <td>
-                    <b>@Model.TotalRemoteCount</b>
-                </td>
+                @if (Model.Event.AllowsRemoteTeams)
+                {
+                    <td>
+                        <b>@Model.TotalRemoteCount</b>
+                    </td>
+                }
                 <td>
                     <b>@Model.TotalTotal</b>
                 </td>

--- a/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
+++ b/ServerCore/Pages/Teams/TeamCompositionSummary.cshtml.cs
@@ -37,6 +37,22 @@ namespace ServerCore.Pages.Teams
             Ascend
         }
 
+        private HashSet<string> NonAliasStrings = new HashSet<string>
+        {
+            "na",
+            "NA",
+            "Na",
+            "none",
+            "None",
+            "123",
+            "secret",
+            "kk",
+            "npl",
+            "NPL",
+            "x",
+            "X" 
+        };
+
         public TeamCompositionSummaryModel(
             PuzzleServerContext serverContext,
             UserManager<IdentityUser> userManager)
@@ -229,7 +245,7 @@ namespace ServerCore.Pages.Teams
                         toReturn.EmployeeCount += 1;
                     }
                 }
-                else if (!string.IsNullOrEmpty(alias) && aliasRegex.IsMatch(alias))
+                else if (IsPossibleAlias(alias))
                 {
                     toReturn.PossibleEmployeeAliases.Add(alias);
                 }
@@ -240,6 +256,15 @@ namespace ServerCore.Pages.Teams
             }
 
             return toReturn;
+        }
+
+        private bool IsPossibleAlias(string alias)
+        {
+            if (string.IsNullOrEmpty(alias)) { return false; }
+            if (!aliasRegex.IsMatch(alias)) { return false; }
+            if(NonAliasStrings.Contains(alias)) { return false; }    
+            
+            return true;
         }
 
         private class IntermediateTeamMember


### PR DESCRIPTION
- Add Custom Author Text and Prerequisite Weight to the Puzzle Checklist
- Expand non-alias checks on TeamCompositionSummary - filters out things that are obviously not Microsoft aliases and doesn't display them as possible aliases on the page (initial dataset is based on common words input by players in the current event)
- Add remote/local team information to Puzzle Status page
- Add puzzle availability to puzzle list for author/admin