### PR TITLE
Split leaderboard remote vs local

### DIFF
--- a/ServerCore/Pages/Events/Standings.cshtml
+++ b/ServerCore/Pages/Events/Standings.cshtml
@@ -10,6 +10,19 @@
 
 <h2>Standings</h2>
 
+@if(Model.Event.AllowsRemoteTeams)
+{ 
+    <p>
+        Filter standings to remote/local/all teams
+    </p>
+    <form method="GET" name="locationForm">
+        <select name="locationFilter" asp-items="@Model.TeamLocationFilter" onchange="this.form.submit();">
+            <option value="">Select Filter</option>
+        </select>
+    </form>
+    <div>@Model.TeamLocationFilter Teams</div>
+}
+
 <table class="table table-condensed">
     <thead>
         <tr>

--- a/ServerCore/Pages/Events/Standings.cshtml
+++ b/ServerCore/Pages/Events/Standings.cshtml
@@ -20,7 +20,8 @@
             <option value="">Select Filter</option>
         </select>
     </form>
-    <div>@Model.TeamLocationFilter Teams</div>
+    <br/><br/>
+    <h3>@Model.LocationDisplayName Teams</h3>
 }
 
 <table class="table table-condensed">

--- a/ServerCore/Pages/Events/Standings.cshtml.cs
+++ b/ServerCore/Pages/Events/Standings.cshtml.cs
@@ -5,12 +5,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.EntityFrameworkCore;
 using ServerCore.DataModel;
-using ServerCore.Helpers;
 using ServerCore.ModelBases;
-using static ServerCore.DataModel.Puzzle;
 
 namespace ServerCore.Pages.Events
 {
@@ -40,10 +37,15 @@ namespace ServerCore.Pages.Events
         {
         }
 
-        public async Task OnGetAsync(SortOrder? sort, TeamLocation locationFilter)
+        public async Task OnGetAsync(SortOrder? sort, TeamLocation? locationFilter)
         {
             Sort = sort;
-            LocationDisplayName = Enum.GetName(locationFilter);
+
+            if (locationFilter == null)
+            {
+                locationFilter = TeamLocation.All;
+            }
+            LocationDisplayName = Enum.GetName(locationFilter.Value);
 
             var puzzleData = await _context.Puzzles
                 .Where(p => p.Event == Event)

--- a/ServerCore/Pages/Events/Standings.cshtml.cs
+++ b/ServerCore/Pages/Events/Standings.cshtml.cs
@@ -21,6 +21,8 @@ namespace ServerCore.Pages.Events
 
         public SortOrder? Sort { get; set; }
 
+        public string LocationDisplayName { get; set; }
+
         public List<SelectListItem> TeamLocationFilter { 
             get
             {
@@ -41,6 +43,7 @@ namespace ServerCore.Pages.Events
         public async Task OnGetAsync(SortOrder? sort, TeamLocation locationFilter)
         {
             Sort = sort;
+            LocationDisplayName = Enum.GetName(locationFilter);
 
             var puzzleData = await _context.Puzzles
                 .Where(p => p.Event == Event)


### PR DESCRIPTION
Add a filter on the leaderboard page to show remote/local/all teams. The standings are calculated on the fly so only UI changes are needed.