### PR TITLE
Fix ordering of singleplayerpuzzle state map

### DIFF
--- a/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml.cs
+++ b/ServerCore/Pages/Events/SinglePlayerPuzzleStateMap.cshtml.cs
@@ -77,8 +77,8 @@ namespace ServerCore.Pages.Events
 
             this.PlayerStatList = playerIdToPlayerStatsMap
                 .Values
-                .OrderBy(playerStat => playerStat.Score)
-                .ThenBy(playerStat => playerStat.SolveCount)
+                .OrderByDescending(playerStat => playerStat.Score)
+                .ThenByDescending(playerStat => playerStat.SolveCount)
                 .ThenBy(playerStat => playerStat.Player.Name)
                 .ToList();
 


### PR DESCRIPTION
Order by player score descending instead of ascending.

