### PR TITLE
Make sure mails always gets sent to players when help thread updates

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -256,8 +256,7 @@ namespace ServerCore.Pages.Threads
                 }
             }
 
-            // We don't really want to send an email non-module events because they are often already watching the site
-            if (isMessageAdded && !Event.IsInternEvent)
+            if (isMessageAdded)
             {
                 await this.SendEmailNotifications(m, puzzle);
             }
@@ -389,7 +388,7 @@ namespace ServerCore.Pages.Threads
                     }
                 }
             }
-            else
+            else if (!Event.IsInternEvent) // For game control, we don't really want to send an email non-module events because they are often already watching the site
             {
                 // Send notification to authors and any game control person on the thread if message from player.
 


### PR DESCRIPTION
There was a previous update that made it so that we didn't send any mail for help threads for InternEvents
https://github.com/PuzzleServer/mainpuzzleserver/pull/1127/files

However, we actually still want to alert players.
This PR fixes that