### PR TITLE
Sort help thread and other minor fixes

### DIFF
--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -258,8 +258,7 @@
         <div class="alert alert-danger" role="alert">
             <h4>Answer Submission Locked Indefinitely</h4>
             <span>
-                You've submitted too many wrong responses. Please <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">click this link to message us your answer or ask for help</a>.
-            </span>
+                You've submitted too many wrong responses. Please <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">click this link to message us your answer or ask for help</a>.</span>
         </div>
     }
     else if (Model.PuzzleState.IsLockedOut)
@@ -280,7 +279,7 @@
     {
         <div class="alert alert-danger" role="alert">
             <h4>Answer Submission Locked</h4>
-            <span>This puzzle is currently locked! Please <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us if you think this is a mistake</a>.</span>
+            <span>This puzzle is currently locked! Please <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us if you think this is a mistake</a>.</span>
         </div>
     }
     else
@@ -419,7 +418,7 @@
     else if (!Model.PuzzleState.IsEmailOnlyMode)
     {
         <h3>Need some help?</h3>
-        <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to ask for help!</a></p>
+        <p>While solving this puzzle, if you've run into a bug, think there's an error, or are not having fun anymore, <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to ask for help!</a></p>
     }
 
     @if (Model.Event.AllowFeedback)
@@ -559,7 +558,7 @@ else
                 }
                 else if (!Model.PuzzleState.IsEmailOnlyMode)
                 {
-                    <div><b>Need help?</b> <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">Click this link</a> to message the author.</div>
+                    <div><b>Need help?</b> <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">Click this link</a> to message the author.</div>
                 }
 
                 @if (Model.Event.AllowFeedback)
@@ -627,7 +626,7 @@ else
         {
             <div class="alert alert-danger" role="alert">
                 <h4>Answer Submission Locked Indefinitely</h4>
-                <span>You've submitted too many wrong responses. Please <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us your answer or ask for help</a>.</span>
+                <span>You've submitted too many wrong responses. Please <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us your answer or ask for help</a>.</span>
             </div>
         }
         else if (Model.PuzzleState.IsLockedOut)
@@ -657,7 +656,7 @@ else
             {
                 <div class="alert alert-danger" role="alert">
                     <h4>Answer Submission Locked</h4>
-                    <span>This puzzle is currently locked! Please <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us if you think this is a mistake</a>.</span>
+                    <span>This puzzle is currently locked! Please <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us if you think this is a mistake</a>.</span>
                 </div>
             }
         }
@@ -890,7 +889,7 @@ else
                             updateVal = `<div class="alert alert-danger" role="alert">This puzzle can't be found in the system, so your answer has not been recorded.</div>`;
                             break;
                         case 6: // Puzzle Locked
-                            updateVal = `<div class="alert alert-danger" role="alert"><h4>Answer Submission Locked</h4><span>This puzzle is currently locked! Please <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us if you think this is a mistake</a>.</span></div>`;
+                            updateVal = `<div class="alert alert-danger" role="alert"><h4>Answer Submission Locked</h4><span>This puzzle is currently locked! Please <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us if you think this is a mistake</a>.</span></div>`;
                             break;
                         case 7: // Empty
                             updateVal = `<div class="alert alert-danger" role="alert">No valid characters were found in this submission. Please try something else.</div>`;

--- a/ServerCore/Pages/Teams/Hints.cshtml
+++ b/ServerCore/Pages/Teams/Hints.cshtml
@@ -108,7 +108,7 @@ You have <b>
                         }
                         else if (puzzleThreadViewState != null)
                         {
-                            <a asp-Page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleid="@Model.PuzzleID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">Use this link to message the author!</a>
+                            <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.PuzzleID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">Use this link to message the author!</a>
                         }
                     }
                     else

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml
@@ -33,7 +33,7 @@
         originalText.classList.remove("hidden");
     }
 </script>
-<div class="sticky-component">
+<div>
     <span>
         @if (Model.EventRole == ServerCore.ModelBases.EventRole.play)
         {
@@ -69,8 +69,66 @@
 </div>
 
 <hr />
-@foreach (var message in Model.Messages)
+
+@if (Model.Event.AreAnswersAvailableNow)
 {
+    <div>No help is needed because answers are now available!</div>
+}
+else
+{
+    <div class="row">
+        <div class="col-md-4" style="width:100%">
+            <form method="post">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group message-subtitle">
+                    @if (Model.PuzzleState.IsEmailOnlyMode)
+                    {
+                        <p>Use this message to fully explain your thought process so we know you're not randomly spamming attempts!</p>
+                    }
+                    else
+                    {
+                        <p>The more details you add here, the more helpful the responses you'll get will be!</p>
+                    }
+                    <textarea asp-for="NewMessage.Text" class="form-control message-subtitle" rows="4" style="width:75%" placeholder="Type message here" autocomplete="off"></textarea>
+                    <span asp-validation-for="NewMessage.Text" class="text-danger"></span>
+                    <input type="hidden" asp-for="NewMessage.ThreadId" value="@Model.NewMessage.ThreadId" />
+                    <input type="hidden" asp-for="NewMessage.EventID" value="@Model.NewMessage.EventID" />
+                    <input type="hidden" asp-for="NewMessage.Subject" value="@Model.NewMessage.Subject" />
+                    <input type="hidden" asp-for="NewMessage.PuzzleID" value="@Model.NewMessage.PuzzleID" />
+                    <input type="hidden" asp-for="NewMessage.TeamID" value="@Model.NewMessage.TeamID" />
+                    <input type="hidden" asp-for="NewMessage.IsFromGameControl" value="@Model.NewMessage.IsFromGameControl" />
+                    <input type="hidden" asp-for="NewMessage.SenderID" value="@Model.NewMessage.SenderID" />
+                    <input type="hidden" asp-for="NewMessage.PlayerID" value="@Model.NewMessage.PlayerID" />
+                </div>
+                <div class="form-group message-subtitle">
+                    <input type="submit" value="Send" class="btn btn-default" />
+                </div>
+            </form>
+        </div>
+    </div>
+}
+
+@if (Model.IsAllowedToClaimMessage() && Model.Messages.Count > 0)
+{
+    Message lastMessage = Model.Messages.Last();
+    <form method="post">
+        @if (lastMessage.ClaimerID.HasValue)
+        {
+            <br />
+            <p>Question has already been marked as read by @lastMessage.Claimer.Name</p>
+            <button type="submit" asp-page-handler="UnclaimThread" asp-route-messageId="@lastMessage.ID" asp-route-puzzleId="@lastMessage.PuzzleID" asp-route-teamId="@lastMessage.TeamID" asp-route-playerId="@lastMessage.PlayerID">Undo mark as read</button>
+        }
+        else if (!lastMessage.IsFromGameControl)
+        {
+            <br />
+            <button type="submit" asp-page-handler="ClaimThread" asp-route-messageId="@lastMessage.ID" asp-route-puzzleId="@lastMessage.PuzzleID" asp-route-teamId="@lastMessage.TeamID" asp-route-playerId="@lastMessage.PlayerID">Mark as read</button>
+        }
+    </form>
+}
+
+@for (int i = Model.Messages.Count - 1; i >= 0; i--)
+{
+    var message = Model.Messages[i];
     string classString = "message-container";
     if (message.IsFromGameControl)
     {
@@ -136,61 +194,6 @@
             </span>
         </div>
     </div>
-}
-@if (Model.Event.AreAnswersAvailableNow)
-{
-    <div id="auto-scroll-target">No help is needed because answers are now available!</div>
-}
-else
-{
-    <div class="row" id="auto-scroll-target">
-        <div class="col-md-4" style="width:100%">
-            <form method="post">
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                <div class="form-group message-subtitle">
-                    @if (Model.PuzzleState.IsEmailOnlyMode)
-                    {
-                        <p>Use this message to fully explain your thought process so we know you're not randomly spamming attempts!</p>
-                    }
-                    else
-                    {
-                        <p>The more details you add here, the more helpful the responses you'll get will be!</p>
-                    }
-                    <textarea asp-for="NewMessage.Text" class="form-control message-subtitle" rows="4" style="width:75%" placeholder="Type message here" autocomplete="off"></textarea>
-                    <span asp-validation-for="NewMessage.Text" class="text-danger"></span>
-                    <input type="hidden" asp-for="NewMessage.ThreadId" value="@Model.NewMessage.ThreadId" />
-                    <input type="hidden" asp-for="NewMessage.EventID" value="@Model.NewMessage.EventID" />
-                    <input type="hidden" asp-for="NewMessage.Subject" value="@Model.NewMessage.Subject" />
-                    <input type="hidden" asp-for="NewMessage.PuzzleID" value="@Model.NewMessage.PuzzleID" />
-                    <input type="hidden" asp-for="NewMessage.TeamID" value="@Model.NewMessage.TeamID" />
-                    <input type="hidden" asp-for="NewMessage.IsFromGameControl" value="@Model.NewMessage.IsFromGameControl" />
-                    <input type="hidden" asp-for="NewMessage.SenderID" value="@Model.NewMessage.SenderID" />
-                    <input type="hidden" asp-for="NewMessage.PlayerID" value="@Model.NewMessage.PlayerID" />
-                </div>
-                <div class="form-group message-subtitle">
-                    <input type="submit" value="Send" class="btn btn-default" />
-                </div>
-            </form>
-        </div>
-    </div>
-}
-
-@if (Model.IsAllowedToClaimMessage() && Model.Messages.Count > 0)
-{
-    Message lastMessage = Model.Messages.Last();
-    <form method="post">
-        @if (lastMessage.ClaimerID.HasValue)
-        {
-            <br/>
-            <p>Question has already been marked as read by @lastMessage.Claimer.Name</p>
-            <button type="submit" asp-page-handler="UnclaimThread" asp-route-messageId="@lastMessage.ID" asp-route-puzzleId="@lastMessage.PuzzleID" asp-route-teamId="@lastMessage.TeamID" asp-route-playerId="@lastMessage.PlayerID">Undo mark as read</button>
-        }
-        else if (!lastMessage.IsFromGameControl)
-        {
-            <br />
-            <button class="message-subtitle" type="submit" asp-page-handler="ClaimThread" asp-route-messageId="@lastMessage.ID" asp-route-puzzleId="@lastMessage.PuzzleID" asp-route-teamId="@lastMessage.TeamID" asp-route-playerId="@lastMessage.PlayerID">Mark as read</button>
-        }
-    </form>
 }
 
 @section Scripts {

--- a/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
+++ b/ServerCore/Pages/Threads/PuzzleThread.cshtml.cs
@@ -261,11 +261,7 @@ namespace ServerCore.Pages.Threads
                 await this.SendEmailNotifications(m, puzzle);
             }
 
-            return RedirectToPage(
-                "/Threads/PuzzleThread",
-                routeValues: new { puzzleId = m.PuzzleID, teamId = m.TeamID, playerId = m.PlayerID },
-                pageHandler: null,
-                fragment: "auto-scroll-target");
+            return RedirectToPage("/Threads/PuzzleThread", new { puzzleId = m.PuzzleID, teamId = m.TeamID, playerId = m.PlayerID });
         }
 
         public async Task<IActionResult> OnPostEditMessageAsync()
@@ -295,11 +291,7 @@ namespace ServerCore.Pages.Threads
                 await _context.SaveChangesAsync();
             }
 
-            return RedirectToPage(
-                "/Threads/PuzzleThread", 
-                routeValues: new { puzzleId = EditMessage.PuzzleID, teamId = EditMessage.TeamID, playerId = EditMessage.PlayerID },
-                pageHandler: null,
-                fragment: "auto-scroll-target");
+            return RedirectToPage("/Threads/PuzzleThread", new { puzzleId = EditMessage.PuzzleID, teamId = EditMessage.TeamID, playerId = EditMessage.PlayerID });
         }
 
         public async Task<IActionResult> OnGetDeleteMessageAsync(int messageId, int puzzleId, int? teamId, int? playerId)
@@ -312,11 +304,7 @@ namespace ServerCore.Pages.Threads
                 await _context.SaveChangesAsync();
             }
 
-            return RedirectToPage(
-                "/Threads/PuzzleThread",
-                routeValues: new { puzzleId = puzzleId, teamId = teamId, playerId = playerId },
-                pageHandler: null,
-                fragment: "auto-scroll-target");
+            return RedirectToPage("/Threads/PuzzleThread", new { puzzleId = puzzleId, teamId = teamId, playerId = playerId });
         }
 
         public async Task<IActionResult> OnPostClaimThreadAsync(int messageId, int puzzleId, int? teamId, int? playerId)
@@ -336,11 +324,7 @@ namespace ServerCore.Pages.Threads
                 throw new InvalidOperationException("You cannot claim this thread! It may have already been claimed.");
             }
 
-            return RedirectToPage(
-                "/Threads/PuzzleThread",
-                routeValues: new { puzzleId = puzzleId, teamId = teamId, playerId = playerId },
-                pageHandler: null,
-                fragment: "auto-scroll-target");
+            return RedirectToPage("/Threads/PuzzleThread", new { puzzleId = puzzleId, teamId = teamId, playerId = playerId });
         }
 
         public async Task<IActionResult> OnPostUnclaimThreadAsync(int messageId, int puzzleId, int? teamId, int? playerId)
@@ -354,11 +338,7 @@ namespace ServerCore.Pages.Threads
                 await _context.SaveChangesAsync();
             }
 
-            return RedirectToPage(
-                "/Threads/PuzzleThread",
-                routeValues: new { puzzleId = puzzleId, teamId = teamId, playerId = playerId },
-                pageHandler: null,
-                fragment: "auto-scroll-target");
+            return RedirectToPage("/Threads/PuzzleThread", new { puzzleId = puzzleId, teamId = teamId, playerId = playerId });
         }
 
         public bool IsAllowedToClaimMessage()

--- a/ServerCore/Pages/Threads/PuzzleThreads.cshtml
+++ b/ServerCore/Pages/Threads/PuzzleThreads.cshtml
@@ -8,6 +8,7 @@
 
     bool isGameControlRole = Model.IsGameControlRole();
 }
+
 <div>
     @if (Model.EventRole == ServerCore.ModelBases.EventRole.play) 
     {
@@ -138,7 +139,7 @@
                     @{
                         string returnQueryParams = ViewContext.HttpContext.Request.QueryString.Value;
                     }
-                    <a asp-page="/Threads/PuzzleThread" asp-fragment="auto-scroll-target" asp-route-puzzleId="@item.PuzzleID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID" asp-route-returnThreadQueryParams=@returnQueryParams>@item.Subject</a>
+                    <a asp-page="/Threads/PuzzleThread" asp-route-puzzleId="@item.PuzzleID" asp-route-teamId="@item.TeamID" asp-route-playerId="@item.PlayerID" asp-route-returnThreadQueryParams=@returnQueryParams>@item.Subject</a>
                 </td>
                 <td>
                     @if (@item.PuzzleID.HasValue)


### PR DESCRIPTION
#1264
This PR does the following:
- Sorts help threads so that oldest modified shows up first 
- Messages themselves are now sorted so that newest show up first

<img width="1269" height="404" alt="image" src="https://github.com/user-attachments/assets/943641d2-f1bf-46bd-aa9e-4282a56252ec" />
