### PR TITLE
EventRole signup fix

### DIFF
--- a/ServerCore/Pages/Teams/AutoTeam.razor.cs
+++ b/ServerCore/Pages/Teams/AutoTeam.razor.cs
@@ -19,7 +19,7 @@ namespace ServerCore.Pages.Teams
         public int LoggedInUserId { get; set; }
 
         [Parameter]
-        public EventRole EventRole { get; set; }
+        public string EventRoleString { get; set; }
 
         [Parameter]
         public bool IsMicrosoft { get; set; }
@@ -39,6 +39,14 @@ namespace ServerCore.Pages.Teams
         public AutoTeamType? PlayerLocation { get; set; } = null;
 
         bool CantCreateTeam { get; set; }
+
+        public EventRole EventRole { get; set; }
+
+        protected override async Task OnParametersSetAsync()
+        {
+            EventRole = EventRole.Parse(EventRoleString);
+            await base.OnParametersSetAsync();
+        }
 
         public async Task OnSubmit()
         {

--- a/ServerCore/Pages/Teams/CreateTeam.razor.cs
+++ b/ServerCore/Pages/Teams/CreateTeam.razor.cs
@@ -92,7 +92,7 @@ namespace ServerCore.Pages.Teams
         public Event Event { get; set; }
 
         [Parameter]
-        public EventRole EventRole { get; set; }
+        public string EventRoleString { get; set; }
 
         [Parameter]
         public int LoggedInUserId { get; set; }
@@ -108,10 +108,12 @@ namespace ServerCore.Pages.Teams
         public bool EventFull { get; set; }
         public bool LocalTeamsFull { get; set; }
         public bool RemoteTeamsFull { get; set; }
+        public EventRole EventRole { get; set; }
 
         protected override async Task OnParametersSetAsync()
         {
             TeamModel.EventId = Event.ID;
+            EventRole = EventRole.Parse(EventRoleString);
 
             if (EventRole == EventRole.play && await _context.Teams.Where((t) => t.EventID == Event.ID).CountAsync() >= Event.MaxNumberOfTeams)
             {

--- a/ServerCore/Pages/Teams/JoinTeam.razor.cs
+++ b/ServerCore/Pages/Teams/JoinTeam.razor.cs
@@ -17,7 +17,7 @@ namespace ServerCore.Pages.Teams
         public int LoggedInUserId { get; set; }
 
         [Parameter]
-        public EventRole EventRole { get; set; }
+        public string EventRoleString { get; set; }
 
         [Inject]
         public PuzzleServerContext _context { get; set; }
@@ -28,8 +28,12 @@ namespace ServerCore.Pages.Teams
 
         int AppliedTeamId { get; set; }
 
+        public EventRole EventRole;
+
         protected override async Task OnParametersSetAsync()
         {
+            EventRole = EventRole.Parse(EventRoleString);
+
             // Join the teams table with the players table to get a dictionary mapping team IDs to player counts.
             PlayerCountByTeamID = await
                 _context.Teams.Where(team => team.Event == Event)

--- a/ServerCore/Pages/Teams/SignupHub.razor
+++ b/ServerCore/Pages/Teams/SignupHub.razor
@@ -44,13 +44,13 @@
 @switch(Strategy)
 {
     case SignupStrategy.Create:
-        <CreateTeam Event="@Event" EventRole="@EventRole" LoggedInUserId="@LoggedInUserId" />
+        <CreateTeam Event="@Event" EventRoleString="@EventRole.ToString()" LoggedInUserId="@LoggedInUserId" />
         break;
     case SignupStrategy.Join:
-        <JoinTeam Event="@Event" EventRole="@EventRole" LoggedInUserId="@LoggedInUserId" />
+        <JoinTeam Event="@Event" EventRoleString="@EventRole.ToString()" LoggedInUserId="@LoggedInUserId" />
         break;
     case SignupStrategy.Auto:
-        <AutoTeam Event="@Event" EventRole="@EventRole" LoggedInUserId="@LoggedInUserId" IsMicrosoft="@IsMicrosoft" />
+        <AutoTeam Event="@Event" EventRoleString="@EventRole.ToString()" LoggedInUserId="@LoggedInUserId" IsMicrosoft="@IsMicrosoft" />
         break;
     case SignupStrategy.None:
         break;


### PR DESCRIPTION
Ensure that the EventRole gets passed properly to the SignupHub pages.

I feel like I should have been able to use IParsable, or a casting operator, to avoid needing to do this, but none of those approaches worked for me. I did verify that this is the only place in the code that passes an EventRole in this manner.