### PR TITLE
Mobile Fixes

### DIFF
--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -162,7 +162,7 @@ namespace ServerCore.Areas.Identity
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             Event thisEvent = await GetEventFromRoute();
 
-            if (thisEvent != null && await puzzleUser.IsRegisteredForEvent(dbContext, thisEvent))
+            if (thisEvent != null && puzzleUser != null && await puzzleUser.IsRegisteredForEvent(dbContext, thisEvent))
             {
                 authContext.Succeed(requirement);
             }

--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -224,11 +224,11 @@ else
                         <td class="puzzle-list-answer-customizable">
                             @if (item.CustomSolutionUrl != null)
                             {
-                                <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomSolutionUrl, item.ID, Model.Event.ID, Model.LoggedInUser.ID, Model.Team.Password, null)" target="_blank">View answer</a>
+                                <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomSolutionUrl, item.ID, Model.Event.ID, Model.LoggedInUser.ID, Model.Team.Password, null)" target="_blank">View Answer</a>
                             }
                             else if (item.Answer != null)
                             {
-                                @Html.ActionLink("View answer", "Index", "Files", new { eventId = Model.Event.ID, filename = item.Answer.ShortName }, new { target = "_blank" })
+                                @Html.ActionLink("View Answer", "Index", "Files", new { eventId = Model.Event.ID, filename = item.Answer.ShortName }, new { target = "_blank" })
                             }
                         </td>
                     }
@@ -362,11 +362,11 @@ else
                             <td class="puzzle-list-answer-customizable">
                                 @if (item.CustomSolutionUrl != null)
                                 {
-                                    <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomSolutionUrl, item.ID, Model.Event.ID, Model.LoggedInUser.ID, teamPassword: null, playerClass: null)" target="_blank">View answer</a>
+                                    <a href="@ServerCore.Helpers.PuzzleHelper.GetFormattedUrl(item.CustomSolutionUrl, item.ID, Model.Event.ID, Model.LoggedInUser.ID, teamPassword: null, playerClass: null)" target="_blank">View Answer</a>
                                 }
                                 else if (item.Answer != null)
                                 {
-                                    @Html.ActionLink("View answer", "Index", "Files", new { eventId = Model.Event.ID, filename = item.Answer.ShortName }, new { target = "_blank" })
+                                    @Html.ActionLink("View Answer", "Index", "Files", new { eventId = Model.Event.ID, filename = item.Answer.ShortName }, new { target = "_blank" })
                                 }
                             </td>
                         }

--- a/ServerCore/Pages/Resources/ToolsPartial.cshtml
+++ b/ServerCore/Pages/Resources/ToolsPartial.cshtml
@@ -6,7 +6,7 @@
     <br />
     <h2>TL;DR</h2>
     <p>All of these links are elaborated on in depth below, and there are even more tools below as well.</p>
-    <div style="display: flex; gap: 40px">
+    <div style="display: flex; gap: 40px; flex-wrap: wrap;">
         <div>
             <h6 style="margin-top: 9px">General</h6>
             <div><a asp-page="/EventSpecific/Encodings" target="_blank">All types of encodings (Braille, Morse, etc.)</a></div>
@@ -82,7 +82,7 @@
 
     <br />
     <h2>Media-Based Puzzles</h2>
-    <h3>Built-in tools</h3>
+    <h3>Built-in Tools</h3>
     <p>If you're using the browser to look something up, don't forget that there are multiple search engines to try, and all have the possibility of giving different results.  Don't like what you find on Google or Bing?  Try <a href="https://www.seekr.com/" target="_blank">Seekr</a>, <a href="https://www.mojeek.com/" target="_blank">Mojeek</a>, or <a href="https://www.qwant.com/" target="_blank">Qwant</a>.  You also don't have to search with just words; you can use reverse image search to upload an image and look for ones just like it.</p>
     <p>Even the browser itself has tools to help you.  For example, Microsoft Edge has built-in screenshotting tools that allow you to draw directly on the screenshot, or web selection tools to only select the relevant parts of a page. Just right-click and look for Web Capture! If your browser doesn't have a screenshot tool, your OS likely does.  The keyboard shortcut in Windows is the Windows key + Shift + S, which puts the screenshot on your clipboard so you can paste it into a program like Paint. </p>
 

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -100,7 +100,7 @@
                             <ul class="dropdown-menu admin-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving tools and techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>
@@ -170,7 +170,7 @@
                             <ul class="dropdown-menu author-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving tools and techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>
@@ -229,7 +229,7 @@
                         }
                         @if (Event.IsTeamMembershipChangeActive)
                         {
-                            <li class="nav-item"><a style="color:yellow" asp-page="@(teamSignupUrl)"> Join or Create a Team!</a></li>
+                            <li class="nav-item"><a style="color:yellow" asp-page="@(teamSignupUrl)"> Join or create a team!</a></li>
                         }
                     }
                     else
@@ -266,7 +266,7 @@
                             <ul class="dropdown-menu player-menu">
                                 @if (!isOnTeam)
                                 {
-                                    <li><a class="dropdown-item" asp-page="@(teamSignupUrl)"> Join or Create a Team!</a></li>
+                                    <li><a class="dropdown-item" asp-page="@(teamSignupUrl)"> Join or create a team!</a></li>
                                 }
                                 else
                                 {
@@ -305,7 +305,7 @@
                             <ul class="dropdown-menu player-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving tools and techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>
@@ -356,7 +356,7 @@
                     <li class="nav-item"><a asp-page="/Teams/AllTeams">View all teams</a></li>
                     @if (Event.ShouldShowSinglePlayerPuzzles)
                     {
-                        <li class="nav-item"><a asp-page="/Events/SolveCounts">Solve counts</a></li>
+                        <li class="nav-item"><a asp-page="/Events/SolveCounts">@(Event.HideStandings ? "Most-solved Puzzles" : "Fastest solves")</a></li>
                     }
                     <li class="nav-item">
                         <div class="dropdown">
@@ -366,7 +366,7 @@
                             <ul class="dropdown-menu player-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
-                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving Tools and Techniques</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving tools and techniques</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
                             </ul>

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -153,7 +153,10 @@
         margin-left: 20px;
     }
     #puzzleAuthorPrintable {
-        margin-top: 4px;
+        margin-top: 8px;
+    }
+    .answer-label-customizable {
+        font-weight:bold;
     }
 
     .puzzle-content-wrapper.unclaimed {
@@ -164,7 +167,17 @@
         opacity: 0.25;
     }
 
+    .title-block .flexwrapper {
+        justify-content: end;
+    }
+
+    .puzzle-title-wrapper {
+        margin-right: auto;
+    }
+
     @@media (max-width: 750px) {
+        .title-block { grid-template-columns: 1fr; }
+        .title-block .flexwrapper { flex-wrap: wrap; }
         .submission-block { grid-template-columns: 1fr; }
     }
 
@@ -245,9 +258,9 @@
 }
 
 <div class="top-header-customizable" id="top-header">
-    <div class="twocolumn">
+    <div class="title-block twocolumn">
         <div class="flexwrapper">
-            <div><h2 class="puzzle-title-customizable" id="puzzleNamePrintable"><b>@RawHtmlHelper.Display(Model.Puzzle.Name, Model.Event.ID, Html)</b></h2></div>
+            <div class="puzzle-title-wrapper"><h2 class="puzzle-title-customizable" id="puzzleNamePrintable"><b>@RawHtmlHelper.Display(Model.Puzzle.Name, Model.Event.ID, Html)</b></h2></div>
             @if (!string.IsNullOrEmpty(Model.Puzzle.Group))
             {
                 <div><h3 class="puzzle-group-customizable" id="puzzleGroupPrintable">@RawHtmlHelper.Display(Model.Puzzle.Group, Model.Event.ID, Html)</h3></div>
@@ -644,7 +657,7 @@
                         updateVal = `<div class="alert alert-danger" role="alert">This puzzle can't be found in the system, so your answer has not been recorded.</div>`;
                         break;
                     case 6: // Puzzle Locked
-                        updateVal = `<div class="alert alert-danger" role="alert"><h4>Answer Submission Locked</h4><span>This puzzle is currently locked! Please <a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID">use this link to message us if you think this is a mistake</a>.</span></div>`;
+                        updateVal = `<div class="alert alert-danger" role="alert"><h4>Answer Submission Locked</h4><span>This puzzle is currently locked! Please <a href="/@(Model.Event.UrlString)/@(Model.EventRole)/Threads/PuzzleThread/@(Model.Puzzle.ID)?teamId=@(Model.Team?.ID)&playerId=@(Model.LoggedInUser.ID)">use this link to message us if you think this is a mistake</a>.</span></div>`;
                         break;
                     case 7: // Empty
                         updateVal = `<div class="alert alert-danger" role="alert">No valid characters were found in this submission. Please try something else.</div>`;

--- a/ServerCore/Pages/Teams/AllTeams.cshtml
+++ b/ServerCore/Pages/Teams/AllTeams.cshtml
@@ -9,7 +9,7 @@
 }
 
 <h2>All teams</h2>
-@if(Model.PlayerNotOnTeam)
+@if(Model.PlayerNotOnTeam && Model.Event.IsTeamRegistrationActive)
 {
     <p>
         You are not yet part of a team. To join a team, go to the register page.

--- a/ServerCore/wwwroot/NewEventTemplate/resources/puzzle-base-styles.css
+++ b/ServerCore/wwwroot/NewEventTemplate/resources/puzzle-base-styles.css
@@ -13,7 +13,7 @@ html {
 }
 
 body {
-  min-width: 600px;
+  min-width: 500px;
   width: 100%;
   margin: 0px;
   padding: 0px;


### PR DESCRIPTION
Fixes several things:
- crash in some pages if you aren't part of a team
- some capitalization tweaks
- tools & techniques list now wraps on narrow screens
- puzzle author aligns better with rest of content at top of page
- content at top of page responds better to narrow widths
- lockout message now has working link
- team registration reminder on team list does not show if registration is closed