### PR TITLE
Fix help thread refresh bug

### DIFF
--- a/ServerCore/Pages/Threads/PuzzleThreadComponent.razor
+++ b/ServerCore/Pages/Threads/PuzzleThreadComponent.razor
@@ -15,10 +15,10 @@
                     {
                         <p>The more details you add here, the more helpful the responses you'll get will be!</p>
                     }
-                    <textarea @bind="NewMessageText" class="form-control message-subtitle" rows="4" style="width:75%" placeholder="Type message here" autocomplete="off"></textarea>
+                    <textarea @bind="NewMessageText" class="form-control message-subtitle" rows="4" style="width:75%" placeholder="Type message here" autocomplete="off" disabled="@isMutationRunning"></textarea>
                 </div>
                 <div class="form-group message-subtitle">
-                    <input type="button" value="Send" class="btn btn-default" @onclick="SendMessageAsync" />
+                    <input type="button" value="Send" class="btn btn-default" @onclick="SendMessageAsync" disabled="@isMutationRunning" />
                 </div>
             </div>
         </div>
@@ -31,13 +31,13 @@
     @if (ShouldShowClaimAction())
     {
         <br />
-        <button type="button" @onclick="ClaimLatestMessageAsync">Mark as read</button>
+        <button type="button" @onclick="ClaimLatestMessageAsync" disabled="@isMutationRunning">Mark as read</button>
     }
     else if (ShouldShowUnclaimAction())
     {
         <br />
         <p>Question has already been marked as read by @LatestMessage.ClaimerName</p>
-        <button type="button" @onclick="UnclaimLatestMessageAsync">Undo mark as read</button>
+        <button type="button" @onclick="UnclaimLatestMessageAsync" disabled="@isMutationRunning">Undo mark as read</button>
     }
 
     @if (!string.IsNullOrEmpty(errorMessage))
@@ -62,10 +62,10 @@
                 {
                     <div id="TextAreaEdit_@message.ID">
                         <div class="form-group message-main-content">
-                            <textarea class="form-control message-subtitle" style="width:100%" @bind="editTexts[message.ID]" rows="4" autocomplete="off"></textarea>
+                            <textarea class="form-control message-subtitle" style="width:100%" @bind="editTexts[message.ID]" rows="4" autocomplete="off" disabled="@isMutationRunning"></textarea>
                         </div>
                         <div class="form-group">
-                            <input type="button" value="Update" class="btn btn-default" @onclick="() => EditMessageAsync(message)" /> | <a role="button" class="message-subtitle" style="text-decoration:underline;color:@GetActionColor(message)" @onclick="() => CancelEdit(message)">Cancel</a>
+                            <input type="button" value="Update" class="btn btn-default" @onclick="() => EditMessageAsync(message)" disabled="@isMutationRunning" /> | <a role="button" class="message-subtitle" style="text-decoration:underline;color:@GetActionColor(message)" @onclick="() => CancelEdit(message)">Cancel</a>
                         </div>
                     </div>
                 }
@@ -81,7 +81,14 @@
                     <span>
                         @if (IsAllowedToEditMessage(message))
                         {
-                            <a role="button" class="message-subtitle" style="text-decoration:underline;color:@GetActionColor(message)" @onclick="() => StartEdit(message)">Edit</a>
+                            @if (isMutationRunning)
+                            {
+                                <span class="message-subtitle" style="color:gray">Edit</span>
+                            }
+                            else
+                            {
+                                <a role="button" class="message-subtitle" style="text-decoration:underline;color:@GetActionColor(message)" @onclick="() => StartEdit(message)">Edit</a>
+                            }
                         }
                         @if (IsAllowedToEditMessage(message) && IsAllowedToDeleteMessage(message))
                         {
@@ -89,7 +96,14 @@
                         }
                         @if (IsAllowedToDeleteMessage(message))
                         {
-                            <a role="button" class="message-subtitle" style="color:@GetActionColor(message)" @onclick="() => DeleteMessageAsync(message)">Delete</a>
+                            @if (isMutationRunning)
+                            {
+                                <span class="message-subtitle" style="color:gray">Delete</span>
+                            }
+                            else
+                            {
+                                <a role="button" class="message-subtitle" style="color:@GetActionColor(message)" @onclick="() => DeleteMessageAsync(message)">Delete</a>
+                            }
                         }
                     </span>
                 </div>

--- a/ServerCore/Pages/Threads/PuzzleThreadComponent.razor.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreadComponent.razor.cs
@@ -78,6 +78,8 @@ namespace ServerCore.Pages.Threads
 
         bool shouldRenderLocalTimes;
 
+        bool isMutationRunning;
+
         ThreadMessageDTO LatestMessage => messages.FirstOrDefault();
 
         protected override async Task OnInitializedAsync()
@@ -250,14 +252,25 @@ namespace ServerCore.Pages.Threads
 
         async Task RunMutationAsync(Func<Task> mutation)
         {
+            if (isMutationRunning)
+            {
+                errorMessage = "Please wait for the current action to finish.";
+                return;
+            }
+
             try
             {
+                isMutationRunning = true;
                 errorMessage = null;
                 await mutation();
             }
             catch (UserOperationException ex)
             {
                 errorMessage = ex.Message;
+            }
+            finally
+            {
+                isMutationRunning = false;
             }
         }
 
@@ -286,3 +299,4 @@ namespace ServerCore.Pages.Threads
         }
     }
 }
+

--- a/ServerCore/Pages/Threads/PuzzleThreadComponent.razor.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreadComponent.razor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -79,6 +80,8 @@ namespace ServerCore.Pages.Threads
         bool shouldRenderLocalTimes;
 
         bool isMutationRunning;
+
+        readonly SemaphoreSlim mutationLock = new SemaphoreSlim(1, 1);
 
         ThreadMessageDTO LatestMessage => messages.FirstOrDefault();
 
@@ -188,6 +191,8 @@ namespace ServerCore.Pages.Threads
 
         async Task SendMessageAsync()
         {
+            string messageText = NewMessageText;
+
             await RunMutationAsync(async () =>
             {
                 ThreadMessageDTO sentMessage = await PuzzleThreadService.SendMessageAsync(
@@ -199,7 +204,7 @@ namespace ServerCore.Pages.Threads
                     PlayerID,
                     IsFromGameControl,
                     CurrentUserId,
-                    NewMessageText);
+                    messageText);
 
                 UpsertMessage(sentMessage);
                 NewMessageText = null;
@@ -252,11 +257,7 @@ namespace ServerCore.Pages.Threads
 
         async Task RunMutationAsync(Func<Task> mutation)
         {
-            if (isMutationRunning)
-            {
-                errorMessage = "Please wait for the current action to finish.";
-                return;
-            }
+            await mutationLock.WaitAsync();
 
             try
             {
@@ -271,6 +272,7 @@ namespace ServerCore.Pages.Threads
             finally
             {
                 isMutationRunning = false;
+                mutationLock.Release();
             }
         }
 
@@ -296,6 +298,7 @@ namespace ServerCore.Pages.Threads
         public void Dispose()
         {
             MessageListener.OnThreadMessage -= OnThreadMessageReceived;
+            mutationLock.Dispose();
         }
     }
 }

--- a/ServerCore/Pages/Threads/PuzzleThreadService.cs
+++ b/ServerCore/Pages/Threads/PuzzleThreadService.cs
@@ -14,17 +14,19 @@ namespace ServerCore.Pages.Threads
 {
     public class PuzzleThreadService
     {
-        private readonly PuzzleServerContext context;
+        private readonly IDbContextFactory<PuzzleServerContext> contextFactory;
         private readonly IHubContext<ServerMessageHub> messageHub;
 
-        public PuzzleThreadService(PuzzleServerContext context, IHubContext<ServerMessageHub> messageHub)
+        public PuzzleThreadService(IDbContextFactory<PuzzleServerContext> contextFactory, IHubContext<ServerMessageHub> messageHub)
         {
-            this.context = context;
+            this.contextFactory = contextFactory;
             this.messageHub = messageHub;
         }
 
         public async Task<ThreadMessageDTO> SendMessageAsync(string threadId, int eventId, string subject, int puzzleId, int? teamId, int? playerId, bool isFromGameControl, int senderId, string text)
         {
+            await using PuzzleServerContext context = await contextFactory.CreateDbContextAsync();
+
             Event eventObj = await context.Events.Where(e => e.ID == eventId).FirstOrDefaultAsync();
             if (eventObj == null)
             {
@@ -48,7 +50,7 @@ namespace ServerCore.Pages.Threads
                 throw new InvalidOperationException("Puzzle not found.");
             }
 
-            await ValidatePostPermissionAsync(eventObj, puzzle, isFromGameControl, senderId, teamId, playerId);
+            await ValidatePostPermissionAsync(context, eventObj, puzzle, isFromGameControl, senderId, teamId, playerId);
 
             PuzzleUser sender = await context.PuzzleUsers.Where(user => user.ID == senderId).FirstOrDefaultAsync();
             if (sender == null)
@@ -74,7 +76,7 @@ namespace ServerCore.Pages.Threads
             message.PlayerID = playerId;
 
             bool isMessageAdded = false;
-            using (IDbContextTransaction transaction = context.Database.BeginTransaction(System.Data.IsolationLevel.Serializable))
+            await using (IDbContextTransaction transaction = await context.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable))
             {
                 Message newestMessage = await context.Messages
                     .Where(existingMessage => existingMessage.ThreadId == threadId)
@@ -94,13 +96,13 @@ namespace ServerCore.Pages.Threads
                 }
             }
 
-            ThreadMessageDTO dto = await BroadcastMessageAsync(message.ID);
+            ThreadMessageDTO dto = await BroadcastMessageAsync(context, message.ID);
 
             if (isMessageAdded)
             {
-                Message savedMessage = await GetMessageAsync(message.ID);
+                Message savedMessage = await GetMessageAsync(context, message.ID);
                 savedMessage.Event = eventObj;
-                await SendEmailNotifications(savedMessage, puzzle, eventObj);
+                await SendEmailNotifications(context, savedMessage, puzzle, eventObj);
             }
 
             return dto;
@@ -108,8 +110,10 @@ namespace ServerCore.Pages.Threads
 
         public async Task<ThreadMessageDTO> EditMessageAsync(int messageId, int currentUserId, string text)
         {
-            Message message = await GetMessageAsync(messageId);
-            if (message == null || !await IsAllowedToModifyMessageAsync(message, currentUserId))
+            await using PuzzleServerContext context = await contextFactory.CreateDbContextAsync();
+
+            Message message = await GetMessageAsync(context, messageId);
+            if (message == null || !await IsAllowedToModifyMessageAsync(context, message, currentUserId))
             {
                 throw new UserOperationException("You are not allowed to edit this message.");
             }
@@ -124,13 +128,15 @@ namespace ServerCore.Pages.Threads
             message.ModifiedDateTimeInUtc = DateTime.UtcNow;
             await context.SaveChangesAsync();
 
-            return await BroadcastMessageAsync(message.ID);
+            return await BroadcastMessageAsync(context, message.ID);
         }
 
         public async Task<ThreadMessageDTO> DeleteMessageAsync(int messageId, int currentUserId)
         {
-            Message message = await GetMessageAsync(messageId);
-            if (message == null || !await IsAllowedToModifyMessageAsync(message, currentUserId))
+            await using PuzzleServerContext context = await contextFactory.CreateDbContextAsync();
+
+            Message message = await GetMessageAsync(context, messageId);
+            if (message == null || !await IsAllowedToModifyMessageAsync(context, message, currentUserId))
             {
                 throw new UserOperationException("You are not allowed to delete this message.");
             }
@@ -139,13 +145,15 @@ namespace ServerCore.Pages.Threads
             message.ModifiedDateTimeInUtc = DateTime.UtcNow;
             await context.SaveChangesAsync();
 
-            return await BroadcastMessageAsync(message.ID);
+            return await BroadcastMessageAsync(context, message.ID);
         }
 
         public async Task<ThreadMessageDTO> ClaimThreadAsync(int messageId, int currentUserId)
         {
-            Message message = await GetMessageAsync(messageId);
-            if (message == null || !await IsAllowedToClaimMessageAsync(message, currentUserId) || message.ClaimerID.HasValue)
+            await using PuzzleServerContext context = await contextFactory.CreateDbContextAsync();
+
+            Message message = await GetMessageAsync(context, messageId);
+            if (message == null || !await IsAllowedToClaimMessageAsync(context, message, currentUserId) || message.ClaimerID.HasValue)
             {
                 throw new UserOperationException("You cannot claim this thread! It may have already been claimed.");
             }
@@ -153,13 +161,15 @@ namespace ServerCore.Pages.Threads
             message.ClaimerID = currentUserId;
             await context.SaveChangesAsync();
 
-            return await BroadcastMessageAsync(message.ID);
+            return await BroadcastMessageAsync(context, message.ID);
         }
 
         public async Task<ThreadMessageDTO> UnclaimThreadAsync(int messageId, int currentUserId)
         {
-            Message message = await GetMessageAsync(messageId);
-            if (message == null || !await IsAllowedToClaimMessageAsync(message, currentUserId))
+            await using PuzzleServerContext context = await contextFactory.CreateDbContextAsync();
+
+            Message message = await GetMessageAsync(context, messageId);
+            if (message == null || !await IsAllowedToClaimMessageAsync(context, message, currentUserId))
             {
                 throw new UserOperationException("You are not allowed to unclaim this thread.");
             }
@@ -167,10 +177,10 @@ namespace ServerCore.Pages.Threads
             message.ClaimerID = null;
             await context.SaveChangesAsync();
 
-            return await BroadcastMessageAsync(message.ID);
+            return await BroadcastMessageAsync(context, message.ID);
         }
 
-        private async Task<bool> IsAllowedToModifyMessageAsync(Message message, int currentUserId)
+        private static async Task<bool> IsAllowedToModifyMessageAsync(PuzzleServerContext context, Message message, int currentUserId)
         {
             Event eventObj = await context.Events.Where(e => e.ID == message.EventID).FirstOrDefaultAsync();
             return eventObj != null
@@ -179,7 +189,7 @@ namespace ServerCore.Pages.Threads
                 && message.Text != PuzzleThreadModel.DeletedMessage;
         }
 
-        private async Task<bool> IsAllowedToClaimMessageAsync(Message message, int currentUserId)
+        private static async Task<bool> IsAllowedToClaimMessageAsync(PuzzleServerContext context, Message message, int currentUserId)
         {
             Event eventObj = await context.Events.Where(e => e.ID == message.EventID).FirstOrDefaultAsync();
             PuzzleUser user = await context.PuzzleUsers.Where(u => u.ID == currentUserId).FirstOrDefaultAsync();
@@ -188,7 +198,7 @@ namespace ServerCore.Pages.Threads
                 && (await user.IsAdminForEvent(context, eventObj) || await user.IsAuthorForEvent(context, eventObj));
         }
 
-        private async Task ValidatePostPermissionAsync(Event eventObj, Puzzle puzzle, bool isFromGameControl, int senderId, int? teamId, int? playerId)
+        private static async Task ValidatePostPermissionAsync(PuzzleServerContext context, Event eventObj, Puzzle puzzle, bool isFromGameControl, int senderId, int? teamId, int? playerId)
         {
             PuzzleUser sender = await context.PuzzleUsers.Where(user => user.ID == senderId).FirstOrDefaultAsync();
             if (sender == null)
@@ -225,7 +235,7 @@ namespace ServerCore.Pages.Threads
             }
         }
 
-        private async Task<Message> GetMessageAsync(int messageId)
+        private static async Task<Message> GetMessageAsync(PuzzleServerContext context, int messageId)
         {
             return await context.Messages
                 .Include(m => m.Sender)
@@ -234,9 +244,9 @@ namespace ServerCore.Pages.Threads
                 .FirstOrDefaultAsync();
         }
 
-        private async Task<ThreadMessageDTO> BroadcastMessageAsync(int messageId)
+        private async Task<ThreadMessageDTO> BroadcastMessageAsync(PuzzleServerContext context, int messageId)
         {
-            Message message = await GetMessageAsync(messageId);
+            Message message = await GetMessageAsync(context, messageId);
             ThreadMessageDTO dto = ToDto(message);
             await messageHub.SendThreadMessage(dto);
             return dto;
@@ -261,7 +271,7 @@ namespace ServerCore.Pages.Threads
             };
         }
 
-        private async Task SendEmailNotifications(Message newMessage, Puzzle puzzle, Event eventObj)
+        private async Task SendEmailNotifications(PuzzleServerContext context, Message newMessage, Puzzle puzzle, Event eventObj)
         {
             string emailTitle = $"{newMessage.Subject} thread update!";
             string emailContent = newMessage.Text;


### PR DESCRIPTION
#1340

During the bugbash on June 1, a subset of players suddenly kept seeing a blank help thread page because the server was returning an error.

**Client side error:**
[2026-06-02T03:21:58.966Z] Error: Connection disconnected with error 'Error: Server returned an error on close: Connection closed with an error.'.
<img width="1192" height="388" alt="image" src="https://github.com/user-attachments/assets/213426ee-17f2-454f-ac66-31fd4e72e716" />

**Error from azure:**
A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext. For more information on how to avoid threading issues with DbContext, see https://go.microsoft.com/fwlink/?linkid=2097913.
unhelpful, but:
System.InvalidOperationException:
   at Microsoft.EntityFrameworkCore.Infrastructure.Internal.ConcurrencyDetector.EnterCriticalSection (Microsoft.EntityFrameworkCore, Version=10.0.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
   at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1+AsyncEnumerator+<MoveNextAsync>d__20.MoveNext (Microsoft.EntityFrameworkCore.Relational, Version=10.0.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)


Here is the explanation and fix from AI

The deployed failure is consistent with Blazor Server dbContext lifetime, not the SignalR payload shape anymore.
•	ThreadMessageDTO is already the full payload.
•	PuzzleThreadComponent already updates from the incoming DTO and no longer fetches the message from the database on receive.
•	PuzzleThreadService was still holding an injected scoped PuzzleServerContext.
•	In Blazor Server, scoped services live for the circuit, so overlapping callbacks can share the same dbContext.
•	Under load, one circuit can start another component/service operation before the prior EF query finishes, causing the ConcurrencyDetector.EnterCriticalSection exception.
•	An unhandled server-side exception can close the Blazor circuit, which matches the browser console disconnect.


What was changed:
•	PuzzleThreadService now injects IDbContextFactory<PuzzleServerContext> instead of a scoped PuzzleServerContext.
•	Each public service operation creates its own short-lived context with CreateDbContextAsync.
•	Helper methods now receive that context explicitly.
•	The transaction creation is now async via BeginTransactionAsync.
•	PuzzleThreadComponent now has a simple isMutationRunning guard to ignore overlapping send/edit/delete/claim clicks from the same component instance.
This is better than a lock as the long-term Blazor Server fix because:
•	It follows the recommended Blazor EF pattern.
•	It avoids serializing unrelated operations through a shared context.
•	It keeps each operation as its own EF unit of work.
•	It removes the underlying shared-dbContext concurrency hazard instead of masking it.
Validation:
•	Build completed successfully.
