### PR TITLE
Archive Prototype

### DIFF
--- a/Data/DataModel/Event.cs
+++ b/Data/DataModel/Event.cs
@@ -184,6 +184,12 @@ namespace ServerCore.DataModel
         }
 
         /// <summary>
+        /// Returns whether the event can be archived.
+        /// </summary>
+        [NotMapped]
+        public bool CanArchive => this.AreAnswersAvailableNow;
+
+        /// <summary>
         /// Determines whether or not the standings page is visible to players.
         /// </summary>
         public bool HideStandings { get; set; }

--- a/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
+++ b/ServerCore/Areas/Identity/UserAuthorizationPolicy/AuthorizationHelper.cs
@@ -154,13 +154,23 @@ namespace ServerCore.Areas.Identity
         public async Task IsPlayerRegisteredForEvent(AuthorizationHandlerContext authContext, IAuthorizationRequirement requirement)
         {
             EventRole role = GetEventRoleFromRoute();
+            Event thisEvent = await GetEventFromRoute();
+
+            if (role == EventRole.archive)
+            {
+                if (thisEvent.CanArchive)
+                {
+                    authContext.Succeed(requirement);
+                }
+                return;
+            }
+
             if (role != EventRole.play)
             {
                 return;
             }
 
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
-            Event thisEvent = await GetEventFromRoute();
 
             if (thisEvent != null && puzzleUser != null && await puzzleUser.IsRegisteredForEvent(dbContext, thisEvent))
             {
@@ -220,11 +230,22 @@ namespace ServerCore.Areas.Identity
 
         public async Task PlayerCanSeePuzzleCheck(AuthorizationHandlerContext authContext, IAuthorizationRequirement requirement)
         {
+            EventRole role = GetEventRoleFromRoute();
+            Event thisEvent = await GetEventFromRoute();
+
+            if (role == EventRole.archive)
+            {
+                if (thisEvent.CanArchive)
+                {
+                    authContext.Succeed(requirement);
+                }
+                return;
+            }
+
             PuzzleUser puzzleUser = await PuzzleUser.GetPuzzleUserForCurrentUser(dbContext, authContext.User, userManager);
             if (puzzleUser == null) { return; }
 
             Puzzle puzzle = await GetPuzzleFromRoute();
-            Event thisEvent = await GetEventFromRoute();
 
             if (thisEvent != null && puzzle != null)
             {
@@ -251,7 +272,6 @@ namespace ServerCore.Areas.Identity
                 }
                 else
                 {
-                    EventRole role = GetEventRoleFromRoute();
                     Team team = null;
                     if (role.IsImpersonating)
                     {

--- a/ServerCore/ModelBases/EventRole.cs
+++ b/ServerCore/ModelBases/EventRole.cs
@@ -66,6 +66,7 @@ namespace ServerCore.ModelBases
         public static EventRole admin = new EventRole() { Type = EventRoleType.admin };
         public static EventRole author = new EventRole() { Type = EventRoleType.author };
         public static EventRole play = new EventRole() { Type = EventRoleType.play };
+        public static EventRole archive = new EventRole() { Type = EventRoleType.archive };
     }
 
     public enum EventRoleType
@@ -73,6 +74,7 @@ namespace ServerCore.ModelBases
         admin = 1,
         author,
         play,
+        archive,
         impersonateteam
     }
 }

--- a/ServerCore/ModelBases/EventSpecificPageModel.cs
+++ b/ServerCore/ModelBases/EventSpecificPageModel.cs
@@ -43,8 +43,9 @@ namespace ServerCore.ModelBases
             bool isAuthor = await IsEventAuthor();
             if (((EventRole == EventRole.admin) && !isAdmin) ||
                 ((EventRole == EventRole.author) && !isAuthor) ||
+                ((EventRole == EventRole.archive) && !Event.CanArchive) ||
                 ((EventRole.IsImpersonating) && !isAuthor && !isAdmin) ||
-                ((EventRole != EventRole.admin) && (EventRole != EventRole.author) && (EventRole != EventRole.play) && !EventRole.IsImpersonating))
+                ((EventRole != EventRole.admin) && (EventRole != EventRole.author) && (EventRole != EventRole.play) && (EventRole != EventRole.archive) && !EventRole.IsImpersonating))
             {
                 context.Result = Forbid();
                 return;

--- a/ServerCore/Pages/Events/Index.cshtml
+++ b/ServerCore/Pages/Events/Index.cshtml
@@ -50,7 +50,8 @@
                 <a asp-page="./Players" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Players</a> |
                 <a asp-page="./Standings" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Standings</a> |
                 <a asp-page="./SolveCounts" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Counts</a> |
-                <a asp-page="./Map" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Map</a>
+                <a asp-page="./Map" asp-route-eventId="@item.EventID" asp-route-eventRole="admin">Map</a> |
+                <a asp-page="/EventSpecific/Index" asp-route-eventId="@item.EventID" asp-route-eventRole="archive">Archive</a>
             </td>
         </tr>
 }

--- a/ServerCore/Pages/Puzzles/Play.cshtml
+++ b/ServerCore/Pages/Puzzles/Play.cshtml
@@ -79,7 +79,7 @@
     <component type="typeof(ServerCore.Pages.Components.TeamPresenceToJSComponent)" render-mode="Server" param-TeamId="@Model.Team.ID" param-MaxUsers=2 />
 }
 
-@if (DateTime.UtcNow > @Model.Event.AnswerSubmissionEnd)
+@if (Model.EventRole != ModelBases.EventRole.archive && DateTime.UtcNow > @Model.Event.AnswerSubmissionEnd)
 {
     <div class="alert alert-warning" role="alert">
         <h4>The event is over.</h4>
@@ -131,7 +131,7 @@
     asp-route-stateFilter=@(unsolvedFilter ? PlayModel.PuzzleStateFilter.All : PlayModel.PuzzleStateFilter.Unsolved)>
         Show @(unsolvedFilter ? "All" : "only unsolved") puzzles
     </a> | 
-    @if (Model.Event.HideHints || Model.Event.DefaultCostForHelpThread >= 0)
+    @if (Model.EventRole != ModelBases.EventRole.archive && (Model.Event.HideHints || Model.Event.DefaultCostForHelpThread >= 0))
     {
         <a asp-page="/Threads/PuzzleThreads">View help threads</a><text> | </text>
     }
@@ -156,7 +156,7 @@
     <a asp-page="/Teams/LiveEventSchedule" asp-route-teamId="@Model.Team.ID">Click Here for the Live Event Schedule</a> <br/> <br/>
 }
 
-@if (Model.Team == null)
+@if (Model.Team == null && Model.EventRole != ModelBases.EventRole.archive)
 {
     if (EventHelper.EventRequiresActivePlayerRegistration(Model.Event))
     {
@@ -189,7 +189,7 @@ else
             <tr>
                 <th>
                     <a asp-page="./Play"
-                        asp-route-teamId="@Model.Team.ID"
+                        asp-route-teamId="@Model.Team?.ID"
                         asp-route-singlePlayerPuzzleSort="@Model.SinglePlayerPuzzleSort" 
                         asp-route-teamPuzzleSort="@(Model.SortForColumnLink(Model.TeamPuzzleSort, PlayModel.SortOrder.GroupAscending, PlayModel.SortOrder.GroupDescending))" 
                         asp-route-stateFilter="@Model.StateFilter">
@@ -297,7 +297,7 @@ else
                     @if (!Model.Event.HideHints)
                     {
                         <td class="puzzle-list-hints-customizable">
-                            <a asp-page="/Teams/Hints" asp-route-puzzleid="@item.ID" asp-route-teamId="@Model.Team.ID">Hints</a>
+                            <a asp-page="/Teams/Hints" asp-route-puzzleid="@item.ID" asp-route-teamId="@Model.Team?.ID">Hints</a>
                         </td>
                     }
                     @if (Model.AllowFeedback)

--- a/ServerCore/Pages/Puzzles/Play.cshtml.cs
+++ b/ServerCore/Pages/Puzzles/Play.cshtml.cs
@@ -88,9 +88,12 @@ namespace ServerCore.Pages.Puzzles
 
             Team = await base.GetTeamAsync();
 
-            if (Team != null)
+            if (EventRole == EventRole.archive || Team != null)
             {
-                await PuzzleStateHelper.CheckForTimedUnlocksAsync(_context, Event, Team);
+                if (Team != null)
+                {
+                    await PuzzleStateHelper.CheckForTimedUnlocksAsync(_context, Event, Team);
+                }
                 VisibleTeamPuzzleViews = (await this.GetVisibleTeamPlayerPuzzleViews(teamPuzzleSort, Team)).ToList();
                 this.PopulatePuzzleViewsWithFiles(VisibleTeamPuzzleViews, puzzleFiles, answerFiles);
                 if (!AnyErrata)
@@ -98,7 +101,7 @@ namespace ServerCore.Pages.Puzzles
                     AnyErrata = VisibleTeamPuzzleViews.Any(v => v.Errata != null);
                 }
 
-                if (Event.HasPlayerClasses)
+                if (Team != null && Event.HasPlayerClasses)
                 {
                     TeamMembers tm = _context.TeamMembers.Where(tm => tm.Team == Team && tm.Member == LoggedInUser).FirstOrDefault();
                     LoggedInPlayerClass = PlayerClassHelper.GetActiveClassForPlayer(Event,tm)?.UniqueName ?? "";
@@ -196,36 +199,46 @@ namespace ServerCore.Pages.Puzzles
             // all puzzles for this event that are real puzzles
             var puzzlesInEventQ = _context.Puzzles.Where(puzzle => puzzle.Event.ID == this.Event.ID && puzzle.IsPuzzle && !puzzle.IsForSinglePlayer);
 
-            if (team.IsRemoteTeam)
+            IQueryable<PuzzleView> visiblePuzzlesQ;
+
+            if (EventRole == EventRole.archive)
             {
-                puzzlesInEventQ = puzzlesInEventQ.Where(puzzle => puzzle.Availability == Puzzle.PuzzleAvailability.AllPlayers || puzzle.Availability == Puzzle.PuzzleAvailability.RemoteOnly);
+                visiblePuzzlesQ = from Puzzle puzzle in puzzlesInEventQ
+                                  select new PuzzleView { ID = puzzle.ID, Group = puzzle.Group, OrderInGroup = puzzle.OrderInGroup, Name = puzzle.Name, CustomUrl = puzzle.CustomURL, CustomSolutionUrl = puzzle.CustomSolutionURL, Errata = puzzle.Errata, SolvedTime = null, PieceMetaUsage = puzzle.PieceMetaUsage };
             }
             else
             {
-                puzzlesInEventQ = puzzlesInEventQ.Where(puzzle => puzzle.Availability == Puzzle.PuzzleAvailability.AllPlayers || puzzle.Availability == Puzzle.PuzzleAvailability.LocalOnly);
-            }
-                
-            // unless we're in a global lockout, then filter to those!
-            var puzzlesCausingGlobalLockoutQ = PuzzleStateHelper.PuzzlesCausingGlobalLockout(_context, Event, team);
-            if (await puzzlesCausingGlobalLockoutQ.AnyAsync())
-            {
-                puzzlesInEventQ = puzzlesCausingGlobalLockoutQ;
-            }
+                if (team.IsRemoteTeam)
+                {
+                    puzzlesInEventQ = puzzlesInEventQ.Where(puzzle => puzzle.Availability == Puzzle.PuzzleAvailability.AllPlayers || puzzle.Availability == Puzzle.PuzzleAvailability.RemoteOnly);
+                }
+                else
+                {
+                    puzzlesInEventQ = puzzlesInEventQ.Where(puzzle => puzzle.Availability == Puzzle.PuzzleAvailability.AllPlayers || puzzle.Availability == Puzzle.PuzzleAvailability.LocalOnly);
+                }
 
-            // all puzzle states for this team that are unlocked (note: IsUnlocked bool is going to harm perf, just null check the time here)
-            // Note that it's OK if some puzzles do not yet have a state record; those puzzles are clearly still locked and hence invisible.
-            // All puzzles will show if all answers have been released)
-            var stateForTeamQ = _context.PuzzleStatePerTeam.Where(state => state.TeamID == this.Team.ID && (ShowAnswers || state.UnlockedTime != null));
+                // unless we're in a global lockout, then filter to those!
+                var puzzlesCausingGlobalLockoutQ = PuzzleStateHelper.PuzzlesCausingGlobalLockout(_context, Event, team);
+                if (await puzzlesCausingGlobalLockoutQ.AnyAsync())
+                {
+                    puzzlesInEventQ = puzzlesCausingGlobalLockoutQ;
+                }
 
-            // join 'em (note: just getting all properties for max flexibility, can pick and choose columns for perf later)
-            // Note: EF gotcha is that you have to join into anonymous types in order to not lose valuable stuff
-            var visiblePuzzlesQ = from Puzzle puzzle in puzzlesInEventQ
-                                  join PuzzleStatePerTeam pspt in stateForTeamQ on puzzle.ID equals pspt.PuzzleID
-                                  select new PuzzleView { ID = puzzle.ID, Group = puzzle.Group, OrderInGroup = puzzle.OrderInGroup, Name = puzzle.Name, CustomUrl = puzzle.CustomURL, CustomSolutionUrl = puzzle.CustomSolutionURL, Errata = puzzle.Errata, SolvedTime = pspt.SolvedTime, PieceMetaUsage = puzzle.PieceMetaUsage };
+                // all puzzle states for this team that are unlocked (note: IsUnlocked bool is going to harm perf, just null check the time here)
+                // Note that it's OK if some puzzles do not yet have a state record; those puzzles are clearly still locked and hence invisible.
+                // All puzzles will show if all answers have been released)
+                var stateForTeamQ = _context.PuzzleStatePerTeam.Where(state => state.TeamID == this.Team.ID && (ShowAnswers || state.UnlockedTime != null));
 
-            if (this.StateFilter == PuzzleStateFilter.Unsolved)
-            {
-                visiblePuzzlesQ = visiblePuzzlesQ.Where(puzzles => puzzles.SolvedTime == null);
+                // join 'em (note: just getting all properties for max flexibility, can pick and choose columns for perf later)
+                // Note: EF gotcha is that you have to join into anonymous types in order to not lose valuable stuff
+                visiblePuzzlesQ = from Puzzle puzzle in puzzlesInEventQ
+                                      join PuzzleStatePerTeam pspt in stateForTeamQ on puzzle.ID equals pspt.PuzzleID
+                                      select new PuzzleView { ID = puzzle.ID, Group = puzzle.Group, OrderInGroup = puzzle.OrderInGroup, Name = puzzle.Name, CustomUrl = puzzle.CustomURL, CustomSolutionUrl = puzzle.CustomSolutionURL, Errata = puzzle.Errata, SolvedTime = pspt.SolvedTime, PieceMetaUsage = puzzle.PieceMetaUsage };
+
+                if (this.StateFilter == PuzzleStateFilter.Unsolved)
+                {
+                    visiblePuzzlesQ = visiblePuzzlesQ.Where(puzzles => puzzles.SolvedTime == null);
+                }
             }
 
             return this.GetSortedView(visiblePuzzlesQ, sortOrder);
@@ -249,20 +262,29 @@ namespace ServerCore.Pages.Puzzles
                     PieceMetaUsage = unlockState.Puzzle.PieceMetaUsage
                 });
 
-            // Populate solve time based on statePerPlayer
-            var singlePlayerPuzzleStatePerPlayer = _context.SinglePlayerPuzzleStatePerPlayer
-                .Where(state => state.PlayerID == LoggedInUser.ID && state.Puzzle.EventID == Event.ID);
-            foreach (SinglePlayerPuzzleStatePerPlayer statePerPlayer in singlePlayerPuzzleStatePerPlayer)
-            {
-                singlePlayerPuzzleViewDict[statePerPlayer.PuzzleID].SolvedTime = statePerPlayer.SolvedTime;
-                singlePlayerPuzzleViewDict[statePerPlayer.PuzzleID].UnlockedTime = statePerPlayer.UnlockedTime;
-            }
+            IEnumerable<PuzzleView> visibleSinglePlayerPuzzlesQ;
 
-            IEnumerable<PuzzleView> visibleSinglePlayerPuzzlesQ = singlePlayerPuzzleViewDict.Values.AsEnumerable().Where(puzzleView => ShowAnswers || puzzleView.UnlockedTime != null);
-            visibleSinglePlayerPuzzlesQ = this.GetSortedView(visibleSinglePlayerPuzzlesQ, sortOrder);
-            if (StateFilter == PuzzleStateFilter.Unsolved)
+            if (EventRole == EventRole.archive)
             {
-                visibleSinglePlayerPuzzlesQ = visibleSinglePlayerPuzzlesQ.Where(puzzles => puzzles.SolvedTime == null);
+                visibleSinglePlayerPuzzlesQ = singlePlayerPuzzleViewDict.Values.AsEnumerable();
+            }
+            else
+            {
+                // Populate solve time based on statePerPlayer
+                var singlePlayerPuzzleStatePerPlayer = _context.SinglePlayerPuzzleStatePerPlayer
+                    .Where(state => state.PlayerID == LoggedInUser.ID && state.Puzzle.EventID == Event.ID);
+                foreach (SinglePlayerPuzzleStatePerPlayer statePerPlayer in singlePlayerPuzzleStatePerPlayer)
+                {
+                    singlePlayerPuzzleViewDict[statePerPlayer.PuzzleID].SolvedTime = statePerPlayer.SolvedTime;
+                    singlePlayerPuzzleViewDict[statePerPlayer.PuzzleID].UnlockedTime = statePerPlayer.UnlockedTime;
+                }
+
+                visibleSinglePlayerPuzzlesQ = singlePlayerPuzzleViewDict.Values.AsEnumerable().Where(puzzleView => ShowAnswers || puzzleView.UnlockedTime != null);
+                visibleSinglePlayerPuzzlesQ = this.GetSortedView(visibleSinglePlayerPuzzlesQ, sortOrder);
+                if (StateFilter == PuzzleStateFilter.Unsolved)
+                {
+                    visibleSinglePlayerPuzzlesQ = visibleSinglePlayerPuzzlesQ.Where(puzzles => puzzles.SolvedTime == null);
+                }
             }
 
             return visibleSinglePlayerPuzzlesQ;

--- a/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
+++ b/ServerCore/Pages/Shared/_EventNavigationPartial.cshtml
@@ -53,6 +53,10 @@
                             <ul class="dropdown-menu admin-menu">
                                 <li><a class="dropdown-item" asp-page="/EventSpecific/Index">Home</a></li>
                                 <li><a class="dropdown-item" asp-page="/Events/Details">Details</a></li>
+                                @if (Event?.CanArchive == true)
+                                {
+                                    <li><a class="dropdown-item" asp-page="/EventSpecific/Index" asp-route-eventRole="@ModelBases.EventRole.archive">View as archive</a></li>
+                                }
                             </ul>
                         </div>
                     </li>
@@ -184,8 +188,90 @@
     </nav>
 }
 <!--AUTHOR NAV BAR END-->
+<!--ARCHIVE NAV BAR-->
+@if (Event != null && EventRole != null && EventRole == ModelBases.EventRole.archive)
+{
+    <nav class="navbar navbar-dark navbar-custom static-top navbar-expand-xl player-menu no-print" data-bs-theme="dark">
+        <div class="container-fluid">
+            <div class="nav-header dropdown">
+                <a class="navbar-brand" data-bs-toggle="dropdown" role="button" href="#">
+                    @Event.Name
+                </a>
+                <!--<partial name="/Pages/Shared/_RoleSwitcherPartial.cshtml" /> -->
+
+                <button type="button" class="navbar-toggler player-menu" data-bs-toggle="collapse" data-bs-target="#topBarCollapsable" title="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+            </div>
+
+            <div class="collapse navbar-collapse" id="topBarCollapsable">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item">
+                        <div class="dropdown">
+                            <a class="dropdown-toggle" data-bs-toggle="dropdown" role="button" href="#">
+                                Event
+                            </a>
+                            <ul class="dropdown-menu player-menu">
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Index">Event homepage</a></li>
+                            </ul>
+                        </div>
+                    </li>
+                    <li class="nav-item"><a asp-page="/Puzzles/Play">Puzzles</a></li>
+                    <li class="nav-item">
+                        <div class="dropdown">
+                            <a class="dropdown-toggle" data-bs-toggle="dropdown" role="button" href="#">
+                                Teams
+                            </a>
+                            <ul class="dropdown-menu player-menu">
+                                <li><a class="dropdown-item" asp-page="/Teams/AllTeams">All teams</a></li>
+                            </ul>
+                        </div>
+                    </li>
+                    <li class="nav-item">
+                        <div class="dropdown">
+                            <a class="dropdown-toggle" data-bs-toggle="dropdown" role="button" href="#">
+                                Leaderboards
+                            </a>
+                            <ul class="dropdown-menu player-menu">
+                                @if (!Event.HideStandings)
+                                {
+                                    <li><a class="dropdown-item" asp-page="/Events/Standings">Standings</a></li>
+                                }
+                                @if (!Event.HideSolveCounts)
+                                {
+                                    <li><a class="dropdown-item" asp-page="/Events/SolveCounts">@(Event.HideStandings ? "Most-solved Puzzles" : "Fastest solves")</a></li>
+                                }
+                                @if (DateTime.UtcNow >= Event.AnswersAvailableBegin)
+                                {
+                                    <li><a class="dropdown-item" asp-page="/Events/PlayerSubmissions">Player submissions</a></li>
+                                }
+                            </ul>
+                        </div>
+                    </li>
+                    <li class="nav-item">
+                        <div class="dropdown">
+                            <a class="dropdown-toggle" data-bs-toggle="dropdown" role="button" href="#">
+                                Resources
+                            </a>
+                            <ul class="dropdown-menu player-menu">
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Rules">Rules</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/FAQ">FAQ</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Tools">Solving tools and techniques</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Encodings">Encodings</a></li>
+                                <li><a class="dropdown-item" asp-page="/EventSpecific/Samples">Sample puzzles</a></li>
+                            </ul>
+                        </div>
+                    </li>
+                </ul>
+
+                <!--<partial name="/Pages/Shared/_LoginPartial.cshtml" />-->
+            </div>
+        </div>
+    </nav>
+}
+<!--ARCHIVE NAV BAR END-->
 <!--REGISTERED PLAYER NAV BAR-->
-@if (Event != null && (EventRole == null || (EventRole != ModelBases.EventRole.admin && EventRole != ModelBases.EventRole.author)) && IsRegistered)
+@if (Event != null && (EventRole == null || (EventRole != ModelBases.EventRole.admin && EventRole != ModelBases.EventRole.author && EventRole != ModelBases.EventRole.archive)) && IsRegistered)
 {
     <nav class="navbar navbar-dark navbar-custom static-top navbar-expand-xl player-menu no-print" data-bs-theme="dark">
         <div class="container-fluid">
@@ -320,7 +406,7 @@
 }
 <!--REGISTERED PLAYER NAV BAR END-->
 <!--UNREGISTERED PLAYER NAV BAR-->
-@if (Event != null && (EventRole == null || (EventRole != ModelBases.EventRole.admin && EventRole != ModelBases.EventRole.author)) && !IsRegistered)
+@if (Event != null && (EventRole == null || (EventRole != ModelBases.EventRole.admin && EventRole != ModelBases.EventRole.author && EventRole != ModelBases.EventRole.archive)) && !IsRegistered)
 {
     <nav class="navbar navbar-dark navbar-custom static-top navbar-expand-xl player-menu no-print" data-bs-theme="dark">
         <div class="container-fluid">
@@ -380,7 +466,7 @@
     </nav>
 }
 <!--UNREGISTERED PLAYER NAV BAR END-->
-@if (Event?.EphemeralHackKillNotifications != true)
+@if (EventRole != ModelBases.EventRole.archive && Event?.EphemeralHackKillNotifications != true)
 {
     <script>
         var allEventToasts = {};

--- a/ServerCore/Pages/Submissions/Index.cshtml
+++ b/ServerCore/Pages/Submissions/Index.cshtml
@@ -363,7 +363,7 @@
                 }
 
                 <div class="d-flex justify-content-end">
-                    @if (!Model.Event.HideHints)
+                    @if (Model.EventRole != ModelBases.EventRole.archive && !Model.Event.HideHints)
                     {
                         if (Model.Puzzle.IsForSinglePlayer)
                         {
@@ -371,15 +371,15 @@
                         }
                         else
                         {
-                            <div><a asp-page="/Teams/Hints" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team.ID" target="_blank" class="btn quick-action" role="button"><span class="quick-action-icon">&#x1F4AC;</span> Get Help</a></div>
+                            <div><a asp-page="/Teams/Hints" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" target="_blank" class="btn quick-action" role="button"><span class="quick-action-icon">&#x1F4AC;</span> Get Help</a></div>
                         }
                     }
-                    else if (!Model.PuzzleState.IsEmailOnlyMode)
+                    else if (Model.EventRole != ModelBases.EventRole.archive && !Model.PuzzleState.IsEmailOnlyMode)
                     {
                         <div><a asp-Page="/Threads/PuzzleThread" asp-route-puzzleid="@Model.Puzzle.ID" asp-route-teamId="@Model.Team?.ID" asp-route-playerId="@Model.LoggedInUser.ID" class="btn quick-action" role="button"><span class="quick-action-icon">&#x1F4AC;</span> Get Help</a></div>
                     }
 
-                    @if (Model.Event.AllowFeedback)
+                    @if (Model.EventRole != ModelBases.EventRole.archive && Model.Event.AllowFeedback)
                     {
                     <div><a asp-Page="/Puzzles/SubmitFeedback" asp-route-puzzleid="@Model.Puzzle.ID" target="_blank" class="btn quick-action" role="button"><span class="quick-action-icon">&#x1F4DD;</span> Give Feedback</a></div>
                     }
@@ -398,24 +398,27 @@
                     }
                 </div>
                 
-                <div class="sync-presence-stack">
-                    @if (!Model.IsPuzzleForSinglePlayer && !Model.Event.EphemeralHackKillSync)
-                    {
-                        <component type="typeof(ClientSyncComponent.Client.Pages.ClientSyncComponent)" render-mode="WebAssembly"
-                        param-PuzzleUserId="@Model.LoggedInUser.ID"
-                        param-TeamId="@Model.Team.ID"
-                        param-PuzzleId="@Model.Puzzle.ID"
-                        param-TableSASUrl="@Model.SyncTableSasUrl"
-                        param-PuzzleUnlockTimeUtc="(DateTimeOffset?)@Model.PuzzleState.UnlockedTime"
-                        param-EventEndTimeUtc="(DateTimeOffset)@Model.Event.AnswerSubmissionEnd"
-                        param-ReadOnly="@(Model.EventRole != ModelBases.EventRole.play)"
-                        />
-                    }
-                    @if (!Model.IsPuzzleForSinglePlayer && !Model.Event.EphemeralHackKillPresence)
-                    {
-                        <component type="typeof(ServerCore.Pages.Components.PresenceComponent)" render-mode="Server" param-PuzzleUserId="@Model.LoggedInUser.ID" param-TeamId="@Model.Team.ID" param-PuzzleId="@Model.Puzzle.ID" />
-                    }
-                </div>
+                @if(Model.EventRole != ModelBases.EventRole.archive)
+                {
+                    <div class="sync-presence-stack">
+                        @if (!Model.IsPuzzleForSinglePlayer && !Model.Event.EphemeralHackKillSync)
+                        {
+                            <component type="typeof(ClientSyncComponent.Client.Pages.ClientSyncComponent)" render-mode="WebAssembly"
+                                       param-PuzzleUserId="@Model.LoggedInUser.ID"
+                                       param-TeamId="@Model.Team.ID"
+                                       param-PuzzleId="@Model.Puzzle.ID"
+                                       param-TableSASUrl="@Model.SyncTableSasUrl"
+                                       param-PuzzleUnlockTimeUtc="(DateTimeOffset?)@Model.PuzzleState.UnlockedTime"
+                                       param-EventEndTimeUtc="(DateTimeOffset)@Model.Event.AnswerSubmissionEnd"
+                                       param-ReadOnly="@(Model.EventRole != ModelBases.EventRole.play)"
+                                       />
+                        }
+                        @if (!Model.IsPuzzleForSinglePlayer && !Model.Event.EphemeralHackKillPresence)
+                        {
+                            <component type="typeof(ServerCore.Pages.Components.PresenceComponent)" render-mode="Server" param-PuzzleUserId="@Model.LoggedInUser.ID" param-TeamId="@Model.Team.ID" param-PuzzleId="@Model.Puzzle.ID" />
+                        }
+                    </div>
+                }
             </div>
         </div>
     </div>
@@ -469,6 +472,13 @@
             <div class="alert alert-warning" role="alert">
                 <h4>Unclaimed Alpha Puzzle</h4>
                 <span>This puzzle needs alpha testers! <a asp-page-handler="ClaimPuzzle">Claim it now!</a></span>
+            </div>
+        }
+        else if (Model.EventRole == ModelBases.EventRole.archive)
+        {
+            <div class="alert alert-danger" role="alert">
+                <h4>Answer Submission Unavailable</h4>
+                <span>This event is an archived version. You can quickly check an answer by looking it up in the "previous submissions" dropdown below. Future updates to the archive will perform checks for you automatically.</span>
             </div>
         }
         else
@@ -762,7 +772,10 @@
                 }
                 document.querySelector("#submitBox").value = "";
             }
-            submit.addEventListener("click", submitClickHandler);
+            @if (Model.EventRole != ModelBases.EventRole.archive)
+            {
+                <text>submit.addEventListener("click", submitClickHandler);</text>
+            }
 
             // Make hitting enter in the answer box trigger a submission
             const submitBox = document.querySelector("#submitBox");

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -347,6 +347,8 @@ namespace ServerCore.Pages.Submissions
             List<SubmissionView> submissionViews = new List<SubmissionView>();
             if (EventRole == EventRole.archive)
             {
+                // PuzzleStatePerTeam works here for single-player puzzles as well, since the only properties used come from the base class.
+                // PuzzleStateBaseClass has no public constructor.
                 PuzzleState = new PuzzleStatePerTeam();
 
                 SubmissionViews = await (from response in _context.Responses

--- a/ServerCore/Pages/Submissions/Index.cshtml.cs
+++ b/ServerCore/Pages/Submissions/Index.cshtml.cs
@@ -345,7 +345,25 @@ namespace ServerCore.Pages.Submissions
 
             IsPuzzleForSinglePlayer = Puzzle.IsForSinglePlayer;
             List<SubmissionView> submissionViews = new List<SubmissionView>();
-            if (Puzzle.IsForSinglePlayer)
+            if (EventRole == EventRole.archive)
+            {
+                PuzzleState = new PuzzleStatePerTeam();
+
+                SubmissionViews = await (from response in _context.Responses
+                                         where response.Puzzle == Puzzle
+                                         orderby response.IsSolution descending, response.SubmittedText descending
+                                         select new SubmissionView()
+                                         {
+                                             Submission = new Submission {  SubmissionText = response.SubmittedText },
+                                             Response = response,
+                                             SubmitterName = "Archive",
+                                             FreeformReponse = null,
+                                             IsFreeform = Puzzle.IsFreeform
+                                         }).ToListAsync();
+
+                PuzzlesCausingGlobalLockout = new List<Puzzle>();
+            }
+            else if (Puzzle.IsForSinglePlayer)
             {
                 PuzzleState = await SinglePlayerPuzzleStateHelper.GetOrAddStateIfNotThere(_context,
                     Event,
@@ -443,7 +461,8 @@ namespace ServerCore.Pages.Submissions
 
                 if (submissionView.Response != null
                     && submissionView.Response.IsSolution 
-                    && !Puzzle.IsFreeform)
+                    && !Puzzle.IsFreeform
+                    && EventRole != EventRole.archive)
                 {
                     AnswerToken = submissionView.Submission.SubmissionText;
                 }


### PR DESCRIPTION
Creates a view of an event where all puzzles can be seen without needing to register.

This view is only available when the event is over.

The view offers a restricted set of features and links.

The hope is that a website downloader can be configured to quickly turn this view into a static event archive, but we'll need to deploy in order to test that and polish.

Future work in this area can provide unlocking and answer submission driven by localStorage, so that static archived events are actually playable.