### PR TITLE
Restore Auto Signup

### DIFF
--- a/ServerCore/Pages/Teams/Signup.cshtml
+++ b/ServerCore/Pages/Teams/Signup.cshtml
@@ -11,7 +11,7 @@
 <div>
     <component type="typeof(ServerCore.Pages.Teams.SignupHub)" render-mode="Server"
         param-EventId="@Model.Event.ID"
-        param-EventRole="@Model.EventRole"
+        param-EventRoleString="@Model.EventRole.ToString()"
         param-LoggedInUserId="@Model.LoggedInUser.ID" 
         param-IsMicrosoft="@Model.IsMicrosoft" />
 </div>

--- a/ServerCore/Pages/Teams/SignupHub.razor.cs
+++ b/ServerCore/Pages/Teams/SignupHub.razor.cs
@@ -21,7 +21,7 @@ namespace ServerCore.Pages.Teams
         public int EventId { get; set; }
 
         [Parameter]
-        public EventRole EventRole { get; set; }
+        public string EventRoleString { get; set; }
 
         [Parameter]
         public int LoggedInUserId { get; set; }
@@ -38,8 +38,12 @@ namespace ServerCore.Pages.Teams
 
         public SignupStrategy Strategy { get; set; } = SignupStrategy.None;
 
+        public EventRole EventRole;
+
         protected override async Task OnParametersSetAsync()
         {
+            EventRole = EventRole.Parse(EventRoleString);
+
             Event = await _context.Events.Where(ev => ev.ID == EventId).SingleAsync();
             int teamCount = await _context.Teams.Where(team => team.Event == Event).CountAsync();
 


### PR DESCRIPTION
Unfortunately, when writing the impersonation feature and plumbing EventRole through to the specific signup pages, a case was missed for the hub itself. Applying the same EventRoleString approach as used for the other pages restores this feature (and also passes the correct role to the individual pages).